### PR TITLE
Change update behavior of the ngsild bridge to batch merge operation

### DIFF
--- a/KafkaBridge/lib/ngsild.js
+++ b/KafkaBridge/lib/ngsild.js
@@ -500,6 +500,26 @@ function fiwareApi (conf) {
   };
 
   /**
+   * Run batch merge operation on the entities
+   * @param {array[Object]} entities - Array of JSON patches to merge
+   * @param {array[Object]} headers - additional headers
+   */
+  this.batchMerge = function (entities, { headers }) {
+    headers = headers || {};
+    headers['Content-Type'] = 'application/ld+json';
+
+    const options = {
+      hostname: config.ngsildServer.hostname,
+      protocol: config.ngsildServer.protocol,
+      port: config.ngsildServer.port,
+      path: '/ngsi-ld/v1/entityOperations/merge',
+      headers: headers,
+      method: 'POST'
+    };
+    return rest.postBody({ options, body: entities });
+  };
+
+  /**
    * Helpers
    */
   const jsonldFilesForTypes = {

--- a/KafkaBridge/lib/ngsildUpdates.js
+++ b/KafkaBridge/lib/ngsildUpdates.js
@@ -128,20 +128,31 @@ module.exports = function NgsildUpdates (conf) {
     try {
       // update the entity - do not create it
       if (op === 'update') {
-        // NOTE: The batch update API of Scorpio does not yet support noOverwrite options. For the time being
-        // the batch processing will be done sequentially - until this is fixed in Scorpio
-        for (const entity of entities) { // olet i = 0; i < entities.length; i ++) {
-          // basic health check of entity
-          if (entity.id === undefined || entity.id == null) {
-            logger.error('Unhealthy entity - ignoring it:' + JSON.stringify(entity));
-          } else {
-            logger.debug('Updating: ' + JSON.stringify(entities));
-            result = await ngsild.updateProperties({ id: entity.id, body: entity, isOverwrite: overwriteOrReplace }, { headers });
-            if (result.statusCode !== 204 && result.statusCode !== 207) {
-              logger.error('Entity cannot update entity:' + JSON.stringify(result.body) + ' and status code ' + result.statusCode); // throw no error, log it and ignore it, repeating would probably not solve it
-            }
+        // Batch merge is run
+        // TODO: change behavior based on overwrite parameter
+        if (entities === undefined || entities == null) {
+          logger.error('Unhealthy entities - ignoring it:' + JSON.stringify(entities));
+        } else {
+          logger.debug('Updating: ' + JSON.stringify(entities));
+          result = await ngsild.batchMerge(entities, { headers });
+          if (result.statusCode !== 204 && result.statusCode !== 207) {
+            logger.error('Entity cannot run merge:' + JSON.stringify(result.body) + ' and status code ' + result.statusCode); // throw no error, log it and ignore it, repeating would probably not solve it
           }
-        };
+        }
+        // // NOTE: The batch update API of Scorpio does not yet support noOverwrite options. For the time being
+        // // the batch processing will be done sequentially - until this is fixed in Scorpio
+        // for (const entity of entities) { // olet i = 0; i < entities.length; i ++) {
+        //   // basic health check of entity
+        //   if (entity.id === undefined || entity.id == null) {
+        //     logger.error('Unhealthy entity - ignoring it:' + JSON.stringify(entity));
+        //   } else {
+        //     logger.debug('Updating: ' + JSON.stringify(entities));
+        //     result = await ngsild.updateProperties({ id: entity.id, body: entity, isOverwrite: overwriteOrReplace }, { headers });
+        //     if (result.statusCode !== 204 && result.statusCode !== 207) {
+        //       logger.error('Entity cannot update entity:' + JSON.stringify(result.body) + ' and status code ' + result.statusCode); // throw no error, log it and ignore it, repeating would probably not solve it
+        //     }
+        //   }
+        // };
       } else if (op === 'upsert') {
         // in this case, entity will be created if not existing
         logger.debug('Upserting: ' + JSON.stringify(entities));

--- a/KafkaBridge/test/testLibNgsild.js
+++ b/KafkaBridge/test/testLibNgsild.js
@@ -971,3 +971,44 @@ describe('Test updateEntities', function () {
     revert();
   });
 });
+describe('Test batchMerge', function () {
+  it('Should use correct options and headers', async function () {
+    const Logger = function () {
+      return logger;
+    };
+    const Rest = function () {
+      return rest;
+    };
+    const headers = { Authorization: 'Bearer token' };
+    const expectedOptions = {
+      hostname: 'hostname',
+      protocol: 'http:',
+      port: 1234,
+      method: 'POST',
+      path: '/ngsi-ld/v1/entityOperations/merge',
+      headers: {
+        'Content-Type': 'application/ld+json',
+        Authorization: 'Bearer token'
+      }
+    };
+    const rest = {
+      postBody: function (obj) {
+        assert.deepEqual(obj.options, expectedOptions);
+        assert.deepEqual(obj.body, entities);
+        return Promise.resolve('merged');
+      }
+    };
+
+    const entities = [
+      { id: 'id1', type: 'type1', attr1: 'value1' },
+      { id: 'id2', type: 'type2', attr2: 'value2' }
+    ];
+
+    const revert = ToTest.__set__('Logger', Logger);
+    ToTest.__set__('Rest', Rest);
+    const ngsild = new ToTest(config);
+    const result = await ngsild.batchMerge(entities, { headers });
+    result.should.equal('merged');
+    revert();
+  });
+});


### PR DESCRIPTION
op='update' now exclusively calls batch merge, overwrite flag is currently ignored.
Unit tests and E2E tests added, existing tests tweaked.

Closes: #556 