### PR TITLE
Fix code scanning alert no. 5: Missing rate limiting

### DIFF
--- a/FlinkSqlGateway/gateway.js
+++ b/FlinkSqlGateway/gateway.js
@@ -21,6 +21,11 @@ const fs = require('fs');
 const path = require('path');
 const app = express();
 const bodyParser = require('body-parser');
+const RateLimit = require('express-rate-limit');
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
 
 const logger = require('./lib/logger.js');
 const port = process.env.SIMPLE_FLINK_SQL_GATEWAY_PORT || 9000;
@@ -185,7 +190,7 @@ function getLocalPythonUdfs () {
 app.use(express.json({ limit: '10mb' }));
 
 app.get('/health', appget);
-app.get('/v1/python_udf/:filename', udfget);
+app.get('/v1/python_udf/:filename', limiter, udfget);
 
 app.post('/v1/sessions/:session_id/statements', apppost);
 app.post('/v1/python_udf/:filename', bodyParser.text(), udfpost);

--- a/FlinkSqlGateway/package.json
+++ b/FlinkSqlGateway/package.json
@@ -11,7 +11,8 @@
     "express": "^4.21.1",
     "jszip": "^3.10.1",
     "uuid": "^8.3.2",
-    "winston": "^3.8.1"
+    "winston": "^3.8.1",
+    "express-rate-limit": "^7.4.1"
   },
   "devDependencies": {
     "chai": "^4.3.6",


### PR DESCRIPTION
Fixes [https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/5](https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/5)

To fix the problem, we will introduce rate limiting to the Express application using the `express-rate-limit` package. This will help prevent denial-of-service attacks by limiting the number of requests that can be made to the `udfget` endpoint within a specified time window.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `FlinkSqlGateway/gateway.js` file.
3. Set up a rate limiter with appropriate configuration (e.g., maximum of 100 requests per 15 minutes).
4. Apply the rate limiter to the `udfget` endpoint.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
