### PR TITLE
Separate minio from S3 configuration and use S3 for database backup.

### DIFF
--- a/helm/charts/flink/templates/flink-configuration-configmap.yaml
+++ b/helm/charts/flink/templates/flink-configuration-configmap.yaml
@@ -17,13 +17,13 @@ data:
     jobmanager.memory.process.size: 1600m
     taskmanager.memory.process.size: 1728m
     parallelism.default: {{ .Values.flink.defaultParalellism }}
-    s3.endpoint: {{ .Values.minio.url }}
+    s3.endpoint: {{ printf "%s://%s" .Values.s3.protocol .Values.s3.endpoint }}
     s3.path.style.access: true
-    s3.access-key: {{ .Values.minio.userAccessKey }}
+    s3.access-key: {{ .Values.s3.userAccessKey }}
     {{ if $secret }}
     s3.secret-key: {{ $secret.data.CONSOLE_SECRET_KEY | b64dec }}
     {{ else }}
-    s3.secret-key: {{ .Values.minio.userSecretKey }}
+    s3.secret-key: {{ .Values.s3.userSecretKey }}
     {{ end }}
     state.checkpoints.dir: s3://{{ .Values.flink.bucket }}/{{ .Values.flink.checkpointDir }}
     state.savepoints.dir: s3://{{ .Values.flink.bucket }}/{{ .Values.flink.savepointDir }}

--- a/helm/charts/flink/templates/jobmanager-session-deployment-ha.yaml
+++ b/helm/charts/flink/templates/jobmanager-session-deployment-ha.yaml
@@ -21,16 +21,16 @@ spec:
       initContainers:
       - name: wait-for-minio
         image: busybox:1.28
-        command: ['sh', '-c', "until wget -S {{ .Values.minio.url }}{{ .Values.minio.healthPath }} 2>&1 | awk '/^  HTTP/{print $2}' | grep 200; do echo waiting for minio; sleep 1; done"]
+        command: ['sh', '-c', "until wget -S {{ printf "%s://%s" .Values.s3.protocol .Values.s3.endpoint }}{{ .Values.minio.healthPath }} 2>&1 | awk '/^  HTTP/{print $2}' | grep 200; do echo waiting for minio; sleep 1; done"]
       - name: create-bucket
         image: {{ .Values.minio.mcImage }}
         env:
         - name: MC_HOST_iff
-          {{ if $secret}}
-          value: {{ printf "http://%s:%s@%s" .Values.minio.userAccessKey ($secret.data.CONSOLE_SECRET_KEY | b64dec) .Values.minio.endpoint }}
-          {{ else }}
-          value: {{ printf "http://novalidkey" }}
-          {{ end }}
+          {{- if $secret }}
+          value: {{ printf "%s://%s:%s@%s" .Values.s3.protocol .Values.s3.userAccessKey ($secret.data.CONSOLE_SECRET_KEY | b64dec) .Values.s3.endpoint }}
+          {{- else }}
+          value: {{ printf "%s://%s:%s@%s" .Values.s3.protocol .Values.s3.userAccessKey .Values.s3.userSecretKey .Values.s3.endpoint }}
+          {{- end }}
         command: ["/bin/bash", "-c", "mc mb -p iff/{{ .Values.flink.bucket }}"]
       containers:
       - name: jobmanager

--- a/helm/charts/flink/templates/taskmanager-session-deployment.yaml
+++ b/helm/charts/flink/templates/taskmanager-session-deployment.yaml
@@ -18,7 +18,7 @@ spec:
       initContainers:
       - name: wait-for-minio
         image: busybox:1.28
-        command: ['sh', '-c', "until wget -S {{ .Values.minio.url }}{{ .Values.minio.healthPath }} 2>&1 | awk '/^  HTTP/{print $2}' | grep 200; do echo waiting for minio; sleep 1; done"]
+        command: ['sh', '-c', "until wget -S {{ printf "%s://%s" .Values.s3.protocol .Values.s3.endpoint }}{{ .Values.minio.healthPath }} 2>&1 | awk '/^  HTTP/{print $2}' | grep 200; do echo waiting for minio; sleep 1; done"]
       containers:
       - name: taskmanager
         image: apache/flink:{{ .Values.flink.imageTag }}

--- a/helm/charts/minio/templates/user.yaml
+++ b/helm/charts/minio/templates/user.yaml
@@ -1,11 +1,11 @@
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace "minio-user") -}}
 apiVersion: v1
 data:
-  CONSOLE_ACCESS_KEY: {{ .Values.minio.userAccessKey | toString | b64enc }}
+  CONSOLE_ACCESS_KEY: {{ .Values.s3.userAccessKey | toString | b64enc }}
   {{- if $secret }}
   CONSOLE_SECRET_KEY: {{ $secret.data.CONSOLE_SECRET_KEY }}
   {{- else }}
-  CONSOLE_SECRET_KEY: {{ .Values.minio.userSecretKey | toString | b64enc }}
+  CONSOLE_SECRET_KEY: {{ .Values.s3.userSecretKey | toString | b64enc }}
   {{- end }}
 kind: Secret
 metadata:

--- a/helm/charts/postgres/templates/buildBackupBucket.yaml
+++ b/helm/charts/postgres/templates/buildBackupBucket.yaml
@@ -1,0 +1,26 @@
+---
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace "minio-user") -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-bucket
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: wait-for-minio
+        image: busybox:1.28
+        command: ['sh', '-c', "until wget -S {{ printf "%s://%s" .Values.s3.protocol .Values.s3.endpoint }}{{ .Values.minio.healthPath }} 2>&1 | awk '/^  HTTP/{print $2}' | grep 200; do echo waiting for minio; sleep 1; done"]
+      containers:
+      - name: create-bucket
+        image: {{ .Values.minio.mcImage }}
+        env:
+        - name: MC_HOST_iff
+          {{ if $secret}}
+          value: {{ printf "%s://%s:%s@%s" .Values.s3.protocol .Values.s3.userAccessKey ($secret.data.CONSOLE_SECRET_KEY | b64dec) .Values.s3.endpoint }}
+          {{ else }}
+          value: {{ printf "%s://%s:%s@%s" .Values.s3.protocol .Values.s3.userAccessKey .Values.s3.userSecretKey .Values.s3.endpoint }}
+          {{ end }}
+        command: ["/bin/bash", "-c", "echo $MC_HOST_IFF; mc mb -p iff/{{ .Values.db.backupBucket }}"]
+      restartPolicy: Never
+  backoffLimit: 4

--- a/helm/charts/postgres/templates/dbsecret.yaml
+++ b/helm/charts/postgres/templates/dbsecret.yaml
@@ -1,8 +1,8 @@
-#
+---
 {{- $name := printf "%s.%s.%s" .Values.db.dbUser .Values.clusterSvcName .Values.db.secretPostfix }}
 {{- $shortname := printf "%s.%s.credentials" .Values.db.dbUser .Values.clusterSvcName }}
 {{- $secret := (lookup "v1" "Secret" .Release.Namespace $name) }}
----
+
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/charts/postgres/templates/minimal-postgres-manifest.yaml
+++ b/helm/charts/postgres/templates/minimal-postgres-manifest.yaml
@@ -1,9 +1,36 @@
+---
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace "minio-user") -}}
 apiVersion: "acid.zalan.do/v1"
 kind: postgresql
 metadata:
   name: {{ .Values.clusterSvcName }}
   namespace: {{ .Release.Namespace }}
 spec:
+  env:
+  - name: AWS_ACCESS_KEY_ID
+    value: {{ .Values.s3.userAccessKey }}
+  - name: AWS_ENDPOINT
+    value: {{ printf "%s://%s" .Values.s3.protocol .Values.s3.endpoint }}
+  - name: AWS_SECRET_ACCESS_KEY
+    {{- if $secret }}
+    value: {{ $secret.data.CONSOLE_SECRET_KEY | b64dec }}
+    {{- else }}
+    value: {{ .Values.s3.userSecretKey }}
+    {{- end }}
+  - name: USE_WALG_BACKUP
+    value: "true"
+  - name: USE_WALG_RESTORE
+    value: "ture"
+  - name: WALG_S3_PREFIX
+    value: s3://{{ .Values.db.backupBucket }}
+  - name: BACKUP_NUM_RETAIN
+    value: {{ .Values.db.backupNum | quote }}
+  - name: BACKUP_SCHEDULE
+    value: {{ .Values.db.backupSchedule | quote }}
+  {{- if .Values.minio.enabled }}
+  - name: AWS_S3_FORCE_PATH_STYLE
+    value: "true"
+  {{- end }}
   teamId: {{ .Values.db.teamId }}
   volume:
     size: {{ .Values.db.pvSize }}
@@ -16,3 +43,32 @@ spec:
     version: "12"
     parameters:
       wal_level: logical
+  {{- if .Values.db.cloneEnabled }}
+  clone:
+    cluster: {{ .Values.clusterSvcName | quote }}
+    timestamp: {{ .Values.db.cloneTimeStamp }}
+    s3_wal_path: s3://{{ .Values.db.backupBucket }}
+    s3_endpoint: {{ printf "%s://%s" .Values.s3.protocol .Values.s3.endpoint }}
+    {{- if $secret }}
+    s3_secret_access_key: {{ $secret.data.CONSOLE_SECRET_KEY | b64dec }}
+    {{- else }}
+    s3_secret_access_key: {{ .Values.s3.userSecretKey }}
+    {{- end }}
+    s3_access_key_id: {{ .Values.s3.userAccessKey }}
+  {{- end }}
+  {{- if .Values.minio.enabled }}
+  initContainers:
+      - name: wait-for-minio
+        image: busybox:1.28
+        command: ['sh', '-c', "until wget -S {{ printf "%s://%s" .Values.s3.protocol .Values.s3.endpoint }}{{ .Values.minio.healthPath }} 2>&1 | awk '/^  HTTP/{print $2}' | grep 200; do echo waiting for minio; sleep 1; done"]
+      - name: test-bucket
+        image: {{ .Values.minio.mcImage }}
+        env:
+        - name: MC_HOST_iff
+          {{- if $secret }}
+          value: {{ printf "%s://%s:%s@%s" .Values.s3.protocol .Values.s3.userAccessKey ($secret.data.CONSOLE_SECRET_KEY | b64dec) .Values.s3.endpoint }}
+          {{- else }}
+          value: {{ printf "%s://%s:%s@%s" .Values.s3.protocol .Values.s3.userAccessKey .Values.s3.userSecretKey .Values.s3.endpoint }}
+          {{- end }}
+        command: ["/bin/bash", "-c", "echo test; until mc ls iff/{{ .Values.db.backupBucket }}; do sleep 1; done"]
+    {{- end }}

--- a/helm/environment/default.yaml
+++ b/helm/environment/default.yaml
@@ -12,7 +12,10 @@ keycloak:
 
 db:
   pvSize: 1Gi
-  podInstances: 2
+  podInstances: 1
+  backupBucket: db-backup
+  backupNum: "5"
+  cloneEnabled: false
 
 scorpio:
   externalHostname: ngsild.local
@@ -50,8 +53,8 @@ flink:
   defaultParalellism: 1
 
 minio:
+  enabled: true
   storageSize: 10G
-
 
 kafka:
   storage:

--- a/helm/environment/production.yaml
+++ b/helm/environment/production.yaml
@@ -14,6 +14,9 @@ keycloak:
 db:
   pvSize: 1Gi
   podInstances: 2
+  backupBucket: db-backup
+  backupNum: "5"
+  cloneEnabled: false
 
 scorpio:
   externalHostname: scorpio.test.streammyiot.com

--- a/helm/helmfile.yaml
+++ b/helm/helmfile.yaml
@@ -17,6 +17,8 @@ releases:
     app: postgres
   chart: ./charts/postgres
   namespace: {{ .Values.namespace }}
+  needs:
+  - minio
   values:
   - values.yaml.gotmpl
 - name: kafka

--- a/helm/install_operators.sh
+++ b/helm/install_operators.sh
@@ -95,11 +95,11 @@ printf -- "------------------------\033[0m\n"
 kubectl -n ${NAMESPACE} apply -f ../FlinkSqlServicesOperator/kubernetes/crd.yml
 
 printf "\n"
-printf "\033[1mInstalling Postgres-operator v1.7.1\n"
+printf "\033[1mInstalling Postgres-operator v1.8.2\n"
 printf -- "------------------------\033[0m\n"
 git clone https://github.com/zalando/postgres-operator.git
 cd postgres-operator
-git checkout v1.7.1
+git checkout v1.8.2
 helm -n iff install postgres-operator ./charts/postgres-operator
 
 printf -- "\033[1mOperators installed successfully.\033[0m\n"

--- a/helm/uninstall_operators.sh
+++ b/helm/uninstall_operators.sh
@@ -3,10 +3,6 @@ NAMESPACE=iff
 
 printf "\n"
 printf "\033[1mUninstalling operator subscriptions\n"
-
-printf "\n"
-printf "\033[1mUninstalling Zalando postgres-operator\n"
-printf -- "------------------------\033[0m "
 kubectl -n {NAMESPACE} delete subscription/keycloak-operator subscription/strimzi-operator operatorgroup/mygroup catalogsource/olm
 kubectl -n operators delete subscription/cert-manager
 
@@ -31,7 +27,7 @@ printf "\033[1mUninstalling Postgres-operator\n"
 printf -- "------------------------\033[0m\n"
 git clone https://github.com/zalando/postgres-operator.git
 cd postgres-operator
-git checkout v1.7.1
+git checkout v1.8.2
 helm -n iff delete postgres-operator ./charts/postgres-operator
 
 

--- a/helm/values.yaml.gotmpl
+++ b/helm/values.yaml.gotmpl
@@ -22,6 +22,12 @@ db:
   dbUser: {{ .StateValues.db.dbUser }}
   scorpioDb: ngb
   secretPostfix: credentials.postgresql.acid.zalan.do
+  backupBucket: {{ .StateValues.db.backupBucket }}
+  backupNum: {{ .StateValues.db.backupNum }}
+  backupSchedule: {{- if hasKey .Values.db "backupSchedule" }}{{ .Values.db.backupSchedule }}{{- else }} '00 00 * * *' {{- end }}
+  cloneEnabled: {{- if hasKey .Values.db "cloneEnabled" }} {{ .Values.db.cloneEnabled }} {{- else }} false {{- end }}
+  cloneTimeStamp: {{- if hasKey .Values.db "timeStamp" }}{{ .Values.db.timeStamp }}{{- else }} '{{ now | date "2006-01-02T15:04:05+00:00" }}' {{ end }}
+
 
 scorpio:
   tag: 3.0.0-SNAPSHOT
@@ -72,14 +78,20 @@ flink:
   ngsildUpdateWindow: '0.001'
 
 minio:
-  url: http://minio
-  endpoint: minio
-  adminAccessKey: console
-  userAccessKey: minio
-  userSecretKey: {{ .StateValues.minioUserSecretKey }}
-  storageSize: 10G
+  enabled: {{ .StateValues.minio.enabled }}
+  storageSize: {{ .StateValues.minio.storageSize }}
   healthPath: /minio/health/live
+  adminAccessKey: console
   mcImage: minio/mc:RELEASE.2022-02-07T09-25-34Z
+
+s3:
+  {{- $s3 := dict "" }}
+  {{- $protocol := "http" }}
+  {{- if (hasKey .StateValues "s3") }}{{- $s3 := .StateValues.s3 }}{{- end }}
+  protocol: {{- if (hasKey $s3 "protocol") -}}{{- quote $s3.protocol }}{{- else }} http {{- end }}
+  endpoint: {{ if (hasKey $s3 "endpoint") }}{{- quote $s3.endpoint }}{{- else }} minio {{- end }}
+  userAccessKey: {{- if (hasKey $s3 "userAccessKey") }}{{- quote $s3.userAccessKey }}{{- else }} minio {{- end }}
+  userSecretKey: {{- if (hasKey $s3 "userSecretKey") }}{{- quote $s3.userSecretKey }}{{- else }} "{{ .StateValues.minioUserSecretKey }}" {{- end }}
 
 alerta:
   externalHostname: {{ .StateValues.alerta.externalHostname }}

--- a/test/bats/test-horizontal-platform/horizontal-platform-up-and-running-first.bats
+++ b/test/bats/test-horizontal-platform/horizontal-platform-up-and-running-first.bats
@@ -31,10 +31,10 @@ DETIK_DEBUG="true"
 
 }
 @test "verify that postgres is up and running" {
-    run try "at most 30 times every 60s to find 2 pod named 'acid-cluster' with 'status.containerStatuses[0].ready' being 'true'"
+    run try "at most 30 times every 60s to find 1 pod named 'acid-cluster' with 'status.containerStatuses[0].ready' being 'true'"
     [ "$status" -eq 0 ]
 
-    run verify "there are 2 pods named '^acid-cluster'"
+    run verify "there is 1 pod named '^acid-cluster'"
     [ "$status" -eq 0 ]
 
 }


### PR DESCRIPTION
* Make postgresoperator clonable from S3
* Disable clone mode as default
* Move to Zalando Posrgres operator v1.8.2 to allow cluster-based S3 configuration
* For default/test setup, use only one database container (instead of 2)
* Automatic Bucket creation for database backup jobs