### PR TITLE
Fix code scanning alert no. 8: Missing rate limiting

### DIFF
--- a/KafkaBridge/lib/authService/index.js
+++ b/KafkaBridge/lib/authService/index.js
@@ -16,6 +16,7 @@
 'use strict';
 
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const Authenticate = require('./authenticate');
 const Acl = require('./acl');
 const app = express();
@@ -30,7 +31,12 @@ const init = async function (conf) {
   const config = conf;
   app.use(express.json());
 
-  app.get('/auth', (req, res) => {
+  const authLimiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+  });
+
+  app.get('/auth', authLimiter, (req, res) => {
     auth.authenticate(req, res);
   });
 

--- a/KafkaBridge/package.json
+++ b/KafkaBridge/package.json
@@ -22,7 +22,8 @@
     "openid-client": "^5.1.2",
     "redis": "^4.6.11",
     "underscore": "^1.13.1",
-    "winston": "^3.8.1"
+    "winston": "^3.8.1",
+    "express-rate-limit": "^7.4.1"
   },
   "devDependencies": {
     "chai": "^4.3.6",


### PR DESCRIPTION
Fixes [https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/8](https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/8)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up rate limiting for our routes. We will configure a rate limiter to limit the number of requests to the `/auth` endpoint to a reasonable number per minute. This will help protect the application from denial-of-service attacks.

We will need to:
1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `KafkaBridge/lib/authService/index.js` file.
3. Set up a rate limiter with appropriate configuration.
4. Apply the rate limiter to the `/auth` route.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
