### PR TITLE
Fix error at prepare platform script by updating Maven version

### DIFF
--- a/test/prepare-platform.sh
+++ b/test/prepare-platform.sh
@@ -87,7 +87,7 @@ sudo apt install openjdk-17-jdk openjdk-17-jre
 
 echo Installing maven
 echo ----------------------
-wget https://dlcdn.apache.org/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz
+wget https://archive.apache.org/dist/maven/maven-3/3.8.7/binaries/apache-maven-3.8.7-bin.tar.gz
 tar -xzf apache-maven-3.8.7-bin.tar.gz
 sudo mv apache-maven-3.8.7 /opt/
 rm apache-maven-3.8.7-bin.tar.gz


### PR DESCRIPTION
With the update of most actual Maven 3.8.x release, the link must be updated.

Closes: #378 