### PR TITLE
Add Default Timeouts to HTTP requests

### DIFF
--- a/FlinkSqlServicesOperator/beamservicesoperator.py
+++ b/FlinkSqlServicesOperator/beamservicesoperator.py
@@ -34,6 +34,7 @@ JOB_STATUS_UNKNOWN = "UNKNOWN"
 JOB_STATUS_FAILED = "FAILED"
 JOB_STATUS_CANCELED = "CANCELED"
 JOB_STATUS_FIXING = "OPERATOR TRIES TO FIX"
+DEFAULT_TIMEOUT = 60
 
 
 @kopf.on.create("industry-fusion.com", "v1", "beamservices")
@@ -42,7 +43,7 @@ JOB_STATUS_FIXING = "OPERATOR TRIES TO FIX"
 def create(body, spec, patch, **kwargs):
     """Handle job creation"""
     kopf.info(body, reason="Creating",
-              message="Creating beamservices"+str(spec))
+              message="Creating beamservices" + str(spec))
     return {"createdOn": str(time.time())}
 
 
@@ -84,7 +85,8 @@ async def updates(stopped, patch, logger, body, spec, status, **kwargs):
     # Assumption: lowercased entry class name
     try:
         jobs = requests.get(
-            f"{FLINK_URL}/jobs").json().get("jobs", [])
+            f"{FLINK_URL}/jobs",
+            timeout=DEFAULT_TIMEOUT).json().get("jobs", [])
         # check whether job is in the list
         job_id = update_status.get("jobId")
         # if we have a job_id, check wether it is running
@@ -104,7 +106,8 @@ async def updates(stopped, patch, logger, body, spec, status, **kwargs):
             # but not handled by us any longer
             # First get detail of the job
             job_name = requests.get(
-                f"{FLINK_URL}/jobs/{element['id']}").json().get("name")
+                f"{FLINK_URL}/jobs/{element['id']}",
+                timeout=DEFAULT_TIMEOUT).json().get("name")
             # cancel if it has the resource prefix
             name = get_jobname_prefix(body, spec)
             if name is not None and job_name.startswith(name):
@@ -139,7 +142,7 @@ def delete(body, **kwargs):
 
 def download_file_via_http(url):
     """Download the file and return the saved path."""
-    response = requests.get(url)
+    response = requests.get(url, timeout=DEFAULT_TIMEOUT)
     path = "/tmp/" + str(uuid.uuid4()) + ".jar"
     with open(path, "wb") as download_file:
         download_file.write(response.content)
@@ -178,7 +181,8 @@ def deploy(body, spec, patch):
         with open(jarfile_path, "rb") as jarfile:
             response = requests.post(
                 f"{FLINK_URL}/jars/upload",
-                files={"jarfile": jarfile})
+                files={"jarfile": jarfile},
+                timeout=DEFAULT_TIMEOUT)
             if response.status_code != 200:
                 delete_jar(body, jarfile_path)
                 raise kopf.TemporaryError(
@@ -221,7 +225,8 @@ def create_job(body, spec, jar_id):
               message=args)
     response = requests.post(f"{FLINK_URL}/jars/{jar_id}/run",
                              json={"entryClass": entry_class,
-                                   "programArgs": args})
+                                   "programArgs": args},
+                             timeout=DEFAULT_TIMEOUT)
     if response.status_code != 200:
         kopf.info(body, reason="BeamExecutionFailed",
                   message="Could not run job, server returned:"
@@ -248,7 +253,9 @@ def delete_jar(body, jar_path):
 def check_readiness(body):
     """Return number of free slots."""
     try:
-        response = requests.get(f"{FLINK_URL}/overview")
+        response = requests.get(
+            f"{FLINK_URL}/overview",
+            timeout=DEFAULT_TIMEOUT)
         if response.status_code == 200:
             free_slots = response.json()["slots-total"]
             return free_slots
@@ -262,7 +269,9 @@ def check_readiness(body):
 def cancel_job(job_id):
     """Cancel job with the given job_id."""
     try:
-        response = requests.patch(f"{FLINK_URL}/jobs/{job_id}")
+        response = requests.patch(
+            f"{FLINK_URL}/jobs/{job_id}",
+            timeout=DEFAULT_TIMEOUT)
         if response.status_code != 202:
             raise kopf.TemporaryError(
                 "Could not cancel job from cluster", delay=5)

--- a/FlinkSqlServicesOperator/flink_util.py
+++ b/FlinkSqlServicesOperator/flink_util.py
@@ -21,6 +21,7 @@ import requests
 namespace = os.getenv("IFF_NAMESPACE", default="iff")
 FLINK_URL = os.getenv("IFF_FLINK_REST",
                       default=f"http://flink-jobmanager-rest.{namespace}:8081")
+DEFAULT_TIMEOUT = 60
 
 
 class CancelJobFailedException(Exception):
@@ -31,7 +32,7 @@ def get_job_status(logger, job_id):
     """Get job status as json dict as returned by Flink"""
     logger.debug(f"Requestion status for {job_id} from flink job-manager")
     job_response = requests.get(
-        f"{FLINK_URL}/jobs/{job_id}")
+        f"{FLINK_URL}/jobs/{job_id}", timeout=DEFAULT_TIMEOUT)
     if job_response.status_code == 404:
         return None
     job_response.raise_for_status()
@@ -43,7 +44,9 @@ def cancel_job(logger, job_id):
     """Cancel job with given id."""
     logger.debug(
         f"Requesting cancelation of job {job_id} from flink job-manager")
-    response = requests.patch(f"{FLINK_URL}/jobs/{job_id}")
+    response = requests.patch(
+        f"{FLINK_URL}/jobs/{job_id}",
+        timeout=DEFAULT_TIMEOUT)
     if response.status_code != 202:
         raise CancelJobFailedException("Could not cancel job {job_id}")
 
@@ -58,7 +61,7 @@ def stop_job(logger, job_id, savepoint_dir):
         json = {"targetDirectory": f"{savepoint_dir}"}
     logger.info(f"sending object: {json}")
     job_response = requests.post(
-        f"{FLINK_URL}/jobs/{job_id}/stop", json=json)
+        f"{FLINK_URL}/jobs/{job_id}/stop", json=json, timeout=DEFAULT_TIMEOUT)
     job_response.raise_for_status()
     if job_response.status_code != 202:
         raise CancelJobFailedException("Could not trigger stop of job "
@@ -80,7 +83,8 @@ def get_savepoint_state(logger, job_id, savepoint_id):
     logger.debug(f"Check state of savepoint trigger {savepoint_id}"
                  " for job  {job_id} ")
     response = requests.get(
-        f"{FLINK_URL}/jobs/{job_id}/savepoints/{savepoint_id}")
+        f"{FLINK_URL}/jobs/{job_id}/savepoints/{savepoint_id}",
+        timeout=DEFAULT_TIMEOUT)
     try:
         response.raise_for_status()
     except requests.exceptions.HTTPError:
@@ -99,7 +103,7 @@ def get_savepoint_state(logger, job_id, savepoint_id):
         return {"status": status}
     try:
         if response['operation'] is None or \
-          response['operation'].get('failure-cause') is not None:
+                response['operation'].get('failure-cause') is not None:
             return {"status": "FAILED", "location": None}
     except KeyError:
         pass


### PR DESCRIPTION
Per Pylint 2.15 a new check called ```missing-timeout(W3101)``` is introduced, which causes the FlinkServicesOperator container not to build correctly. This commit aims to fix that issue.

Closes #194 

Signed-off-by: Meric Feyzullahoglu <meric.feyzullahoglu@gmail.com>