### PR TITLE
Fix code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/FlinkSqlGateway/gateway.js
+++ b/FlinkSqlGateway/gateway.js
@@ -21,6 +21,16 @@ const fs = require('fs');
 const path = require('path');
 const app = express();
 const bodyParser = require('body-parser');
+const RateLimit = require('express-rate-limit');
+
+// set up rate limiter: maximum of 100 requests per 15 minutes
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+// apply rate limiter to all requests
+app.use(limiter);
 
 const logger = require('./lib/logger.js');
 const port = process.env.SIMPLE_FLINK_SQL_GATEWAY_PORT || 9000;

--- a/FlinkSqlGateway/package.json
+++ b/FlinkSqlGateway/package.json
@@ -11,7 +11,8 @@
     "express": "^4.21.1",
     "jszip": "^3.10.1",
     "uuid": "^8.3.2",
-    "winston": "^3.8.1"
+    "winston": "^3.8.1",
+    "express-rate-limit": "^7.4.1"
   },
   "devDependencies": {
     "chai": "^4.3.6",


### PR DESCRIPTION
Fixes [https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/6](https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/6)

To fix the problem, we need to introduce rate limiting to the Express application. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up rate limiting middleware. We will configure the rate limiter to allow a maximum of 100 requests per 15 minutes and apply it to all routes.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `gateway.js` file.
3. Set up the rate limiter with the desired configuration.
4. Apply the rate limiter middleware to the Express application.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
