### PR TITLE
Add core-tables, NGSILD-tables and sql creation from SHACL-properties

### DIFF
--- a/semantic-model/shacl2flink/Makefile
+++ b/semantic-model/shacl2flink/Makefile
@@ -1,6 +1,6 @@
 SHACL:= ../kms/shacl.ttl
 KNOWLEDGE := ../kms/knowledge.ttl
-MODEL := ../kms/example-model.ttl
+MODEL := ../kms/model-example.jsonld
 PYTHON := python3
 LINTER := flake8
 PIP := pip
@@ -8,11 +8,15 @@ OUTPUTDIR := output
 SQLITEDB := $(OUTPUTDIR)/database.db
 SQLITE3 := sqlite3
 
-sqlite_scripts = $(wildcard $(OUTPUTDIR)/*.sqlite)
+sqlite_files = $(OUTPUTDIR)/core.sqlite $(OUTPUTDIR)/ngsild.sqlite $(OUTPUTDIR)/rdf.sqlite $(OUTPUTDIR)/ngsild-models.sqlite $(OUTPUTDIR)/shacl-validation.sqlite
 
 build: $(SHACL) $(KNOWLEDGE $(MODEL)
 	@echo Build tables
 	$(PYTHON) create_rdf_table.py $(KNOWLEDGE)
+	$(PYTHON) create_core_tables.py
+	$(PYTHON) create_ngsild_tables.py $(SHACL)
+	$(PYTHON) create_ngsild_models.py $(SHACL) $(KNOWLEDGE) $(MODEL)
+	$(PYTHON) create_sql_checks_from_shacl.py $(SHACL) $(KNOWLEDGE)
 
 test: requirements-dev.txt
 	$(PYTHON) -m pytest --cov . --cov-fail-under=80
@@ -28,4 +32,4 @@ setup-dev: requirements-dev.txt
 
 test-sqlite:
 	@echo Test with sqlite
-	$(SQLITE3) $(SQLITEDB) < $(sqlite_scripts) 
+	cat $(sqlite_files) | $(SQLITE3) $(SQLITEDB) 

--- a/semantic-model/shacl2flink/README.md
+++ b/semantic-model/shacl2flink/README.md
@@ -4,7 +4,6 @@
 
 - You need to have Python > 3.8
 - Virtualenv needs to be installed
-- Proxy needs to be setup if you are in Intel network
 - `sqlite3` and `sqlite3-pcre` need to be installed
 
   ```bash

--- a/semantic-model/shacl2flink/create_core_tables.py
+++ b/semantic-model/shacl2flink/create_core_tables.py
@@ -1,0 +1,174 @@
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import lib.configs as configs
+import ruamel.yaml
+import lib.utils as utils
+yaml = ruamel.yaml.YAML()
+
+
+def main():
+    utils.create_output_folder()
+
+    kafka_topic_bulk_alerts = configs.kafka_topic_bulk_alerts
+    kafka_topic_listen_alerts = configs.kafka_topic_listen_alerts
+    kafka_topic_ngsild_updates = configs.kafka_topic_ngsild_updates
+    kafka_topic_attributes = configs.kafka_topic_attributes
+    kafka_bootstrap = configs.kafka_bootstrap
+
+    f = open("output/core.yaml", "w")
+    sqlitef = open("output/core.sqlite", "w")
+
+    # alerts table
+    table_name = "alerts"
+    connector = 'upsert-kafka'
+    table = [{'resource': 'STRING'},
+             {'event': 'STRING'},
+             {'environment': 'STRING'},
+             {'service': 'ARRAY<STRING>'},
+             {'severity': 'STRING'},
+             {'customer': 'STRING'},
+             {'text': 'STRING'}]
+    table_sqlite = [{'resource': 'STRING'},
+                    {'event': 'STRING'},
+                    {'environment': 'STRING'},
+                    {'service': 'STRING'},
+                    {'severity': 'STRING'},
+                    {'customer': 'STRING'},
+                    {'text': 'STRING'}]
+    primary_key = ['resource', 'event']
+    kafka = {'topic': kafka_topic_listen_alerts,
+             'properties': {'bootstrap.servers': kafka_bootstrap},
+             'key.format': 'json'
+             }
+    value = {
+                'format': 'json',
+                'json.fail-on-missing-field': False,
+                'json.ignore-parse-errors': True
+            }
+
+    print('---', file=f)
+    yaml.dump(utils.create_yaml_table(table_name, connector, table,
+                                      primary_key, kafka, value), f)
+    print(utils.create_sql_table(table_name, table_sqlite,
+                                 primary_key), file=sqlitef)
+
+    # alerts-bulk table
+    table_name = "alerts-bulk"
+    spec_name = "alerts_bulk"
+    connector = 'upsert-kafka'
+    table = [{'resource': 'STRING'},
+             {'event': 'STRING'},
+             {'environment': 'STRING'},
+             {'service': 'ARRAY<STRING>'},
+             {'severity': 'STRING'},
+             {'customer': 'STRING'},
+             {'text': 'STRING'},
+             {'watermark': 'FOR `ts` AS `ts`'},
+             {'ts': ' TIMESTAMP(3) METADATA VIRTUAL'}]
+    table_sqlite = [{'resource': 'STRING'},
+                    {'event': 'STRING'},
+                    {'environment': 'STRING'},
+                    {'service': 'STRING'},
+                    {'severity': 'STRING'},
+                    {'customer': 'STRING'},
+                    {'text': 'STRING'},
+                    {'watermark': 'FOR `ts` AS `ts`'},
+                    {'ts': ' TIMESTAMP(3) METADATA VIRTUAL'}]
+    primary_key = ['resource', 'event']
+    kafka = {'topic': kafka_topic_bulk_alerts,
+             'properties': {'bootstrap.servers': kafka_bootstrap},
+             'key.format': 'json'
+             }
+    value = {
+             'format': 'json',
+             'json.fail-on-missing-field': False,
+             'json.ignore-parse-errors': True
+            }
+
+    print('---', file=f)
+    yaml.dump(utils.create_yaml_table(spec_name, connector, table,
+                                      primary_key, kafka, value), f)
+    print(utils.create_sql_table(spec_name, table_sqlite,
+                                 primary_key, utils.SQL_DIALECT.SQLITE),
+          file=sqlitef)
+    print(utils.create_sql_view(spec_name, table_sqlite, primary_key, []),
+          file=sqlitef)
+
+    # ngsild-updates table
+    table_name = "ngsild-updates"
+    spec_name = "ngsild_updates"
+    connector = 'kafka'
+    table = [{'op': 'STRING'},
+             {'overwirteOrReplace': 'BOOLEAN'},
+             {'noForward': 'BOOLEAN'},
+             {'entities': 'STRING'}]
+    primary_key = None
+    kafka = {'topic': kafka_topic_ngsild_updates,
+             'properties': {'bootstrap.servers': kafka_bootstrap},
+             'scan.startup.mode': 'latest-offset'
+             }
+    value = {
+             'format': 'json',
+             'json.fail-on-missing-field': False,
+             'json.ignore-parse-errors': True
+            }
+
+    print('---', file=f)
+    yaml.dump(utils.create_yaml_table(spec_name, connector, table,
+                                      primary_key, kafka, value), f)
+    print(utils.create_sql_table(spec_name, table, primary_key),
+          file=sqlitef)
+
+    # attributes table
+    table_name = "attributes"
+    spec_name = "attributes"
+    connector = 'kafka'
+    table = [{'id': 'STRING'},
+             {'entityId': 'STRING'},
+             {'name': 'STRING'},
+             {'nodeType': 'STRING'},
+             {'valueType': 'STRING'},
+             {'index': 'INTEGER'},
+             {'type': 'STRING'},
+             {'https://uri.etsi.org/ngsi-ld/hasValue': 'STRING'},
+             {'https://uri.etsi.org/ngsi-ld/hasObject': 'STRING'},
+             {'watermark': 'FOR `ts` AS `ts`'},
+             {'ts': "TIMESTAMP(3) METADATA FROM 'timestamp'"}]
+    primary_key = None
+    kafka = {'topic': kafka_topic_attributes,
+             'properties': {'bootstrap.servers': kafka_bootstrap},
+             'scan.startup.mode': 'earliest-offset'
+             }
+    value = {
+             'format': 'json',
+             'json.fail-on-missing-field': False,
+             'json.ignore-parse-errors': True
+            }
+
+    print('---', file=f)
+    yaml.dump(utils.create_yaml_table(table_name, connector, table,
+                                      primary_key, kafka, value), f)
+    print(utils.create_sql_table(table_name, table, primary_key,
+                                 utils.SQL_DIALECT.SQLITE), file=sqlitef)
+    print('---', file=f)
+    yaml.dump(utils.create_yaml_view(table_name, table, ['id', 'index']), f)
+    print(utils.create_sql_view(table_name, table, ['id', 'index']),
+          file=sqlitef)
+
+
+if __name__ == '__main__':
+    main()

--- a/semantic-model/shacl2flink/create_ngsild_models.py
+++ b/semantic-model/shacl2flink/create_ngsild_models.py
@@ -1,0 +1,214 @@
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from rdflib import Graph, URIRef
+from rdflib.namespace import RDFS
+import owlrl
+import os
+import sys
+import re
+import argparse
+import lib.utils as utils
+import lib.configs as configs
+
+
+def parse_args(args=sys.argv[1:]):
+    parser = argparse.ArgumentParser(description='create_ngsild_models.py \
+                                                  <shacl.ttl> <knowledge.ttl> \
+                                                  <model.jsonld>')
+
+    parser.add_argument('shaclfile', help='Path to the SHACL file')
+    parser.add_argument('knowledgefile', help='Path to the knowledge file')
+    parser.add_argument('modelfile', help='Path to the model file')
+    parsed_args = parser.parse_args(args)
+    return parsed_args
+
+
+attributes_query = """
+PREFIX iff: <https://industry-fusion.com/types/v0.9/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ngsild: <https://uri.etsi.org/ngsi-ld/>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+SELECT (?a as ?entityId) (?b as ?name) (?e as ?type) (?d as ?nodeType) \
+(datatype(?g) as ?valueType) (?f as ?hasValue) (?g as ?hasObject)
+#SELECT ?a ?b ?c ?d
+where {
+    ?nodeshape a sh:NodeShape .
+    ?nodeshape sh:targetClass ?class .
+    ?a a ?class .
+    {?a ?b [ ngsild:hasObject ?g ] .
+    VALUES ?d { '@id'} .
+    VALUES ?e {ngsild:Relationship}
+    }
+    UNION
+    { ?a ?b [ ngsild:hasValue ?f ] .
+    VALUES ?d {'@value'} .
+    VALUES ?e {ngsild:Property}
+    FILTER(!isIRI(?f))
+    }
+    UNION
+    { ?a ?b [ ngsild:hasValue ?f ] .
+    VALUES ?d {'@id'} .
+    VALUES ?e {ngsild:Property}
+    FILTER(isIRI(?f))
+    }
+    ?nodeshape sh:property [ sh:path ?b ] .
+}
+"""
+
+ngsild_tables_query = """
+PREFIX iff: <https://industry-fusion.com/types/v0.9/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ngsild: <https://uri.etsi.org/ngsi-ld/>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+SELECT ?id ?type ?field ?ord
+where {
+    ?nodeshape a sh:NodeShape .
+    ?nodeshape sh:targetClass ?type .
+    ?id a ?type .
+    ?nodeshape sh:property [ sh:path ?field ; sh:order ?ord ] .
+    }
+    ORDER BY ?id ?ord
+"""
+
+ngsild_tables_query_noinference = """
+PREFIX iff: <https://industry-fusion.com/types/v0.9/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ngsild: <https://uri.etsi.org/ngsi-ld/>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+
+SELECT DISTINCT ?id ?type ?field ?ord ?shacltype
+where {
+    ?nodeshape a sh:NodeShape .
+    ?nodeshape sh:targetClass ?shacltype .
+    ?id a ?type .
+    ?type rdfs:subClassOf* ?shacltype .
+    ?nodeshape sh:property [ sh:path ?field ; sh:order ?ord ] .
+    }
+    ORDER BY ?id ?ord
+"""
+
+
+def nullify(field):
+    if field is None:
+        field = 'NULL'
+    else:
+        field = "'" + str(field.toPython()) + "'"
+    return field
+
+
+def main(shaclfile, knowledgefile, modelfile, output_folder='output'):
+    utils.create_output_folder(output_folder)
+    with open(os.path.join(output_folder, "ngsild-models.sqlite"), "w")\
+            as sqlitef:
+        g = Graph()
+        g.parse(shaclfile)
+        model = Graph()
+        model.parse(modelfile)
+        knowledge = Graph()
+        knowledge.parse(knowledgefile)
+        model += g + knowledge
+
+        # Create attributes table by sparql
+        # query first before inferencing
+        qres_noinf = model.query(ngsild_tables_query_noinference)
+        # now infer types and do rest of the queries
+        owlrl.RDFSClosure.RDFS_Semantics(model, axioms=False,
+                                         daxioms=False,
+                                         rdfs=False).closure()
+        qres = model.query(attributes_query)
+        entity_count = {}
+        first = True
+        print(f'INSERT INTO `{configs.attributes_table_name}` VALUES',
+              file=sqlitef)
+        for entityId, name, type, nodeType, valueType, hasValue,\
+                hasObject in qres:
+            id = entityId.toPython() + "\\\\" + name.toPython()
+            if id not in entity_count:
+                entity_count[id] = 0
+            else:
+                entity_count[id] += 1
+
+            valueType = nullify(valueType)
+            hasValue = nullify(hasValue)
+            hasObject = nullify(hasObject)
+            if "string" in valueType:
+                valueType = 'NULL'
+            if first:
+                first = False
+            else:
+                print(',', file=sqlitef)
+            print("('" + id + "', '" + entityId.toPython() + "', '" +
+                  name.toPython() +
+                  "', '" + nodeType + "', " + valueType + ", " +
+                  str(entity_count[id]) +
+                  ", '" + type.toPython() + "'," + hasValue + ", " +
+                  hasObject + ", " + 'CURRENT_TIMESTAMP' + ")", end='',
+                  file=sqlitef)
+        print(";", file=sqlitef)
+
+        # Create ngsild tables by sparql
+        qres = model.query(ngsild_tables_query)
+        tables = {}
+
+        # orig_class contains the real, not inferenced type, e.g. plasmacutter
+        # instead of machine, even though it is inserted in the machine table
+        orig_class = {}
+        for id, type, field, ord, shacltype in qres_noinf:
+            if id not in orig_class:
+                orig_class[id] = type
+            else:
+                if (type, RDFS.subClassOf, orig_class[id]) in model:
+                    orig_class[id] = type
+
+        # Now create the entity tables
+        for id, type, field, ord in qres:
+            combined_key = id.toPython() + '\\\\' + type.toPython()
+            if combined_key not in tables:
+                table = []
+                table.append(id.toPython())
+                table.append(orig_class[id])
+                tables[combined_key] = table
+            tables[combined_key].append(id.toPython() + "\\\\" +
+                                        field.toPython())
+        for id, table in tables.items():
+            table.append('CURRENT_TIMESTAMP')
+
+        for id, table in tables.items():
+            type = re.search('^.*\\\\(.*)$', id)[1]
+            print(f'INSERT INTO `{utils.strip_class(URIRef(type))}` VALUES',
+                  file=sqlitef)
+            first = True
+            print("(", end='', file=sqlitef)
+            for field in table:
+                if first:
+                    first = False
+                else:
+                    print(", ", end='', file=sqlitef)
+                if isinstance(field, str) and not field == 'CURRENT_TIMESTAMP':
+                    print("'" + field + "'", end='', file=sqlitef)
+                else:
+                    print(field, end='', file=sqlitef)
+            print(");", file=sqlitef)
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    shaclfile = args.shaclfile
+    knowledgefile = args.knowledgefile
+    modelfile = args.modelfile
+    main(shaclfile, knowledgefile, modelfile)

--- a/semantic-model/shacl2flink/create_ngsild_tables.py
+++ b/semantic-model/shacl2flink/create_ngsild_tables.py
@@ -1,0 +1,94 @@
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from rdflib import Graph, Namespace
+from rdflib.namespace import RDF
+import os
+import sys
+import argparse
+from urllib.parse import urlparse
+import ruamel.yaml
+import lib.utils as utils
+import lib.configs as configs
+from ruamel.yaml.scalarstring import (SingleQuotedScalarString as sq)
+
+
+def parse_args(args=sys.argv[1:]):
+    parser = argparse.ArgumentParser(description='create_ngsild_tables.py \
+                                                  <shacl.ttl>')
+    parser.add_argument('shaclfile', help='Path to the SHACL file')
+    parsed_args = parser.parse_args(args)
+    return parsed_args
+
+
+def main(shaclfile, output_folder='output'):
+    yaml = ruamel.yaml.YAML()
+    utils.create_output_folder(output_folder)
+    g = Graph()
+    g.parse(shaclfile)
+    sh = Namespace("http://www.w3.org/ns/shacl#")
+    tables = {}
+    for s, p, o in g.triples((None, RDF.type, sh.NodeShape)):
+        for _, _, target_class in g.triples((s, sh.targetClass, None)):
+            if (s, sh.property, None) not in g:
+                break
+            a = urlparse(target_class)
+            stripped_class = os.path.basename(a.path)
+            if stripped_class not in tables:
+                table = []
+                tables[stripped_class] = table
+            else:
+                table = tables[stripped_class]
+            table.append({sq("id"): "STRING"})
+            table.append({sq("type"): "STRING"})
+
+            for _, _, target_property in g.triples((s, sh.property, None)):
+                target_path = g.value(target_property, sh.path)
+                table.append({sq(f'{target_path}'): "STRING"})
+            table.append({sq("ts"): "TIMESTAMP(3) METADATA FROM 'timestamp'"})
+            table.append({sq("WATERMARK"): "FOR `ts` AS `ts`"})
+
+    with open(os.path.join(output_folder, "ngsild.yaml"), "w") as f,\
+            open(os.path.join(output_folder, "ngsild.sqlite"), "w") as sqlitef:
+        for table_name, table in tables.items():
+            connector = 'kafka'
+            primary_key = None
+            kafka = {'topic':
+                     f'{configs.kafka_topic_ngsi_prefix}.{table_name}',
+                     'properties': {'bootstrap.servers':
+                                    configs.kafka_bootstrap},
+                     'scan.startup.mode': 'earliest-offset'
+                     }
+            value = {
+                        'format': 'json',
+                        'json.fail-on-missing-field': False,
+                        'json.ignore-parse-errors': True
+                    }
+            print('---', file=f)
+            yaml.dump(utils.create_yaml_table(table_name, connector, table,
+                                              primary_key, kafka, value), f)
+            print(utils.create_sql_table(table_name, table, primary_key,
+                                         utils.SQL_DIALECT.SQLITE),
+                  file=sqlitef)
+            print('---', file=f)
+            yaml.dump(utils.create_yaml_view(table_name, table), f)
+            print(utils.create_sql_view(table_name, table), file=sqlitef)
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    shaclfile = args.shaclfile
+    main(shaclfile)

--- a/semantic-model/shacl2flink/create_sql_checks_from_shacl.py
+++ b/semantic-model/shacl2flink/create_sql_checks_from_shacl.py
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import sys
+import lib.utils as utils
+from lib.shacl_properties_to_sql import translate as translate_properties
+import ruamel.yaml
+import argparse
+
+
+def parse_args(args=sys.argv[1:]):
+    parser = argparse.ArgumentParser(description='\
+create_sql_checks_from_shacl.py <shacl.ttl> <knowledge.ttl>')
+
+    parser.add_argument('shaclfile', help='Path to the SHACL file')
+    parser.add_argument('knowledgefile', help='Path to the knowledge file')
+    parsed_args = parser.parse_args(args)
+    return parsed_args
+
+
+def main(shaclfile, knowledgefile, output_folder='output'):
+    utils.create_output_folder(output_folder)
+
+    yaml = ruamel.yaml.YAML()
+
+    sqlite, (statementsets, tables, views) = \
+        translate_properties(shaclfile, knowledgefile)
+
+    tables = list(set(tables))
+    views = list(set(views))
+
+    with open(os.path.join(output_folder, "shacl-validation.yaml"), "w") as f:
+        yaml.dump(utils.create_statementset('shacl-validation', tables, views,
+                                            statementsets), f)
+    with open(os.path.join(output_folder, "shacl-validation.sqlite"), "w") \
+            as sqlitef:
+        print(sqlite, file=sqlitef)
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    shaclfile = args.shaclfile
+    knowledgefile = args.knowledgefile
+    main(shaclfile, knowledgefile)

--- a/semantic-model/shacl2flink/lib/shacl_properties_to_sql.py
+++ b/semantic-model/shacl2flink/lib/shacl_properties_to_sql.py
@@ -1,0 +1,663 @@
+from rdflib import Graph, Namespace
+import os
+import sys
+import owlrl
+import ruamel.yaml
+from jinja2 import Template
+
+file_dir = os.path.dirname(__file__)
+sys.path.append(file_dir)
+import configs  # noqa: E402
+import utils  # noqa: E402
+
+
+yaml = ruamel.yaml.YAML()
+
+alerts_bulk_table = configs.alerts_bulk_table_name
+alerts_bulk_table_object = configs.alerts_bulk_table_object_name
+
+sparql_get_all_relationships = """
+PREFIX iff: <https://industry-fusion.com/types/v0.9/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ngsild: <https://uri.etsi.org/ngsi-ld/>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+SELECT ?nodeshape ?targetclass ?propertypath ?mincount ?maxcount ?attributeclass ?severitycode
+where {
+    ?nodeshape a sh:NodeShape .
+    ?nodeshape sh:targetClass ?targetclass .
+    ?nodeshape sh:property [
+        sh:path ?propertypath ;
+        sh:property [
+            sh:path ngsild:hasObject ;
+            sh:class ?attributeclass ;
+        ]
+    ] .
+    OPTIONAL{?nodeshape sh:property [ sh:path ?propertypath; sh:maxCount ?maxcount ]}
+    OPTIONAL{?nodeshape sh:property [ sh:path ?propertypath; sh:minCount ?mincount ]}
+    OPTIONAL {
+        ?nodeshape sh:property [
+            sh:path ?propertypath;
+            sh:severity ?severity ;
+        ] .
+        ?severity iff:severityCode ?severitycode .
+    }
+}
+order by ?targetclass
+"""  # noqa: E501
+
+sparql_get_all_properties = """
+PREFIX iff: <https://industry-fusion.com/types/v0.9/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX ngsild: <https://uri.etsi.org/ngsi-ld/>
+PREFIX sh: <http://www.w3.org/ns/shacl#>
+SELECT
+    ?nodeshape ?targetclass ?propertypath ?mincount ?maxcount ?attributeclass ?nodekind
+    ?minexclusive ?maxexclusive ?mininclusive ?maxinclusive ?minlength ?maxlength ?pattern
+where {
+    ?nodeshape a sh:NodeShape .
+    ?nodeshape sh:targetClass ?targetclass .
+    ?nodeshape sh:property [
+        sh:path ?propertypath ;
+        sh:property [
+            sh:path ngsild:hasValue ;
+            sh:nodeKind ?nodekind ;
+        ] ;
+
+    ] .
+    OPTIONAL { ?nodeshape sh:property [ sh:path ?propertypath ; sh:minCount ?mincount ; ] }
+    OPTIONAL { ?nodeshape sh:property [ sh:path ?propertypath ; sh:maxCount ?maxcount ; ] }
+    OPTIONAL { ?nodeshape sh:property [ sh:path ?propertypath ; sh:property [sh:path ngsild:hasValue ; sh:minExclusive ?minexclusive ;] ; ] }
+    OPTIONAL { ?nodeshape sh:property [ sh:path ?propertypath ; sh:property [sh:path ngsild:hasValue ; sh:maxExclusive ?maxexclusive ;] ; ] }
+    OPTIONAL { ?nodeshape sh:property [ sh:path ?propertypath ; sh:property [sh:path ngsild:hasValue ; sh:minInclusive ?mininclusive ;] ; ] }
+    OPTIONAL { ?nodeshape sh:property [ sh:path ?propertypath ; sh:property [sh:path ngsild:hasValue ; sh:maxInclusive ?maxinclusive ;] ; ] }
+    OPTIONAL { ?nodeshape sh:property [ sh:path ?propertypath ; sh:property [sh:path ngsild:hasValue ; sh:minLength ?minlength ;] ; ] }
+    OPTIONAL { ?nodeshape sh:property [ sh:path ?propertypath ; sh:property [sh:path ngsild:hasValue ; sh:maxLength ?maxlength ;] ; ] }
+    OPTIONAL { ?nodeshape sh:property [ sh:path ?propertypath ; sh:property [sh:path ngsild:hasValue ; sh:pattern ?pattern ;] ; ] }
+    OPTIONAL { ?nodeshape sh:property [ sh:path ?propertypath ; sh:property [sh:path ngsild:hasValue ; sh:class ?attributeclass ;] ; ] }
+
+}
+order by ?targetclass
+
+"""  # noqa: E501
+sql_check_relationship_base = """
+            INSERT {% if sqlite %}OR REPlACE{% endif %} INTO {{alerts_bulk_table}}
+            WITH A1 as (
+                    SELECT A.id AS this,
+                           A.`type` as typ,
+                           {%- if property_class %}
+                           C.`type` AS entity,
+                           {%- endif %}
+                           B.`type` AS link,
+                    IFNULL(B.`index`, 0) as `index` FROM {{target_class}}_view AS A
+                    LEFT JOIN attributes_view AS B ON B.id = A.`{{property_path}}`
+                    {%- if property_class %}
+                    LEFT JOIN {{property_class}}_view AS C ON B.`https://uri.etsi.org/ngsi-ld/hasObject` = C.id
+                    {%- endif %}
+                    WHERE
+                        (B.`type` = 'https://uri.etsi.org/ngsi-ld/Relationship' OR B.`type` IS NULL)
+                        AND (B.entityId = A.id OR B.entityId IS NULL)
+                        AND (B.name = '{{property_path}}' OR B.name IS NULL)
+
+            )
+"""  # noqa: E501
+
+sql_check_relationship_property_class = """
+            SELECT this AS resource,
+                'PropertyClassCheck({{property_path}}[' || CAST( `index` AS STRING) || '])' AS event,
+                'Development' AS environment,
+                {% if sqlite %}
+                '[SHACL Validator]' AS service,
+                {% else %}
+                ARRAY ['SHACL Validator'] AS service,
+                {% endif %}
+                CASE WHEN typ is NOT NULL AND entity is NULL THEN '{{severity}}'
+                    ELSE 'ok' END AS severity,
+                'customer'  customer,
+
+                CASE WHEN typ is NOT NULL AND entity is NULL
+                        THEN 'Model validation for relationship {{property_path}} failed for '|| this || '. Relationship not linked to existing entity of type {{property_class}}.'
+                    ELSE 'All ok' END as `text`
+                {%- if sqlite %}
+                ,CURRENT_TIMESTAMP
+                {%- endif %}
+            FROM A1
+"""  # noqa: E501
+
+sql_check_relationship_property_count = """
+            SELECT this AS resource,
+                'PropertyCountCheck({{property_path}})' AS event,
+                'Development' AS environment,
+                {% if sqlite %}
+                '[SHACL Validator]' AS service,
+                {% else %}
+                ARRAY ['SHACL Validator'] AS service,
+                {% endif %}
+                CASE WHEN typ IS NOT NULL AND ({%- if maxcount %} count(link) > {{maxcount}} {%- endif %} {%- if mincount and maxcount %} OR {%- endif %} {%- if mincount %} count(link) < {{mincount}} {%- endif %})
+                    THEN '{{severity}}'
+                    ELSE 'ok' END AS severity,
+                'customer'  customer,
+                CASE WHEN typ IS NOT NULL AND ({%- if maxcount %} count(link) > {{maxcount}} {%- endif %} {%- if mincount and maxcount %} OR {%- endif %} {%- if mincount %} count(link) < {{mincount}} {%- endif %})
+                    THEN
+                        'Model validation for relationship {{property_path}} failed for ' || this || ' . Found ' || CAST(count(link) AS STRING) || ' relationships instead of
+                            [{%- if mincount %}{{mincount}}{%- else %} 0 {%- endif %},{%if maxcount %}{{maxcount}}]{%- else %}[ {%- endif %}!'
+                    ELSE 'All ok' END as `text`
+                {%- if sqlite %}
+                ,CURRENT_TIMESTAMP
+                {%- endif %}
+            FROM A1
+            group by this, typ
+"""  # noqa: E501
+
+sql_check_property_iri_base = """
+INSERT {% if sqlite %} OR REPlACE{% endif %} INTO {{alerts_bulk_table}}
+WITH A1 AS (SELECT A.id as this,
+                   A.`type` as typ,
+                   B.`https://uri.etsi.org/ngsi-ld/hasValue` as val,
+                   B.`nodeType` as nodeType,
+                   B.`type` as attr_typ,
+                   {% if property_class -%}
+                   C.subject as foundVal,
+                   C.object as foundClass,
+                   {%- endif %}
+                   IFNULL(B.`index`, 0) as `index` FROM `{{target_class}}_view` AS A
+            LEFT JOIN attributes_view AS B ON A.`{{property_path}}` = B.id
+            {% if property_class -%}
+            LEFT JOIN {{rdf_table_name}} as C ON C.subject = B.`https://uri.etsi.org/ngsi-ld/hasValue` and C.predicate = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' and C.object = '{{property_class}}'
+            {%- endif %}
+            )
+"""  # noqa: E501
+sql_check_property_iri_class = """
+SELECT this AS resource,
+    'DataTypeValidation({{property_path}}[' || CAST( `index` AS STRING) || '])' AS event,
+    'Development' AS environment,
+    {%- if sqlite %}
+    '[SHACL Validator]' AS service,
+    {%- else %}
+    ARRAY ['SHACL Validator'] AS service,
+    {%- endif %}
+    CASE WHEN typ IS NOT NULL AND attr_typ IS NOT NULL AND (val is NULL OR foundVal is NULL)
+        THEN '{{severity}}'
+        ELSE 'ok' END AS severity,
+    'customer'  customer,
+    CASE WHEN typ IS NOT NULL AND attr_typ IS NOT NULL AND (val is NULL OR foundVal is NULL)
+        THEN 'Model validation for Property {{property_path}} failed for ' || this || '. Invalid value ' || IFNULL(val, 'NULL') || ' not type of {{property_class}}'
+        ELSE 'All ok' END as `text`
+        {% if sqlite %}
+        ,CURRENT_TIMESTAMP
+        {% endif %}
+FROM A1
+"""  # noqa: E501
+sql_check_property_nodeType = """
+SELECT this AS resource,
+ 'NodeTypeValidation({{property_path}}[' || CAST( `index` AS STRING) || '])' AS event,
+    'Development' AS environment,
+     {%- if sqlite -%}
+    '[SHACL Validator]' AS service,
+    {%- else %}
+    ARRAY ['SHACL Validator'] AS service,
+    {%- endif %}
+    CASE WHEN typ IS NOT NULL AND attr_typ IS NOT NULL AND (nodeType is NULL OR nodeType <> '{{ property_nodetype }}')
+        THEN '{{severity}}'
+        ELSE 'ok' END AS severity,
+    'customer'  customer,
+    CASE WHEN typ IS NOT NULL AND attr_typ IS NOT NULL AND (nodeType is NULL OR nodeType <> '{{ property_nodetype }}')
+        THEN 'Model validation for Property {{property_path}} failed for ' || this || '. Node is not {{ property_nodetype_description }}.'
+        ELSE 'All ok' END as `text`
+        {% if sqlite %}
+        ,CURRENT_TIMESTAMP
+        {% endif %}
+FROM A1
+"""  # noqa: E501
+
+sql_check_property_minmax = """
+SELECT this AS resource,
+ '{{minmaxname}}Validation({{property_path}}[' || CAST( `index` AS STRING) || '])' AS event,
+    'Development' AS environment,
+     {%- if sqlite -%}
+    '[SHACL Validator]' AS service,
+    {%- else %}
+    ARRAY ['SHACL Validator'] AS service,
+    {%- endif %}
+    CASE WHEN typ IS NOT NULL AND attr_typ IS NOT NULL AND (CAST(val AS DOUBLE) is NULL or NOT (CAST(val as DOUBLE) {{ operator }} {{ comparison_value }}) )
+        THEN '{{severity}}'
+        ELSE 'ok' END AS severity,
+    'customer'  customer,
+    CASE WHEN typ IS NOT NULL AND attr_typ IS NOT NULL AND (CAST(val AS DOUBLE) is NULL)
+        THEN 'Model validation for Property {{property_path}} failed for ' || this || '. Value ' || IFNULL(val, 'NULL') || ' not comparable with {{ comparison_value }}.'
+        WHEN typ IS NOT NULL AND attr_typ IS NOT NULL AND NOT (CAST(val as DOUBLE) {{ operator }} {{ comparison_value }})
+        THEN 'Model validation for Property {{property_path}} failed for ' || this || '. Value ' || IFNULL(val, 'NULL') || ' is not {{ operator }} {{ comparison_value }}.'
+        ELSE 'All ok' END as `text`
+        {% if sqlite %}
+        ,CURRENT_TIMESTAMP
+        {% endif %}
+FROM A1
+"""  # noqa: E501
+
+sql_check_string_length = """
+SELECT this AS resource,
+ '{{minmaxname}}Validation({{property_path}}[' || CAST( `index` AS STRING) || '])' AS event,
+    'Development' AS environment,
+     {%- if sqlite -%}
+    '[SHACL Validator]' AS service,
+    {%- else %}
+    ARRAY ['SHACL Validator'] AS service,
+    {%- endif %}
+    CASE WHEN typ IS NOT NULL AND attr_typ IS NOT NULL AND {%- if sqlite %} LENGTH(val) {%- else  %} CHAR_LENGTH(val) {%- endif %} {{ operator }} {{ comparison_value }}
+        THEN '{{severity}}'
+        ELSE 'ok' END AS severity,
+    'customer'  customer,
+    CASE WHEN typ IS NOT NULL AND attr_typ IS NOT NULL AND {%- if sqlite %} LENGTH(val) {%- else  %} CHAR_LENGTH(val) {%- endif %} {{ operator }} {{ comparison_value }}
+        THEN 'Model validation for Property {{property_path}} failed for ' || this || '. Length of ' || IFNULL(val, 'NULL') || ' is {{ operator }} {{ comparison_value }}.'
+        ELSE 'All ok' END as `text`
+        {% if sqlite %}
+        ,CURRENT_TIMESTAMP
+        {% endif %}
+FROM A1
+"""  # noqa: E501
+
+sql_check_literal_pattern = """
+SELECT this AS resource,
+ '{{validationname}}Validation({{property_path}}[' || CAST( `index` AS STRING) || '])' AS event,
+    'Development' AS environment,
+     {%- if sqlite -%}
+    '[SHACL Validator]' AS service,
+    {%- else %}
+    ARRAY ['SHACL Validator'] AS service,
+    {%- endif %}
+    CASE WHEN typ IS NOT NULL AND attr_typ IS NOT NULL AND {%- if sqlite %} NOT (val REGEXP '{{pattern}}') {%- else  %} NOT REGEXP(val, '{{pattern}}') {%- endif %}
+        THEN '{{severity}}'
+        ELSE 'ok' END AS severity,
+    'customer'  customer,
+    CASE WHEN typ IS NOT NULL AND attr_typ IS NOT NULL AND {%- if sqlite %} NOT (val REGEXP '{{pattern}}') {%- else  %} NOT REGEXP(val, '{{pattern}}') {%- endif %}
+        THEN 'Model validation for Property {{property_path}} failed for ' || this || '. Value ' || IFNULL(val, 'NULL') || ' does not match pattern {{ pattern }}'
+        ELSE 'All ok' END as `text`
+        {% if sqlite %}
+        ,CURRENT_TIMESTAMP
+        {% endif %}
+FROM A1
+"""  # noqa: E501
+
+
+def translate(shaclefile, knowledgefile):
+    """
+    Translate shacl properties into SQL constraints.
+
+    Parameters:
+        filename: filename of SHACL file
+
+    Returns:
+        sql-statement-list: list of plain SQL objects
+        (statementset, tables, views): statementset in yaml format
+
+    """
+    g = Graph()
+    h = Graph()
+    g.parse(shaclefile)
+    h.parse(knowledgefile)
+    g += h
+    owlrl.RDFSClosure.RDFS_Semantics(g, axioms=False, daxioms=False,
+                                     rdfs=False).closure()
+    sh = Namespace("http://www.w3.org/ns/shacl#")
+    tables = [alerts_bulk_table_object, configs.attributes_table_obj_name,
+              configs.rdf_table_obj_name]
+    views = [configs.attributes_view_obj_name]
+    statementsets = []
+    sqlite = ''
+    # Get all NGSI-LD Relationship
+    qres = g.query(sparql_get_all_relationships)
+    for row in qres:
+        target_class = utils.strip_class(row.targetclass.toPython()) \
+            if row.targetclass else None
+        property_path = row.propertypath.toPython() if row.propertypath \
+            else None
+        property_class = row.attributeclass.toPython() if row.attributeclass \
+            else None
+        mincount = row.mincount.toPython() if row.mincount else 0
+        maxcount = row.maxcount.toPython() if row.maxcount else None
+        severitycode = row.severitycode.toPython() if row.severitycode \
+            else 'warning'
+        sql_command_yaml = Template(sql_check_relationship_base).render(
+                alerts_bulk_table=alerts_bulk_table,
+                target_class=target_class,
+                property_path=property_path,
+                property_class=utils.strip_class(property_class),
+                mincount=mincount,
+                maxcount=maxcount,
+                sqlite=False)
+        sql_command_sqlite = Template(sql_check_relationship_base).render(
+            alerts_bulk_table=alerts_bulk_table,
+            target_class=target_class,
+            property_path=property_path,
+            property_class=utils.strip_class(property_class),
+            mincount=mincount,
+            maxcount=maxcount,
+            sqlite=True)
+        add_union = False
+        if property_class:
+            add_union = True
+            sql_command_yaml += \
+                Template(sql_check_relationship_property_class).render(
+                         alerts_bulk_table=alerts_bulk_table,
+                         target_class=target_class,
+                         property_path=property_path,
+                         property_class=property_class,
+                         severity=severitycode,
+                         sqlite=False)
+            sql_command_sqlite += \
+                Template(sql_check_relationship_property_class).render(
+                         alerts_bulk_table=alerts_bulk_table,
+                         target_class=target_class,
+                         property_path=property_path,
+                         property_class=property_class,
+                         severity=severitycode,
+                         sqlite=True)
+        if mincount > 0 or maxcount:
+            if add_union:
+                sql_command_yaml += "\nUNION ALL"
+                sql_command_sqlite += "\nUNION ALL"
+            add_union = True
+            sql_command_yaml += \
+                Template(sql_check_relationship_property_count).render(
+                         alerts_bulk_table=alerts_bulk_table,
+                         target_class=target_class,
+                         property_path=property_path,
+                         mincount=mincount,
+                         maxcount=maxcount,
+                         severity=severitycode,
+                         sqlite=False)
+            sql_command_sqlite += \
+                Template(sql_check_relationship_property_count).render(
+                         alerts_bulk_table=alerts_bulk_table,
+                         target_class=target_class,
+                         property_path=property_path,
+                         mincount=mincount,
+                         maxcount=maxcount,
+                         severity=severitycode,
+                         sqlite=True)
+        sql_command_sqlite += ";"
+        sql_command_yaml += ";"
+        statementsets.append(sql_command_yaml)
+        sqlite += sql_command_sqlite
+
+        target_class_obj = utils.class_to_obj_name(target_class)
+        target_class_obj = utils.class_to_obj_name(target_class)
+        if target_class_obj not in tables:
+            tables.append(target_class_obj)
+            views.append(target_class_obj + "-view")
+        target_class_obj = \
+            utils.class_to_obj_name(utils.strip_class(property_class))
+        if target_class_obj not in tables:
+            tables.append(target_class_obj)
+            views.append(target_class_obj + "-view")
+    # Get all NGSI-LD Properties
+    qres = g.query(sparql_get_all_properties)
+    for row in qres:
+        nodeshape = row.nodeshape.toPython()
+        target_class = utils.strip_class(row.targetclass.toPython()) \
+            if row.targetclass else None
+        property_path = row.propertypath.toPython() if row.propertypath \
+            else None
+        property_class = row.attributeclass.toPython() if row.attributeclass\
+            else None
+        mincount = row.mincount.toPython() if row.mincount else 0
+        maxcount = row.maxcount.toPython() if row.maxcount else None
+        nodekind = row.nodekind
+        min_exclusive = row.minexclusive.toPython() if row.minexclusive \
+            is not None else None
+        max_exclusive = row.maxexclusive.toPython() if row.maxexclusive \
+            else None
+        min_inclusive = row.mininclusive.toPython() if row.mininclusive \
+            is not None else None
+        max_inclusive = row.maxinclusive.toPython() if row.maxinclusive \
+            else None
+        min_length = row.minlength.toPython() if row.minlength is not None \
+            else None
+        max_length = row.maxlength.toPython() if row.maxlength is not None \
+            else None
+        pattern = row.pattern.toPython() if row.pattern is not None else None
+        if (nodekind == sh.IRI):
+            sql_command_yaml = Template(sql_check_property_iri_base).render(
+                alerts_bulk_table=alerts_bulk_table,
+                target_class=target_class,
+                property_path=property_path,
+                property_class=property_class,
+                rdf_table_name=configs.rdf_table_name,
+                sqlite=False
+            )
+            sql_command_sqlite = Template(sql_check_property_iri_base).render(
+                alerts_bulk_table=alerts_bulk_table,
+                target_class=target_class,
+                property_path=property_path,
+                property_class=property_class,
+                rdf_table_name=configs.rdf_table_name,
+                severity=severitycode,
+                sqlite=True
+            )
+            sql_command_yaml += Template(sql_check_property_nodeType).render(
+                alerts_bulk_table=alerts_bulk_table,
+                target_class=target_class,
+                property_path=property_path,
+                severity=severitycode,
+                property_nodetype='@id',
+                property_nodetype_description='an IRI',
+                sqlite=False
+            )
+            sql_command_sqlite += Template(sql_check_property_nodeType).render(
+                alerts_bulk_table=alerts_bulk_table,
+                target_class=target_class,
+                property_path=property_path,
+                severity=severitycode,
+                property_nodetype='@id',
+                property_nodetype_description='an IRI',
+                sqlite=True
+            )
+            if property_class:
+                sql_command_yaml += "\nUNION ALL"
+                sql_command_sqlite += "\nUNION ALL"
+                sql_command_yaml += \
+                    Template(sql_check_property_iri_class).render(
+                             alerts_bulk_table=alerts_bulk_table,
+                             target_class=target_class,
+                             property_path=property_path,
+                             property_class=property_class,
+                             severity=severitycode,
+                             sqlite=False)
+                sql_command_sqlite += \
+                    Template(sql_check_property_iri_class).render(
+                             alerts_bulk_table=alerts_bulk_table,
+                             target_class=target_class,
+                             property_path=property_path,
+                             property_class=property_class,
+                             severity=severitycode,
+                             sqlite=True)
+
+        elif (nodekind == sh.Literal):
+            sql_command_yaml = Template(sql_check_property_iri_base).render(
+                alerts_bulk_table=alerts_bulk_table,
+                target_class=target_class,
+                property_path=property_path,
+                property_class=property_class,
+                rdf_table_name=configs.rdf_table_name,
+                severity=severitycode,
+                sqlite=False
+            )
+            sql_command_sqlite = Template(sql_check_property_iri_base).render(
+                alerts_bulk_table=alerts_bulk_table,
+                target_class=target_class,
+                property_path=property_path,
+                property_class=property_class,
+                rdf_table_name=configs.rdf_table_name,
+                severity=severitycode,
+                sqlite=True
+            )
+            sql_command_yaml += Template(sql_check_property_nodeType).render(
+                alerts_bulk_table=alerts_bulk_table,
+                target_class=target_class,
+                property_path=property_path,
+                severity=severitycode,
+                property_nodetype='@value',
+                property_nodetype_description='a Literal',
+                sqlite=False
+            )
+            sql_command_sqlite += Template(sql_check_property_nodeType).render(
+                alerts_bulk_table=alerts_bulk_table,
+                target_class=target_class,
+                property_path=property_path,
+                severity=severitycode,
+                property_nodetype='@value',
+                property_nodetype_description='a Literal',
+                sqlite=True
+            )
+            if min_exclusive is not None:
+                sql_command_yaml += "\nUNION ALL"
+                sql_command_sqlite += "\nUNION ALL"
+                sql_command_yaml += Template(sql_check_property_minmax).render(
+                    target_class=target_class,
+                    property_path=property_path,
+                    operator='>',
+                    comparison_value=min_exclusive,
+                    severity=severitycode,
+                    minmaxname="MinExclusive",
+                    sqlite=False
+                )
+                sql_command_sqlite += \
+                    Template(sql_check_property_minmax).render(
+                             target_class=target_class,
+                             property_path=property_path,
+                             operator='>',
+                             comparison_value=min_exclusive,
+                             severity=severitycode,
+                             minmaxname="MinExclusive",
+                             sqlite=True)
+            if max_exclusive is not None:
+                sql_command_yaml += "\nUNION ALL"
+                sql_command_sqlite += "\nUNION ALL"
+                sql_command_yaml += Template(sql_check_property_minmax).render(
+                    target_class=target_class,
+                    property_path=property_path,
+                    operator='<',
+                    comparison_value=max_exclusive,
+                    severity=severitycode,
+                    minmaxname="MaxExclusive",
+                    sqlite=False
+                )
+                sql_command_sqlite += \
+                    Template(sql_check_property_minmax).render(
+                             target_class=target_class,
+                             property_path=property_path,
+                             operator='<',
+                             comparison_value=max_exclusive,
+                             severity=severitycode,
+                             minmaxname="MaxExclusive",
+                             sqlite=True)
+            if max_inclusive is not None:
+                sql_command_yaml += "\nUNION ALL"
+                sql_command_sqlite += "\nUNION ALL"
+                sql_command_yaml += Template(sql_check_property_minmax).render(
+                    target_class=target_class,
+                    property_path=property_path,
+                    operator='<=',
+                    comparison_value=max_inclusive,
+                    severity=severitycode,
+                    minmaxname="MaxInclusive",
+                    sqlite=False
+                )
+                sql_command_sqlite += \
+                    Template(sql_check_property_minmax).render(
+                             target_class=target_class,
+                             property_path=property_path,
+                             operator='<=',
+                             comparison_value=max_inclusive,
+                             severity=severitycode,
+                             minmaxname="MaxInclusive",
+                             sqlite=True)
+            if min_inclusive is not None:
+                sql_command_yaml += "\nUNION ALL"
+                sql_command_sqlite += "\nUNION ALL"
+                sql_command_yaml += Template(sql_check_property_minmax).render(
+                    target_class=target_class,
+                    property_path=property_path,
+                    operator='>=',
+                    comparison_value=min_inclusive,
+                    severity=severitycode,
+                    minmaxname="MinInclusive",
+                    sqlite=False
+                )
+                sql_command_sqlite += \
+                    Template(sql_check_property_minmax).render(
+                             target_class=target_class,
+                             property_path=property_path,
+                             operator='>=',
+                             comparison_value=min_inclusive,
+                             severity=severitycode,
+                             minmaxname="MinInclusive",
+                             sqlite=True)
+            if pattern is not None:
+                sql_command_yaml += "\nUNION ALL"
+                sql_command_sqlite += "\nUNION ALL"
+                sql_command_yaml += Template(sql_check_literal_pattern).render(
+                    property_path=property_path,
+                    pattern=pattern,
+                    severity=severitycode,
+                    validationname="Pattern",
+                    sqlite=False
+                )
+                sql_command_sqlite += \
+                    Template(sql_check_literal_pattern).render(
+                             property_path=property_path,
+                             pattern=pattern,
+                             severity=severitycode,
+                             validationname="Pattern",
+                             sqlite=True)
+
+        else:
+            print(f'WARNING: Property path {property_path} of Nodeshape \
+                  {nodeshape} is neither IRI nor Literal')
+            continue
+        if min_length is not None:
+            sql_command_yaml += "\nUNION ALL"
+            sql_command_sqlite += "\nUNION ALL"
+            sql_command_yaml += Template(sql_check_string_length).render(
+                property_path=property_path,
+                operator='<',
+                comparison_value=min_length,
+                minmaxname="MinLength",
+                severity=severitycode,
+                sqlite=False
+            )
+            sql_command_sqlite += Template(sql_check_string_length).render(
+                    property_path=property_path,
+                    operator='<',
+                    comparison_value=min_length,
+                    minmaxname="MinLength",
+                    severity=severitycode,
+                    sqlite=True
+            )
+        if max_length is not None:
+            sql_command_yaml += "\nUNION ALL"
+            sql_command_sqlite += "\nUNION ALL"
+            sql_command_yaml += Template(sql_check_string_length).render(
+                property_path=property_path,
+                operator='>',
+                comparison_value=max_length,
+                minmaxname="MaxLength",
+                severity=severitycode,
+                sqlite=False
+            )
+            sql_command_sqlite += Template(sql_check_string_length).render(
+                    property_path=property_path,
+                    operator='>',
+                    comparison_value=max_length,
+                    minmaxname="MaxLength",
+                    severity=severitycode,
+                    sqlite=True
+            )
+        sql_command_sqlite += ";"
+        sql_command_yaml += ";"
+        sqlite += sql_command_sqlite
+        statementsets.append(sql_command_yaml)
+        target_class_obj = utils.class_to_obj_name(target_class)
+        if target_class_obj not in tables:
+            tables.append(target_class_obj)
+            views.append(target_class_obj + "-view")
+    return sqlite, (statementsets, tables, views)

--- a/semantic-model/shacl2flink/requirements-dev.txt
+++ b/semantic-model/shacl2flink/requirements-dev.txt
@@ -4,3 +4,4 @@ bandit==1.7.4
 black==22.8.0
 pytest==7.1.3
 pytest-cov==4.0.0
+bunch==1.0.1

--- a/semantic-model/shacl2flink/tests/test_create_core_tables.py
+++ b/semantic-model/shacl2flink/tests/test_create_core_tables.py
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from unittest.mock import patch, call
+import create_core_tables
+
+
+@patch('create_core_tables.ruamel.yaml')
+@patch('create_core_tables.configs')
+@patch('create_core_tables.utils')
+def test_main(mock_utils, mock_configs, mock_yaml):
+    mock_configs.kafka_topic_bulk_alerts = 'bulk_alerts'
+    mock_configs.kafa_topic_listen_alerts = 'listen_alerts'
+    mock_configs.kafka_topic_ngsild_updates = 'ngsild_updates'
+    mock_configs.kafka_topic_attributes = 'attributes'
+    mock_configs.kafka_bootstrap = 'bootstrap'
+    mock_utils.create_sql_table.return_value = "sqltable"
+    mock_utils.create_yaml_table.return_value = "yamltable"
+    mock_utils.create_sql_view.return_value = "sqlview"
+    mock_utils.create_yaml_view.return_value = "yamlview"
+    mock_yaml.dump.return_value = "dump"
+
+    with patch('builtins.open') as mocked_open:
+        create_core_tables.main()
+
+        mocked_open.assert_has_calls([call("output/core.yaml", "w"),
+                                      call("output/core.sqlite", 'w')])

--- a/semantic-model/shacl2flink/tests/test_create_ngsild_models.py
+++ b/semantic-model/shacl2flink/tests/test_create_ngsild_models.py
@@ -1,0 +1,70 @@
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from unittest.mock import MagicMock, patch
+import os
+
+import create_ngsild_models
+
+
+def test_nullify():
+    field = MagicMock()
+    field.toPython.return_value = 'field'
+    result = create_ngsild_models.nullify(None)
+    assert result == 'NULL'
+    result = create_ngsild_models.nullify(field)
+    assert result == "'field'"
+
+
+@patch('create_ngsild_models.nullify')
+@patch('create_ngsild_models.Graph')
+@patch('create_ngsild_models.configs')
+@patch('create_ngsild_models.utils')
+def test_main(mock_utils, mock_configs, mock_graph, mock_nullify, tmp_path):
+    def __add__(self, other):
+        return self
+
+    mock_nullify.return_value = 'nullify'
+    mock_configs.iff_namespace = 'iff_namespace'
+    mock_configs.attributes_table_name = 'attributes'
+    mock_utils.strip_class.return_value = 'strip_class'
+    mock_graph.__add__.return_value = 'xxxx'
+    g = mock_graph.return_value.__iadd__.return_value
+    g.parse.return_value = 'xx'
+    entityId = MagicMock()
+    entityId.toPython.return_value = 'entityId'
+    name = MagicMock()
+    name.toPython.return_value = 'name'
+    name.return_value = 'name'
+    type = MagicMock()
+    type.toPython.return_value = 'type'
+    nodeType = MagicMock()
+    nodeType.toPython.return_value = 'nodeType'
+    valueType = MagicMock()
+    valueType.toPython.return_value = 'valueType'
+    hasValue = MagicMock()
+    hasValue.toPython.return_value = 'hasValue'
+    hasObject = MagicMock()
+    hasObject.toPython.return_value = 'hasObject'
+    g.query = MagicMock(side_effect=[
+        [(entityId, name, type, nodeType, valueType)],
+        [(entityId, name, type, nodeType, valueType, hasValue, hasObject)],
+        [(entityId, name, type, nodeType)]])
+
+    create_ngsild_models.main('kms/shacl.ttl', 'kms/knowledge.ttl',
+                              'kms/model.jsonld', tmp_path)
+    assert os.path.exists(os.path.join(tmp_path, 'ngsild-models.sqlite'))\
+        is True

--- a/semantic-model/shacl2flink/tests/test_create_ngsild_tables.py
+++ b/semantic-model/shacl2flink/tests/test_create_ngsild_tables.py
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from unittest.mock import patch
+from rdflib import Namespace
+from rdflib.namespace import RDF
+import create_ngsild_tables
+import os
+
+ex = Namespace("http://example.com#")
+sh = Namespace("http://www.w3.org/ns/shacl#")
+
+
+@patch('create_ngsild_tables.ruamel.yaml')
+@patch('create_ngsild_tables.Graph')
+@patch('create_ngsild_tables.configs')
+@patch('create_ngsild_tables.utils')
+def test_main(mock_utils, mock_configs, mock_graph,
+              mock_yaml, tmp_path):
+    mock_configs.kafka_topic_ngsi_prefix = 'ngsild_prefix'
+    mock_configs.kafka_bootstrap = 'bootstrap'
+    mock_utils.create_sql_table.return_value = "sqltable"
+    mock_utils.create_yaml_table.return_value = "yamltable"
+    mock_utils.create_sql_view.return_value = "sqlview"
+    mock_utils.create_yaml_view.return_value = "yamlview"
+    mock_yaml.dump.return_value = "dump"
+    g = mock_graph.return_value
+    g.__contains__.return_value = True
+    g.triples.return_value = [(ex.test, RDF.type, sh.NodeShape)]
+    g.value.return_value = [(ex.test, sh.targetClass, ex.test2)]
+    g.return_value = [(ex.test, sh.property, None)]
+
+    create_ngsild_tables.main('kms/shacl.ttl', tmp_path)
+
+    assert os.path.exists(os.path.join(tmp_path, 'ngsild.yaml')) is True
+    assert os.path.exists(os.path.join(tmp_path, 'ngsild.sqlite')) is True

--- a/semantic-model/shacl2flink/tests/test_create_rdf_table.py
+++ b/semantic-model/shacl2flink/tests/test_create_rdf_table.py
@@ -1,3 +1,19 @@
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import os.path
 from unittest.mock import patch, MagicMock
 import create_rdf_table

--- a/semantic-model/shacl2flink/tests/test_create_sql_check_from_shacl.py
+++ b/semantic-model/shacl2flink/tests/test_create_sql_check_from_shacl.py
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from unittest.mock import patch
+import os
+
+import create_sql_checks_from_shacl
+
+
+@patch('create_sql_checks_from_shacl.translate_properties')
+@patch('create_sql_checks_from_shacl.ruamel.yaml')
+@patch('create_sql_checks_from_shacl.utils')
+def test_main(mock_utils, mock_yaml, mock_translate_properties, tmp_path):
+    def __add__(self, other):
+        return self
+
+    mock_utils.create_statementset.return_value = 'create_statementsets'
+
+    mock_translate_properties.return_value = 'sqlite', ('statementsets',
+                                                        ['tables'], ['views'])
+
+    create_sql_checks_from_shacl.main('kms/shacl.ttl', 'kms/knowledge.ttl',
+                                      tmp_path)
+    assert os.path.exists(os.path.join(tmp_path, 'shacl-validation.sqlite'))\
+        is True
+    assert os.path.exists(os.path.join(tmp_path, 'shacl-validation.yaml'))\
+        is True

--- a/semantic-model/shacl2flink/tests/test_lib_shacl_properties_to_sql.py
+++ b/semantic-model/shacl2flink/tests/test_lib_shacl_properties_to_sql.py
@@ -1,0 +1,157 @@
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from unittest.mock import MagicMock, patch
+import lib.shacl_properties_to_sql
+from bunch import Bunch
+from rdflib import Namespace
+
+
+@patch('lib.shacl_properties_to_sql.Graph')
+@patch('lib.shacl_properties_to_sql.ruamel.yaml')
+@patch('lib.shacl_properties_to_sql.configs')
+@patch('lib.shacl_properties_to_sql.utils')
+def test_lib_shacl_prroperties_to_sql(mock_utils, mock_configs, mock_yaml,
+                                      mock_graph):
+    def identity(klass):
+        return klass
+    mock_utils.strip_class = identity
+    mock_utils.class_to_obj_name = identity
+    mock_configs.attributes_table_obj_name = 'attributes'
+    mock_configs.rdf_table_obj_name = 'rdf'
+    mock_configs.attributes_view_obj_name = 'attributes-view'
+    sh = Namespace("http://www.w3.org/ns/shacl#")
+    targetclass = MagicMock()
+    targetclass.toPython.return_value = 'targetclass'
+    propertypath = MagicMock()
+    propertypath.toPython.return_value = 'propertypath'
+    attributeclass = MagicMock()
+    attributeclass.toPython.return_value = 'attributeclass'
+    mincount = MagicMock()
+    mincount.toPython.return_value = 4
+    maxcount = MagicMock()
+    maxcount.toPython.return_value = None
+    g = mock_graph.return_value
+    severitycode = MagicMock()
+    severitycode.toPython.return_value = 'severitycode'
+    nodeshape = MagicMock()
+    nodeshape.toPython.return_value = 'nodeshape'
+    minexclusive = MagicMock()
+    minexclusive.toPython.return_value = 0
+    maxexclusive = MagicMock()
+    maxexclusive.toPython.return_value = 3
+    mininclusive = MagicMock()
+    mininclusive.toPython.return_value = 1
+    maxinclusive = MagicMock()
+    maxinclusive.toPython.return_value = 2
+    minlength = MagicMock()
+    minlength.toPython.return_value = None
+    maxlength = MagicMock()
+    maxlength.toPython.return_value = None
+    pattern = MagicMock()
+    pattern.toPython.return_value = 'pattern'
+    g.__iadd__.return_value.query.return_value = [Bunch()]
+    g.__iadd__.return_value.query.return_value[0].targetclass = targetclass
+    g.__iadd__.return_value.query.return_value[0].propertypath = propertypath
+    g.__iadd__.return_value.query.return_value[0].attributeclass = \
+        attributeclass
+    g.__iadd__.return_value.query.return_value[0].mincount = mincount
+    g.__iadd__.return_value.query.return_value[0].maxcount = maxcount
+    g.__iadd__.return_value.query.return_value[0].severitycode = severitycode
+    g.__iadd__.return_value.query.return_value[0].nodeshape = nodeshape
+    g.__iadd__.return_value.query.return_value[0].nodekind = sh.Literal
+    g.__iadd__.return_value.query.return_value[0].minexclusive = minexclusive
+    g.__iadd__.return_value.query.return_value[0].maxexclusive = maxexclusive
+    g.__iadd__.return_value.query.return_value[0].mininclusive = mininclusive
+    g.__iadd__.return_value.query.return_value[0].maxinclusive = maxinclusive
+    g.__iadd__.return_value.query.return_value[0].minlength = minlength
+    g.__iadd__.return_value.query.return_value[0].maxlength = maxlength
+    g.__iadd__.return_value.query.return_value[0].pattern = pattern
+    sqlite, (statementsets, tables, views) = \
+        lib.shacl_properties_to_sql.translate('kms/shacl.ttl',
+                                              'kms/knowledge.ttl')
+
+    assert tables == ['alerts-bulk', 'attributes', 'rdf', 'targetclass',
+                      'attributeclass']
+    assert views == ['attributes-view', 'targetclass-view',
+                     'attributeclass-view']
+    assert len(statementsets) == 2
+    lower_sqlite = sqlite.lower()
+    assert lower_sqlite.count('select') == 10
+    assert lower_sqlite.count(' < 4') == 2
+    assert lower_sqlite.count(' < 3') == 3
+    assert lower_sqlite.count(' <= 2') == 3
+    assert lower_sqlite.count(' > 0') == 3
+    assert lower_sqlite.count(' >= 1') == 3
+    assert lower_sqlite.count("regexp 'pattern'") == 2
+
+    targetclass = MagicMock()
+    targetclass.toPython.return_value = 'targetclass'
+    propertypath = MagicMock()
+    propertypath.toPython.return_value = 'propertypath'
+    attributeclass = MagicMock()
+    attributeclass.toPython.return_value = 'attributeclass'
+    mincount = MagicMock()
+    mincount.toPython.return_value = 0
+    maxcount = MagicMock()
+    maxcount.toPython.return_value = 3
+    g = mock_graph.return_value
+    severitycode = MagicMock()
+    severitycode.toPython.return_value = 'severitycode'
+    nodeshape = MagicMock()
+    nodeshape.toPython.return_value = 'nodeshape'
+    minexclusive = MagicMock()
+    minexclusive.toPython.return_value = None
+    maxexclusive = MagicMock()
+    maxexclusive.toPython.return_value = None
+    mininclusive = MagicMock()
+    mininclusive.toPython.return_value = None
+    maxinclusive = MagicMock()
+    maxinclusive.toPython.return_value = None
+    minlength = MagicMock()
+    minlength.toPython.return_value = 3
+    maxlength = MagicMock()
+    maxlength.toPython.return_value = 10
+    g.__iadd__.return_value.query.return_value = [Bunch()]
+    g.__iadd__.return_value.query.return_value[0].targetclass = targetclass
+    g.__iadd__.return_value.query.return_value[0].propertypath = propertypath
+    g.__iadd__.return_value.query.return_value[0].attributeclass = \
+        attributeclass
+    g.__iadd__.return_value.query.return_value[0].mincount = mincount
+    g.__iadd__.return_value.query.return_value[0].maxcount = maxcount
+    g.__iadd__.return_value.query.return_value[0].severitycode = severitycode
+    g.__iadd__.return_value.query.return_value[0].nodeshape = nodeshape
+    g.__iadd__.return_value.query.return_value[0].nodekind = sh.IRI
+    g.__iadd__.return_value.query.return_value[0].minexclusive = minexclusive
+    g.__iadd__.return_value.query.return_value[0].maxexclusive = maxexclusive
+    g.__iadd__.return_value.query.return_value[0].mininclusive = mininclusive
+    g.__iadd__.return_value.query.return_value[0].maxinclusive = maxinclusive
+    g.__iadd__.return_value.query.return_value[0].minlength = minlength
+    g.__iadd__.return_value.query.return_value[0].maxlength = maxlength
+    g.__iadd__.return_value.query.return_value[0].pattern = None
+    sqlite, (statementsets, tables, views) = \
+        lib.shacl_properties_to_sql.translate('kms/shacl.ttl',
+                                              'kms/knowledge.ttl')
+
+    assert tables == ['alerts-bulk', 'attributes', 'rdf', 'targetclass',
+                      'attributeclass']
+    assert views == ['attributes-view', 'targetclass-view',
+                     'attributeclass-view']
+    assert len(statementsets) == 2
+    lower_sqlite = sqlite.lower()
+    assert lower_sqlite.count('select') == 8
+    assert lower_sqlite.count('> 10') == 3
+    assert lower_sqlite.count('< 3') == 3

--- a/semantic-model/shacl2flink/tests/test_utils.py
+++ b/semantic-model/shacl2flink/tests/test_utils.py
@@ -1,3 +1,19 @@
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import os.path
 from unittest.mock import patch
 import lib.utils as utils

--- a/test/bats/test-horizontal-platform/horizontal-platform-up-and-running-rest.bats
+++ b/test/bats/test-horizontal-platform/horizontal-platform-up-and-running-rest.bats
@@ -55,4 +55,6 @@ DETIK_DEBUG="true"
 
 @test "verify that the core services are up" {
     run try "at most 30 times every 60s to find 1 bsqls named 'core-services' with 'status.state' being 'RUNNING'"
+    [ "$status" -eq 0 ]
+
 }


### PR DESCRIPTION
- Core tables contain alert, NGSILD updates and attributes
- NGSILD-tables are entities generated from SHACL spec
- Extented linting, unit-test and SQLite tests