### PR TITLE
Remove old scorpio naming scheme from workflow files

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -32,13 +32,6 @@ jobs:
             docker tag ${image} ${newimage};
             docker push ${newimage};
           done
-          # Rename and push passed "k3d-iff.localhost:12345" scorpio related images
-          images=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep "k3d-iff.localhost:12345/digitaltwin" | grep -v :0.1 | grep -v "<none>")
-          for image in ${images}; do
-            newimage=$(echo ${image} | sed -r "s/k3d-iff.localhost:12345/${DOCKER_PREFIX}/g");
-            docker tag ${image} ${newimage};
-            docker push ${newimage};
-          done
 
 
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,9 +32,4 @@ jobs:
             docker tag ${image} ${newimage};
             docker push ${newimage};
           done
-          # Tag and push scorpio-aio image
-          image=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep "k3d-iff.localhost:12345/digitaltwin:scorpio-all-in-one")
-          newimage="${DOCKER_PREFIX}/digitaltwin:${TARGET_DOCKER_TAG}"
-          docker tag ${image} ${newimage}
-          docker push ${newimage}
 


### PR DESCRIPTION
- Scorpio images do not create an edge case anymore, it is compatible with the regular naming scheme of IFF organization

closes #385