### PR TITLE
Fix issues with the Kafka debezium bridge

### DIFF
--- a/KafkaBridge/lib/debeziumBridge.js
+++ b/KafkaBridge/lib/debeziumBridge.js
@@ -49,13 +49,16 @@ module.exports = function DebeziumBridge (conf) {
     const isEntityUpdated = this.diffEntity(beforeEntity, afterEntity);
     const { updatedAttrs, deletedAttrs } = this.diffAttributes(beforeAttrs, afterAttrs);
     const isChanged = isEntityUpdated || Object.keys(updatedAttrs).length > 0 || Object.keys(deletedAttrs).length > 0;
+    var deletedEntity;
     if (isChanged && Object.keys(afterEntity).length === 0) {
-      afterEntity.id = beforeEntity.id;
-      afterEntity.type = beforeEntity.type;
+      deletedEntity = {};
+      deletedEntity.id = beforeEntity.id;
+      deletedEntity.type = beforeEntity.type;
     }
     result = {
       entity: isChanged ? afterEntity : null,
-      updatedAttrs: isChanged ? afterAttrs : null,
+      deletedEntity: deletedEntity,
+      updatedAttrs: isChanged ? updatedAttrs : null,
       deletedAttrs: isChanged ? deletedAttrs : null
     };
     return result;

--- a/test/bats/test-bridges/test-debezium-bridge.bats
+++ b/test/bats/test-bridges/test-debezium-bridge.bats
@@ -41,33 +41,33 @@ EOF
 
 compare_create_attributes() {
     cat << EOF | diff "$1" - >&3
-[{"id":"urn:plasmacutter:1\\\https://industry-fusion.com/types/v0.9/state",\
+{"id":"urn:plasmacutter:1\\\https://industry-fusion.com/types/v0.9/state",\
 "entityId":"urn:plasmacutter:1",\
 "synchronized":true,\
 "name":"https://industry-fusion.com/types/v0.9/state",\
 "type":"https://uri.etsi.org/ngsi-ld/Property",\
-"https://uri.etsi.org/ngsi-ld/hasValue":"OFF","index":0}]
-[{"id":"urn:plasmacutter:1\\\https://industry-fusion.com/types/v0.9/hasFilter",\
+"https://uri.etsi.org/ngsi-ld/hasValue":"OFF","index":0}
+{"id":"urn:plasmacutter:1\\\https://industry-fusion.com/types/v0.9/hasFilter",\
 "entityId":"urn:plasmacutter:1",\
 "synchronized":true,\
 "name":"https://industry-fusion.com/types/v0.9/hasFilter",\
 "type":"https://uri.etsi.org/ngsi-ld/Relationship",\
-"https://uri.etsi.org/ngsi-ld/hasObject":"urn:filter:1","index":0}]
-[{"id":"urn:plasmacutter:1\\\https://industry-fusion.com/types/v0.9/hasWorkpiece",\
+"https://uri.etsi.org/ngsi-ld/hasObject":"urn:filter:1","index":0}
+{"id":"urn:plasmacutter:1\\\https://industry-fusion.com/types/v0.9/hasWorkpiece",\
 "entityId":"urn:plasmacutter:1",\
 "synchronized":true,\
 "name":"https://industry-fusion.com/types/v0.9/hasWorkpiece",\
 "type":"https://uri.etsi.org/ngsi-ld/Relationship",\
 "https://uri.etsi.org/ngsi-ld/hasObject":"urn:workpiece:1",\
-"index":0}]
+"index":0}
 EOF
 }
 
 compare_delete_attributes() {
     cat << EOF | diff "$1" - >&3
-[{"id":"urn:plasmacutter:1\\\https://industry-fusion.com/types/v0.9/state","index":0}]
-[{"id":"urn:plasmacutter:1\\\https://industry-fusion.com/types/v0.9/hasFilter","index":0}]
-[{"id":"urn:plasmacutter:1\\\https://industry-fusion.com/types/v0.9/hasWorkpiece","index":0}]
+{"id":"urn:plasmacutter:1\\\https://industry-fusion.com/types/v0.9/state","index":0}
+{"id":"urn:plasmacutter:1\\\https://industry-fusion.com/types/v0.9/hasFilter","index":0}
+{"id":"urn:plasmacutter:1\\\https://industry-fusion.com/types/v0.9/hasWorkpiece","index":0}
 EOF
 }
 
@@ -82,7 +82,7 @@ EOF
 
 compare_delete_cutter() {
     cat << EOF | diff "$1" - >&3
-{"id":"urn:plasmacutter:1","type":"https://industry-fusion.com/types/v0.9/plasmacutter"}
+{"id":"urn:plasmacutter:1"}
 EOF
 }
 
@@ -97,7 +97,7 @@ EOF
 
 compare_delete_plasmacutter() {
     cat << EOF | diff "$1" - >&3
-{"id":"urn:plasmacutter:1","type":"https://industry-fusion.com/types/v0.9/plasmacutter"}
+{"id":"urn:plasmacutter:1"}
 EOF
 }
 


### PR DESCRIPTION
Changes by this PR:
- When entities are deleted, the type field is no longer sent, only the primary key 'id'.
- Attributes are sent 'flattened' to the attributes kafka channel, i.e. not as array
- Updated E2E bats test for the Debezium Bridge