### PR TITLE
Fix code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/FlinkSqlGateway/package.json
+++ b/FlinkSqlGateway/package.json
@@ -12,7 +12,8 @@
     "jszip": "^3.10.1",
     "uuid": "^8.3.2",
     "winston": "^3.8.1",
-    "express-rate-limit": "^7.4.1"
+    "express-rate-limit": "^7.4.1",
+    "sanitize-filename": "^1.6.3"
   },
   "devDependencies": {
     "chai": "^4.3.6",


### PR DESCRIPTION
Fixes [https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/3](https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/3)

To fix the problem, we need to ensure that the `filename` parameter is validated and sanitized before it is used to construct the file path. We can achieve this by normalizing the path and ensuring it is contained within a safe root directory. Additionally, we can use a library like `sanitize-filename` to remove any special characters from the filename.

1. Import the `sanitize-filename` library.
2. Normalize the path using `path.resolve` to remove any ".." segments.
3. Check that the normalized path starts with the root directory.
4. If the path is invalid, return an error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
