### PR TITLE
Introduce Resource Restrictions for test profile

### DIFF
--- a/helm/charts/kafka/templates/KafkaCluster.yaml
+++ b/helm/charts/kafka/templates/KafkaCluster.yaml
@@ -15,6 +15,16 @@ spec:
         port: 9093
         type: internal
         tls: true
+    resources:
+      requests:
+        memory: 500Mi
+        cpu: 100m
+      limits:
+        memory: 500Mi
+        cpu: 200m
+    jvmOptions:
+      "-Xmx": "250m"
+      "-Xms": "250m"
     config:
       offsets.topic.replication.factor: 1
       transaction.state.log.replication.factor: 1
@@ -34,6 +44,35 @@ spec:
       type: {{ .Values.kafka.zookeeper.storage.type }}
       size: {{ .Values.kafka.zookeeper.storage.size }}
       deleteClaim: false
+    resources:
+      requests:
+        memory: 128Mi
+        cpu: 100m
+      limits:
+        memory: 256Mi
+        cpu: 200m
   entityOperator:
-    topicOperator: {}
-    userOperator: {}
+    topicOperator:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
+    userOperator:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
+    tlsSidecar:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi

--- a/helm/charts/kafka/templates/kafkaconnect.yaml
+++ b/helm/charts/kafka/templates/kafkaconnect.yaml
@@ -13,7 +13,15 @@ metadata:
 spec:
   replicas: 1
   image: {{ .Values.mainRepo }}/{{ .Values.kafka.connect.image }}:{{ .Values.mainVersion }}
+  jvmOptions:
+    "-Xms": "128M"
+    "-Xmx": "128M"
   bootstrapServers: {{ .Values.kafka.bootstrapServer }}
+  resources:
+    requests:
+      memory: 256Mi
+    limits:
+      memory: 512Mi
   config:
     config.storage.replication.factor: 1
     offset.storage.replication.factor: 1

--- a/helm/charts/scorpio/templates/atcontext-server-deployment.yaml
+++ b/helm/charts/scorpio/templates/atcontext-server-deployment.yaml
@@ -23,13 +23,14 @@ spec:
     spec:
       containers:
       - image: {{ .Values.mainRepo }}/digitaltwin:AtContextServer_{{ .Values.scorpio.tag }}
+        command: ["java"]
+        args: ["-XshowSettings:vm", {{ .Values.scorpio.heap_min.Xms | quote }}, {{ .Values.scorpio.heap_min.Xmx | quote }}, "-jar", "AtContextServer.jar"]
         env:
         {{- range $key, $val := .Values.kafka_vars }}
           - name: {{ $key }}
             value: {{ $val | quote }}
         {{- end }}
         {{- if .Values.springArgs.overrideSpringArgs }}
-        env:
           - name: spring_args
             value: {{ .Values.springArgs.value }}
         {{- end}}
@@ -58,7 +59,7 @@ spec:
           periodSeconds: {{ .Values.AtContextServer.readinessProbe.periodSeconds }}
           {{- end}}
         resources:
-{{ toYaml .Values.AtContextServer.resources | indent 10 }}
+{{ toYaml .Values.scorpio.resources_min | indent 10 }}
       restartPolicy: {{ .Values.AtContextServer.restartPolicy }}
       {{- if .Values.AtContextServer.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.AtContextServer.serviceAccount.name }}

--- a/helm/charts/scorpio/templates/atcontext-server-hpa.yaml
+++ b/helm/charts/scorpio/templates/atcontext-server-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.AtContextServer.enabled .Values.AtContextServer.hpa.enabled }}
+{{- if and .Values.AtContextServer.enabled .Values.AtContextServer.hpa.enabled .Values.scorpio.hpa.enabled }}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm/charts/scorpio/templates/config-server-deployment.yaml
+++ b/helm/charts/scorpio/templates/config-server-deployment.yaml
@@ -23,8 +23,10 @@ spec:
     spec:
       containers:
       - image: {{ .Values.mainRepo }}/digitaltwin:config-server_{{ .Values.scorpio.tag }}
-        {{- if .Values.springArgs.overrideSpringArgs }}
+        command: ["java"]
+        args: ["-XshowSettings:vm", {{ .Values.scorpio.heap_min.Xms | quote }}, {{ .Values.scorpio.heap_min.Xmx | quote }}, "-jar", "config-server.jar"]
         env:
+        {{- if .Values.springArgs.overrideSpringArgs }}
           - name: spring_args
             value: {{ .Values.springArgs.value }}
         {{- end}}
@@ -53,7 +55,7 @@ spec:
           periodSeconds: {{ .Values.ConfigServer.readinessProbe.periodSeconds }}
           {{- end}}
         resources:
-{{ toYaml .Values.ConfigServer.resources | indent 10 }}
+{{ toYaml .Values.scorpio.resources_min | indent 10 }}
       restartPolicy: {{ .Values.ConfigServer.restartPolicy }}
       {{- if .Values.ConfigServer.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.ConfigServer.serviceAccount.name }}

--- a/helm/charts/scorpio/templates/config-server-hpa.yaml
+++ b/helm/charts/scorpio/templates/config-server-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ConfigServer.enabled .Values.ConfigServer.hpa.enabled }}
+{{- if and .Values.ConfigServer.enabled .Values.ConfigServer.hpa.enabled .Values.scorpio.hpa.enabled }}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm/charts/scorpio/templates/entity-manager-deployment.yaml
+++ b/helm/charts/scorpio/templates/entity-manager-deployment.yaml
@@ -23,6 +23,8 @@ spec:
     spec:
       containers:
       - image: {{ .Values.mainRepo }}/digitaltwin:EntityManager_{{ .Values.scorpio.tag }}
+        command: ["java"]
+        args: ["-XshowSettings:vm", {{ .Values.scorpio.heap_main.Xms | quote }}, {{ .Values.scorpio.heap_main.Xmx | quote }}, "-jar", "EntityManager.jar"]
         env:
           - name: CLIENT_ID
             value: {{ .Values.keycloak.scorpio.client }}
@@ -50,7 +52,6 @@ spec:
             value: {{ $val | quote }}
         {{- end }}
         {{- if .Values.springArgs.overrideSpringArgs }}
-        env:
           - name: spring_args
             value: {{ .Values.springArgs.value }}
         {{- end}}
@@ -79,7 +80,7 @@ spec:
           periodSeconds: {{ .Values.EntityManager.readinessProbe.periodSeconds }}
           {{- end}}
         resources:
-{{ toYaml .Values.EntityManager.resources | indent 10 }}
+{{ toYaml .Values.scorpio.resources_main | indent 10 }}
       restartPolicy: {{ .Values.EntityManager.restartPolicy }}
       {{- if .Values.EntityManager.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.EntityManager.serviceAccount.name }}

--- a/helm/charts/scorpio/templates/entity-manager-hpa.yaml
+++ b/helm/charts/scorpio/templates/entity-manager-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.EntityManager.enabled .Values.EntityManager.hpa.enabled }}
+{{- if and .Values.EntityManager.enabled .Values.EntityManager.hpa.enabled .Values.scorpio.hpa.enabled }}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm/charts/scorpio/templates/eureka-deployment.yaml
+++ b/helm/charts/scorpio/templates/eureka-deployment.yaml
@@ -23,8 +23,10 @@ spec:
     spec:
       containers:
       - image: {{ .Values.mainRepo }}/digitaltwin:eureka-server_{{ .Values.scorpio.tag }}
-        {{- if .Values.springArgs.overrideSpringArgs }}
+        command: ["java"]
+        args: ["-XshowSettings:vm", {{ .Values.scorpio.heap_min.Xms | quote }}, {{ .Values.scorpio.heap_min.Xmx | quote }}, "-jar", "eureka-server.jar"]
         env:
+        {{- if .Values.springArgs.overrideSpringArgs }}
           - name: spring_args
             value: {{ .Values.springArgs.value }}
         {{- end}}
@@ -46,7 +48,7 @@ spec:
           periodSeconds: {{ .Values.eureka.readinessProbe.periodSeconds }}
           {{- end}}
         resources:
-{{ toYaml .Values.eureka.resources | indent 10 }}
+{{ toYaml .Values.scorpio.resources_min | indent 10 }}
       restartPolicy: {{ .Values.eureka.restartPolicy }}
       {{- if .Values.eureka.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.eureka.serviceAccount.name }}

--- a/helm/charts/scorpio/templates/eureka-server-hpa.yaml
+++ b/helm/charts/scorpio/templates/eureka-server-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.eureka.enabled .Values.eureka.hpa.enabled }}
+{{- if and .Values.eureka.enabled .Values.eureka.hpa.enabled .Values.scorpio.hpa.enabled }}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm/charts/scorpio/templates/gateway-deployment.yaml
+++ b/helm/charts/scorpio/templates/gateway-deployment.yaml
@@ -27,11 +27,15 @@ spec:
         command: ['sh', '-c', "until wget -qO - http://eureka:8761/actuator/health| grep UP; do echo waiting for eureka service; sleep 1; done"]
       containers:
       - image: {{ .Values.mainRepo }}/digitaltwin:gateway_{{ .Values.scorpio.tag }}
+        command: ["java"]
+        args: ["-XshowSettings:vm", {{ .Values.scorpio.heap_main.Xms | quote }}, {{ .Values.scorpio.heap_main.Xmx | quote }}, "-jar", "gateway.jar"]
         env:
         {{- if .Values.springArgs.overrideSpringArgs }}
           - name: spring_args
             value: {{ .Values.springArgs.value }}
         {{- end}}
+          - name: JAVA_OPTS
+            value: {{ .Values.scorpio.java_opts_main }}
         imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
         name: {{ .Values.gateway.name }}
         ports:
@@ -57,7 +61,7 @@ spec:
           periodSeconds: {{ .Values.gateway.readinessProbe.periodSeconds }}
           {{- end}}
         resources:
-{{ toYaml .Values.gateway.resources | indent 10 }}
+{{ toYaml .Values.scorpio.resources_main | indent 10 }}
       restartPolicy: {{ .Values.gateway.restartPolicy }}
       {{- if .Values.gateway.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.gateway.serviceAccount.name }}

--- a/helm/charts/scorpio/templates/gateway-server-hpa.yaml
+++ b/helm/charts/scorpio/templates/gateway-server-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.gateway.enabled .Values.gateway.hpa.enabled }}
+{{- if and .Values.gateway.enabled .Values.gateway.hpa.enabled .Values.scorpio.hpa.enabled }}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm/charts/scorpio/templates/history-manager-hpa.yaml
+++ b/helm/charts/scorpio/templates/history-manager-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.HistoryManager.enabled .Values.HistoryManager.hpa.enabled }}
+{{- if and .Values.HistoryManager.enabled .Values.HistoryManager.hpa.enabled .Values.scorpio.hpa.enabled }}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm/charts/scorpio/templates/query-manager-deployment.yaml
+++ b/helm/charts/scorpio/templates/query-manager-deployment.yaml
@@ -23,6 +23,8 @@ spec:
     spec:
       containers:
       - image: {{ .Values.mainRepo }}/digitaltwin:QueryManager_{{ .Values.scorpio.tag }}
+        command: ["java"]
+        args: ["-XshowSettings:vm", {{ .Values.scorpio.heap_main.Xms | quote }}, {{ .Values.scorpio.heap_main.Xmx | quote }}, "-jar", "QueryManager.jar"]
         env:
           - name: CLIENT_ID
             value: {{ .Values.keycloak.scorpio.client }}
@@ -50,7 +52,6 @@ spec:
             value: {{ $val | quote }}
         {{- end }}
         {{- if .Values.springArgs.overrideSpringArgs }}
-        env:
           - name: spring_args
             value: {{ .Values.springArgs.value }}
         {{- end}}
@@ -79,7 +80,7 @@ spec:
           periodSeconds: {{ .Values.QueryManager.readinessProbe.periodSeconds }}
           {{- end}}
         resources:
-{{ toYaml .Values.QueryManager.resources | indent 10 }}
+{{ toYaml .Values.scorpio.resources_main | indent 10 }}
       restartPolicy: {{ .Values.QueryManager.restartPolicy }}
       {{- if .Values.QueryManager.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.QueryManager.serviceAccount.name }}

--- a/helm/charts/scorpio/templates/query-manager-hpa.yaml
+++ b/helm/charts/scorpio/templates/query-manager-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.QueryManager.enabled .Values.QueryManager.hpa.enabled }}
+{{- if and .Values.QueryManager.enabled .Values.QueryManager.hpa.enabled .Values.scorpio.hpa.enabled }}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm/charts/scorpio/templates/registration-manager-hpa.yaml
+++ b/helm/charts/scorpio/templates/registration-manager-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.RegistryManager.enabled .Values.RegistryManager.hpa.enabled }}
+{{- if and .Values.RegistryManager.enabled .Values.RegistryManager.hpa.enabled .Values.scorpio.hpa.enabled }}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm/charts/scorpio/templates/storage-manager-deployment.yaml
+++ b/helm/charts/scorpio/templates/storage-manager-deployment.yaml
@@ -23,6 +23,8 @@ spec:
     spec:
       containers:
       - image: {{ .Values.mainRepo }}/digitaltwin:StorageManager_{{ .Values.scorpio.tag }}
+        command: ["java"]
+        args: ["-XshowSettings:vm", {{ .Values.scorpio.heap_main.Xms | quote }}, {{ .Values.scorpio.heap_main.Xmx | quote }}, "-Xms50M","-Xmx64M", "-jar", "StorageManager.jar"]
         env:
           - name: CLIENT_ID
             value: {{ .Values.keycloak.scorpio.client }}
@@ -46,7 +48,6 @@ spec:
             value: {{ $val | quote }}
         {{- end }}
         {{- if .Values.springArgs.overrideSpringArgs }}
-        env:
           - name: spring_args
             value: {{ .Values.springArgs.value }}
         {{- end}}
@@ -75,7 +76,7 @@ spec:
           periodSeconds: {{ .Values.StorageManager.readinessProbe.periodSeconds }}
           {{- end}}
         resources:
-{{ toYaml .Values.StorageManager.resources | indent 10 }}
+{{ toYaml .Values.scorpio.resources_main | indent 10 }}
       restartPolicy: {{ .Values.StorageManager.restartPolicy }}
       {{- if .Values.StorageManager.serviceAccount.enabled }}
       serviceAccountName: {{ .Values.StorageManager.serviceAccount.name }}

--- a/helm/charts/scorpio/templates/storage-manager-hpa.yml
+++ b/helm/charts/scorpio/templates/storage-manager-hpa.yml
@@ -1,4 +1,4 @@
-{{- if and .Values.StorageManager.enabled .Values.StorageManager.hpa.enabled }}
+{{- if and .Values.StorageManager.enabled .Values.StorageManager.hpa.enabled .Values.scorpio.hpa.enabled }}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm/charts/scorpio/templates/subscription-manager-hpa.yaml
+++ b/helm/charts/scorpio/templates/subscription-manager-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.SubscriptionManager.enabled .Values.SubscriptionManager.hpa.enabled }}
+{{- if and .Values.SubscriptionManager.enabled .Values.SubscriptionManager.hpa.enabled .Values.scorpio.hpa.enabled }}
 apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:

--- a/helm/charts/scorpio/values.yaml
+++ b/helm/charts/scorpio/values.yaml
@@ -485,7 +485,7 @@ EntityManager:
 ################################### HistoryManager ##########################################################################
 HistoryManager:
 ## Enable the HistoryManager deployment & service
-  enabled: true
+  enabled: false
   name: history-manager
 ## Number of HistoryManager instances to deploy
 ##
@@ -633,7 +633,7 @@ QueryManager:
 ################################### RegistryManager ##########################################################################
 RegistryManager:
 ## Enable the RegistryManager deployment & service
-  enabled: true
+  enabled: false
   name: registry-manager
 ## Number of RegistryManager instances to deploy
 ##
@@ -782,7 +782,7 @@ StorageManager:
 ################################### SubscriptionManager ##########################################################################
 SubscriptionManager:
 ## Enable the SubscriptionManager deployment & service
-  enabled: true
+  enabled: false
   name: subscription-manager
 ## Number of SubscriptionManager instances to deploy
 ##

--- a/helm/default.yaml
+++ b/helm/default.yaml
@@ -52,7 +52,27 @@ scorpio:
   internalHostname: gateway
   internalPort: 9090
   internalProtocol: "http:"
-
+  heap_min:
+    Xms: "-Xms64M"
+    Xmx: "-Xmx64M"
+  heap_main:
+    Xms: "-Xms64M"
+    Xmx: "-Xmx64M"
+  hpa:
+    enabled: false
+  resources_min:
+    limits:
+      cpu: 100m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  resources_main:
+    limits:
+      memory: 512Mi
+    requests:
+      cpu: 200m
+      memory: 256Mi
 
 certmanager:
   secret: selfsigned-cert-tls

--- a/test/bats/test-horizontal-platform/horizontal-platform-up-and-running-second.bats
+++ b/test/bats/test-horizontal-platform/horizontal-platform-up-and-running-second.bats
@@ -46,19 +46,10 @@ DETIK_DEBUG="true"
     run try "at most 30 times every 30s to find 1 pod named 'gateway' with 'status.containerStatuses[0].ready' being 'true'"
     [ "$status" -eq 0 ]
 
-    run try "at most 30 times every 30s to find 1 pod named 'history-manager' with 'status.containerStatuses[0].ready' being 'true'"
-    [ "$status" -eq 0 ]
-
     run try "at most 30 times every 30s to find 1 pod named 'entity-manager' with 'status.containerStatuses[0].ready' being 'true'"
     [ "$status" -eq 0 ]
 
-    run try "at most 30 times every 30s to find 1 pod named 'subscription-manager' with 'status.containerStatuses[0].ready' being 'true'"
-    [ "$status" -eq 0 ]
-
     run try "at most 30 times every 30s to find 1 pod named 'query-manager' with 'status.containerStatuses[0].ready' being 'true'"
-    [ "$status" -eq 0 ]
-
-    run try "at most 30 times every 30s to find 1 pod named 'registry-manager' with 'status.containerStatuses[0].ready' being 'true'"
     [ "$status" -eq 0 ]
 
     run try "at most 30 times every 30s to find 1 pod named 'storage-manager' with 'status.containerStatuses[0].ready' being 'true'"


### PR DESCRIPTION
- Disabled currently not needed Scorpio modules (Registry, History, Subscription)
- Disabled podautoscaler for Scorpio components
- Restrict size of JAVA Heap of Scorpio Components
- Added resource constraints to Kafka and Kafka-connect
- Removed scorpio e2e tests of deleted components