### PR TITLE
Make checkpointing configurable in shacl2flink

### DIFF
--- a/semantic-model/shacl2flink/Makefile
+++ b/semantic-model/shacl2flink/Makefile
@@ -10,7 +10,14 @@ SQLITE3 := sqlite3
 HELM_DIR := ../../helm/charts/shacl
 NAMESPACE := iff
 ONTDIR := ../kms/ontology
+CHECKPOINT ?= false
 
+# Conditionally set CHECKPOINTVAR based on CHECKPOINT
+ifeq ($(CHECKPOINT), true)
+    CHECKPOINTSWITCH = -p
+else
+    CHECKPOINTSWITCH =
+endif
 
 sqlite_files = $(OUTPUTDIR)/core.sqlite $(OUTPUTDIR)/ngsild.sqlite $(OUTPUTDIR)/rdf.sqlite $(OUTPUTDIR)/ngsild-models.sqlite $(OUTPUTDIR)/shacl-validation.sqlite
 
@@ -21,7 +28,7 @@ build: $(SHACL) $(KNOWLEDGE $(MODEL)
 	${PYTHON} create_udfs.py
 	$(PYTHON) create_ngsild_tables.py $(SHACL) $(KNOWLEDGE) $(KAFKA_TOPICS)
 	$(PYTHON) create_ngsild_models.py $(SHACL) $(KNOWLEDGE) $(MODEL)
-	$(PYTHON) create_sql_checks_from_shacl.py $(SHACL) $(KNOWLEDGE)
+	$(PYTHON) create_sql_checks_from_shacl.py $(CHECKPOINTSWITCH) $(SHACL) $(KNOWLEDGE)
 
 helm: export IFF_HELM=true
 helm: build

--- a/semantic-model/shacl2flink/create_sql_checks_from_shacl.py
+++ b/semantic-model/shacl2flink/create_sql_checks_from_shacl.py
@@ -37,12 +37,14 @@ create_sql_checks_from_shacl.py <shacl.ttl> <knowledge.ttl>')
     parser.add_argument('-c', '--context', help='Context URI. If not given it is derived implicitly \
 from the common helmfile configs.')
     parser.add_argument('--namespace', help='namespace for configmaps', default='iff')
+    parser.add_argument('-p', '--enable-checkpointing', action="store_true", default=False,
+                        help="Enable checkpointing by putting checkpointing options into the flink sql yaml.")
 
     parsed_args = parser.parse_args(args)
     return parsed_args
 
 
-def main(shaclfile, knowledgefile, context, maps_namespace, output_folder='output'):
+def main(shaclfile, knowledgefile, context, maps_namespace, output_folder='output', enable_checkpointing=False):
     # If no context is defined, try to derive it from common.yaml
     prefixes = {}
     if context is None:
@@ -97,7 +99,7 @@ is accessible.")
             yaml.dump(utils.create_configmap(configmapname, statementset_map), fm)
             statementmap.append(f'{maps_namespace}/{configmapname}')
         yaml.dump(utils.create_statementmap('shacl-validation', tables, views, ttl,
-                                            statementmap), f)
+                                            statementmap, enable_checkpointing), f)
 
     with open(os.path.join(output_folder, "shacl-validation.sqlite"), "w") \
             as sqlitef:
@@ -110,4 +112,4 @@ if __name__ == '__main__':
     knowledgefile = args.knowledgefile
     context = args.context
     maps_namespace = args.namespace
-    main(shaclfile, knowledgefile, context, maps_namespace)
+    main(shaclfile, knowledgefile, context, maps_namespace, enable_checkpointing=args.enable_checkpointing)

--- a/semantic-model/shacl2flink/tests/test_utils.py
+++ b/semantic-model/shacl2flink/tests/test_utils.py
@@ -197,6 +197,74 @@ def test_create_statementmap():
             'tables': 'table_object',
             'refreshInterval': '12h',
             'views': 'view',
+            'sqlsettings': [
+                {"table.exec.sink.upsert-materialize": "none"},
+                {"execution.savepoint.ignore-unclaimed-state": "true"},
+                {"pipeline.object-reuse": "true"},
+                {"parallelism.default": "{{ .Values.flink.defaultParalellism }}"},
+                {"state.backend.rocksdb.writebuffer.size": "64 kb"},
+                {"state.backend.rocksdb.use-bloom-filter": "true"},
+                {"state.backend": "rocksdb"},
+                {"state.backend.rocksdb.predefined-options": "SPINNING_DISK_OPTIMIZED_HIGH_MEM"}
+            ],
+            'sqlstatementmaps': ['namespace/configmap'],
+            'updateStrategy': 'none'
+        }
+    }
+
+    result = utils.create_statementmap('object', 'table_object', 'view', 'ttl',
+                                       ['namespace/configmap'])
+
+    assert result == {
+        'apiVersion': 'industry-fusion.com/v1alpha4',
+        'kind': 'BeamSqlStatementSet',
+        'metadata': {
+            'name': 'object'
+        },
+        'spec': {
+            'tables': 'table_object',
+            'refreshInterval': '12h',
+            'views': 'view',
+            'sqlsettings': [
+                {"table.exec.sink.upsert-materialize": "none"},
+                {"execution.savepoint.ignore-unclaimed-state": "true"},
+                {"pipeline.object-reuse": "true"},
+                {"parallelism.default": "{{ .Values.flink.defaultParalellism }}"},
+                {"state.backend.rocksdb.writebuffer.size": "64 kb"},
+                {"state.backend.rocksdb.use-bloom-filter": "true"},
+                {"state.backend": "rocksdb"},
+                {"state.backend.rocksdb.predefined-options": "SPINNING_DISK_OPTIMIZED_HIGH_MEM"},
+                {"table.exec.state.ttl": 'ttl'}
+            ],
+            'sqlstatementmaps': ['namespace/configmap'],
+            'updateStrategy': 'none'
+        }
+    }
+
+    result = utils.create_statementmap('object', 'table_object', 'view', None,
+                                       ['namespace/configmap'], enable_checkpointing=True)
+
+    assert result == {
+        'apiVersion': 'industry-fusion.com/v1alpha4',
+        'kind': 'BeamSqlStatementSet',
+        'metadata': {
+            'name': 'object'
+        },
+        'spec': {
+            'tables': 'table_object',
+            'refreshInterval': '12h',
+            'views': 'view',
+            'sqlsettings': [
+                {"table.exec.sink.upsert-materialize": "none"},
+                {"execution.savepoint.ignore-unclaimed-state": "true"},
+                {"pipeline.object-reuse": "true"},
+                {"parallelism.default": "{{ .Values.flink.defaultParalellism }}"},
+                {"state.backend.rocksdb.writebuffer.size": "64 kb"},
+                {"state.backend.rocksdb.use-bloom-filter": "true"},
+                {"state.backend": "rocksdb"},
+                {"state.backend.rocksdb.predefined-options": "SPINNING_DISK_OPTIMIZED_HIGH_MEM"},
+                {"execution.checkpointing.interval": "{{ .Values.flink.checkpointInterval }}"}
+            ],
             'sqlstatementmaps': ['namespace/configmap'],
             'updateStrategy': 'none'
         }


### PR DESCRIPTION
Checkpointing is used by Flink to keep and recover complex states. However, in many use-cases, state management is not needed. Also, state management must be understood by the user and should therefore explicitly switch on if needed.
Checkpointing can be enabled by setting the environment variable CHECKPOINT=true For instance 'CHECKPOINT=true make flink-deploy' would deploy the SHACL constraints as FLINK job