### PR TITLE
Fix velero issue causing nightlies to fail

### DIFF
--- a/helm/charts/velero/Chart.yaml
+++ b/helm/charts/velero/Chart.yaml
@@ -25,4 +25,4 @@ appVersion: "0.1.0"
 dependencies:
 - name: velero
   version: "3.1.4"
-  repository: "https://vmware-tanzu.github.io/helm-charts"
+  repository: "@vmware-tanzu"

--- a/test/install-local-platform.sh
+++ b/test/install-local-platform.sh
@@ -43,6 +43,7 @@ echo Install third part
 ( cd ./bats && bats test-horizontal-platform/horizontal-platform-up-and-running-third.bats )
 
 echo Install the rest
+( cd ../helm && helm repo add vmware-tanzu https://vmware-tanzu.github.io/helm-charts )
 ( cd ../helm && ./helmfile apply --set "mainRepo=k3d-iff.localhost:12345" )
 ( cd ./bats && bats test-horizontal-platform/horizontal-platform-up-and-running-velero.bats )
 


### PR DESCRIPTION
Helm fails to find the chart by name. The issue is fixed by adding the repository explicitly with helm add before the helmfile command is ran.

Closes: Open-IoT-Service-Platform/platform-launcher#716