### PR TITLE
Fix code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/KafkaBridge/lib/authService/authenticate.js
+++ b/KafkaBridge/lib/authService/authenticate.js
@@ -115,7 +115,8 @@ class Authenticate {
   }
 
   verifyAndDecodeToken (token) {
-    this.logger.debug('decode token: ' + token);
+    const maskedToken = token ? token.substring(0, 4) + '...' : 'null';
+    this.logger.debug('decode token: ' + maskedToken);
     return this.keycloakAdapter.grantManager
       .createGrant({ access_token: token })
       .then(grant => grant.access_token.content)


### PR DESCRIPTION
Fixes [https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/1](https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/1)

To fix the problem, we need to avoid logging sensitive information such as tokens. Instead of logging the entire token, we can log a masked version of it or simply avoid logging it altogether. This change should be made in the `verifyAndDecodeToken` method where the token is being logged.

- Replace the line that logs the token with a line that logs a masked version of the token or a generic message.
- Ensure that the fix does not change the existing functionality of the code.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
