### PR TITLE
Fix code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/FlinkSqlGateway/gateway.js
+++ b/FlinkSqlGateway/gateway.js
@@ -19,6 +19,7 @@ const { spawn } = require('child_process');
 const uuid = require('uuid');
 const fs = require('fs');
 const path = require('path');
+const sanitize = require('sanitize-filename');
 const app = express();
 const bodyParser = require('body-parser');
 
@@ -136,9 +137,15 @@ function apppost (request, response) {
 }
 
 function udfget (req, res) {
-  const filename = req.params.filename;
+  let filename = req.params.filename;
+  filename = sanitize(filename);
   logger.debug('python_udf get was requested for: ' + filename);
-  const fullname = `${udfdir}/${filename}.py`;
+  const fullname = path.resolve(udfdir, `${filename}.py`);
+  if (!fullname.startsWith(udfdir)) {
+    res.status(403).send('Forbidden');
+    logger.info('Attempt to access file outside of udfdir: ' + fullname);
+    return;
+  }
   try {
     fs.readFileSync(fullname);
   } catch (err) {
@@ -150,7 +157,8 @@ function udfget (req, res) {
 };
 
 function udfpost (req, res) {
-  const filename = req.params.filename;
+  let filename = req.params.filename;
+  filename = sanitize(filename);
   const body = req.body;
   if (body === undefined || body === null) {
     res.status(500);
@@ -158,7 +166,12 @@ function udfpost (req, res) {
     return;
   }
   logger.debug(`python_udf with name ${filename}`);
-  const fullname = `${udfdir}/${filename}.py`;
+  const fullname = path.resolve(udfdir, `${filename}.py`);
+  if (!fullname.startsWith(udfdir)) {
+    res.status(403).send('Forbidden');
+    logger.info('Attempt to write file outside of udfdir: ' + fullname);
+    return;
+  }
   try {
     fs.writeFileSync(fullname, body);
   } catch (err) {

--- a/FlinkSqlGateway/package.json
+++ b/FlinkSqlGateway/package.json
@@ -11,7 +11,8 @@
     "express": "^4.21.1",
     "jszip": "^3.10.1",
     "uuid": "^8.3.2",
-    "winston": "^3.8.1"
+    "winston": "^3.8.1",
+    "sanitize-filename": "^1.6.3"
   },
   "devDependencies": {
     "chai": "^4.3.6",


### PR DESCRIPTION
Fixes [https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/3](https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/3)

To fix the problem, we need to ensure that the `filename` parameter is validated and sanitized before it is used to construct the file path. We can use the `path` module to resolve the path and ensure it is within a designated safe directory. Additionally, we can use a library like `sanitize-filename` to remove any special characters from the filename.

1. Import the `sanitize-filename` library.
2. Sanitize the `filename` parameter.
3. Resolve the full path and ensure it is within the `udfdir` directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
