### PR TITLE
Run docker system prune every night to ensure disk availability

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -32,6 +32,7 @@ jobs:
             docker tag ${image} ${newimage};
             docker push ${newimage};
           done
+          docker system prune -a -f
 
 
 


### PR DESCRIPTION
Because of how docker works, if not cleaned up regularly the disk gets swelled up, ultimately causing failures during build and deployment phases because of the lack of space in the disk. Nightly clean-ups will fix this at the expense of the first workflow run of the day being relatively slower since the cached images and layers have been deleted in the night.