### PR TITLE
Fix code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/FlinkSqlGateway/package.json
+++ b/FlinkSqlGateway/package.json
@@ -11,7 +11,8 @@
     "express": "^4.21.1",
     "jszip": "^3.10.1",
     "uuid": "^8.3.2",
-    "winston": "^3.8.1"
+    "winston": "^3.8.1",
+    "sanitize-filename": "^1.6.3"
   },
   "devDependencies": {
     "chai": "^4.3.6",


### PR DESCRIPTION
Fixes [https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/2](https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/2)

To fix the problem, we need to ensure that the `filename` parameter is properly validated and sanitized before being used to construct file paths. We can achieve this by normalizing the path and ensuring it is contained within a safe root directory. Additionally, we can use a library like `sanitize-filename` to remove any special characters from the filename.

1. Import the `sanitize-filename` library.
2. Sanitize the `filename` parameter to remove any special characters.
3. Normalize the constructed file path and ensure it is within the intended directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
