### PR TITLE
Fix postgres-operator repo checkout problem

### DIFF
--- a/helm/install_operators.sh
+++ b/helm/install_operators.sh
@@ -90,6 +90,7 @@ printf "\033[1mInstalling Postgres-operator v1.9.0\n"
 printf -- "------------------------\033[0m\n"
 git clone https://github.com/zalando/postgres-operator.git
 cd postgres-operator
+git fetch
 git checkout v1.9.0
 helm -n iff install postgres-operator ./charts/postgres-operator
 

--- a/helm/uninstall_operators.sh
+++ b/helm/uninstall_operators.sh
@@ -27,7 +27,8 @@ printf "\033[1mUninstalling Postgres-operator\n"
 printf -- "------------------------\033[0m\n"
 git clone https://github.com/zalando/postgres-operator.git
 cd postgres-operator
-git checkout v1.8.2
+git fetch
+git checkout v1.9.0
 helm -n iff delete postgres-operator ./charts/postgres-operator
 
 


### PR DESCRIPTION
When git fetch not run before git checkout on an environment that had already a folder named postgres-operator, then the cloning fails and checking out a recent branch is not possible as the local repo is outdated. In addition, uninstall operators try to uninstall the previous version of postgres-operator, that is also fixed.