### PR TITLE
Upgrade Scorpio to v5.0.3

### DIFF
--- a/test/bats/test-scorpio/test-scorpio-mqtt-subscriptions.bats
+++ b/test/bats/test-scorpio/test-scorpio-mqtt-subscriptions.bats
@@ -83,7 +83,8 @@ cat << EOF > ${CUTTER_MERGE}
   "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
   "https://industry-fusion.com/types/v0.9/state": {
     "type": "Property",
-    "value": "OFF"
+    "value": "OFF",
+    "datasetId": "urn:cutter:test1"
   }
 }
 EOF

--- a/test/bats/test-scorpio/test-scorpio-mqtt-subscriptions.bats
+++ b/test/bats/test-scorpio/test-scorpio-mqtt-subscriptions.bats
@@ -150,7 +150,8 @@ compare_mqtt_sub_update() {
         type,
         "https://industry-fusion.com/types/v0.9/state": {
             type: ."https://industry-fusion.com/types/v0.9/state".type,
-            value: ."https://industry-fusion.com/types/v0.9/state".value
+            value: ."https://industry-fusion.com/types/v0.9/state".value,
+            datasetId: ."https://industry-fusion.com/types/v0.9/state".datasetId
         }
     }' "$temp_file") - >&3
 {
@@ -158,7 +159,8 @@ compare_mqtt_sub_update() {
   "type": "https://industry-fusion.com/types/v0.9/plasmacutter_test",
   "https://industry-fusion.com/types/v0.9/state": {
     "type": "Property",
-    "value": "OFF"
+    "value": "OFF",
+    "datasetId": "urn:cutter:test1"
   }
 }
 EOF

--- a/test/build-local-platform.sh
+++ b/test/build-local-platform.sh
@@ -27,7 +27,7 @@ echo Build Scorpio containers
 
 if [[ $TEST -eq "true" ]]; then
     ( cd ../.. && git clone https://github.com/IndustryFusion/ScorpioBroker.git)
-    ( cd ../../ScorpioBroker && git checkout a49ce4e ) # Checking out specific commit for CI purposes
+    ( cd ../../ScorpioBroker && git checkout 64afd0b ) # Checking out specific commit for CI purposes
     ( cd ../../ScorpioBroker && source /etc/profile.d/maven.sh && mvn clean package -DskipTests -Ddocker -Ddocker-tag=$DOCKER_TAG -Dkafka -Pkafka -Dquarkus.profile=kafka)
 else
     ( cd ../.. && git clone https://github.com/IndustryFusion/ScorpioBroker.git )


### PR DESCRIPTION
Scorpio v5.0.3 fixes the issue where running a merge patch while specifying datasetId you'd get internal server error on Scorpio. This lets us to test with the datasetId again. See #592 for more.