### PR TITLE
Removed docker prefix usage from Nightly

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -22,7 +22,6 @@ jobs:
     env:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      DOCKER_PREFIX: ${{ secrets.DOCKER_PREFIX }}
       SELF_HOSTED_RUNNER: true
     steps:
       - uses: actions/checkout@v4
@@ -37,14 +36,10 @@ jobs:
           # Tag and push passed "k3d-iff.localhost:12345:<image>:${DOCKER_TAG}" images as latest
           images=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep k3d-iff | grep ${DOCKER_TAG} )
           for image in ${images}; do
-            newimage=$(echo $image | sed -r "s/:${DOCKER_TAG}/:latest/g" | sed -r "s/k3d-iff.localhost:12345/${DOCKER_PREFIX}/g");
+            newimage=$(echo $image | sed -r "s/:${DOCKER_TAG}/:latest/g" | sed -r "s/k3d-iff.localhost:12345\///g");
             docker tag ${image} ${newimage};
             docker push ${newimage};
-            newimage=$(echo $image | sed -r "s/:${DOCKER_TAG}/:${TARGET_DOCKER_TAG}/g" | sed -r "s/k3d-iff.localhost:12345/${DOCKER_PREFIX}/g");
+            newimage=$(echo $image | sed -r "s/:${DOCKER_TAG}/:${TARGET_DOCKER_TAG}/g" | sed -r "s/k3d-iff.localhost:12345\///g");
             docker tag ${image} ${newimage};
             docker push ${newimage};
           done
-
-
-
-


### PR DESCRIPTION
Hence ibn40 is added already as part of build (e.g., k3d-iff.localhost:12345/ibn40/scorpio-all-in-one-runner:v0.6.0-beta.1), the sed command fails to create correct name for ibn40 docker push for nightly.

Eg: DOCKER_PREFIX=ibn40

**Current:**

`newimage=$(echo k3d-iff.localhost:12345/ibn40/scorpio-all-in-one-runner:v0.6.0-beta.1 | sed -r "s/:${DOCKER_TAG}/:latest/g" | sed -r "s/k3d-iff.localhost:12345/$(DOCKER_PREFIX)/g");`

Output: ibn40/ibn40/scorpio-all-in-one-runner:latest  - Fails to push because of two ibn40.

**Proposed Change**

`newimage=$(echo k3d-iff.localhost:12345/ibn40/scorpio-all-in-one-runner:v0.6.0-beta.1 | sed -r "s/:${DOCKER_TAG}/:latest/g" | sed -r "s/k3d-iff.localhost:12345\///g");`

Output: ibn40/scorpio-all-in-one-runner:latest  -  Push must work.

