### PR TITLE
Enable configurable Kafka topics for Scorpio

### DIFF
--- a/helm/charts/kafka/templates/KafkaCluster.yaml
+++ b/helm/charts/kafka/templates/KafkaCluster.yaml
@@ -29,6 +29,7 @@ spec:
       transaction.state.log.min.isr: 1
       log.message.format.version: "3.3"
       inter.broker.protocol.version: "3.3"
+      auto.create.topics.enable: true
     storage:
       type: jbod
       volumes:

--- a/helm/charts/scorpio/templates/scorpio-aaio-topics.yaml
+++ b/helm/charts/scorpio/templates/scorpio-aaio-topics.yaml
@@ -1,0 +1,110 @@
+{{- if .Values.aaio.enabled }}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: {{.Values.kafka_topic_vars.ENTITY_TOPIC}}
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: {{.Values.kafka_topic_vars.retention}}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: {{.Values.kafka_topic_vars.REGISTRY_TOPIC}}
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: {{.Values.kafka_topic_vars.retention}}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: {{.Values.kafka_topic_vars.TEMPORAL_TOPIC}}
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: {{.Values.kafka_topic_vars.retention}}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: {{.Values.kafka_topic_vars.INTERNAL_NOTIFY_TOPIC}}
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: {{.Values.kafka_topic_vars.retention}}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: {{.Values.kafka_topic_vars.INTERNAL_REGISTRYSUB_TOPIC}}
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: {{.Values.kafka_topic_vars.retention}}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: {{.Values.kafka_topic_vars.SUB_ALIVE_TOPIC}}
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: {{.Values.kafka_topic_vars.retention}}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: {{.Values.kafka_topic_vars.SUB_SYNC_TOPIC}}
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: {{.Values.kafka_topic_vars.retention}}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: {{.Values.kafka_topic_vars.REGISTRYSUB_SYNC_TOPIC}}
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: {{.Values.kafka_topic_vars.retention}}
+---
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaTopic
+metadata:
+  name: {{.Values.kafka_topic_vars.REGISTRYSUB_ALIVE_TOPIC}}
+  labels:
+    strimzi.io/cluster: my-cluster
+spec:
+  partitions: 1
+  replicas: 1
+  config:
+    retention.ms: {{.Values.kafka_topic_vars.retention}}
+{{- end }}

--- a/helm/charts/scorpio/templates/scorpio-aaio.yaml
+++ b/helm/charts/scorpio/templates/scorpio-aaio.yaml
@@ -54,6 +54,10 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
           {{- end }}
+          {{- range $key, $val := .Values.kafka_topic_vars }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+          {{- end }}
           ports:
             - containerPort: 9090
               protocol: TCP

--- a/helm/charts/scorpio/values.yaml
+++ b/helm/charts/scorpio/values.yaml
@@ -32,6 +32,19 @@ kafka_vars:
   KAFKA_LOG_RETENTION_MS: 10000
   KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS: 5000
 
+## kafka topic names for topics used by scorpio
+kafka_topic_vars:
+  ENTITY_TOPIC: scorpio.entity
+  REGISTRY_TOPIC: scorpio.registry
+  TEMPORAL_TOPIC: scorpio.temporal
+  INTERNAL_NOTIFY_TOPIC: scorpio.inotify
+  INTERNAL_REGISTRYSUB_TOPIC: scorpio.regsub
+  SUB_ALIVE_TOPIC: scorpio.sub.alive
+  SUB_SYNC_TOPIC: scorpio.sub.sync
+  REGISTRYSUB_ALIVE_TOPIC: scorpio.regsub.alive
+  REGISTRYSUB_SYNC_TOPIC: scorpio.regsub.sync
+  retention: 3600000
+
 ## credentials for private docker repo
 imageCredentials:
   name: regcred

--- a/test/build-local-platform.sh
+++ b/test/build-local-platform.sh
@@ -25,7 +25,7 @@ echo Build Scorpio containers
 
 if [[ $TEST -eq "true" ]]; then
     ( cd ../.. && git clone https://github.com/IndustryFusion/ScorpioBroker.git)
-    ( cd ../../ScorpioBroker && git checkout 2a3b3c3 ) # Checking out specific commit for CI purposes
+    ( cd ../../ScorpioBroker && git checkout 10a93c8 ) # Checking out specific commit for CI purposes
     ( cd ../../ScorpioBroker && source /etc/profile.d/maven.sh && mvn clean package -DskipTests -Ddocker -Ddocker-tag=$VERSION -Dkafka -Pkafka -Dquarkus.profile=kafka -Dos=java)
 else
     ( cd ../.. && git clone https://github.com/IndustryFusion/ScorpioBroker.git )


### PR DESCRIPTION
With this commit Scorpio's kafka topics' name and retention time are configurable by parameters. By changing the parameters in helm/charts/scorpio/values.yaml under kafka_topic_vars, you can configure topic names and retention (in milliseconds). In addition an option to configure the automatic topic creation of the kafka cluster is added, enabled for stability reasons.