### PR TITLE
Fix extractType.py overwrites default base ontology

### DIFF
--- a/semantic-model/opcua/extractType.py
+++ b/semantic-model/opcua/extractType.py
@@ -500,7 +500,8 @@ if __name__ == '__main__':
         h.parse(imprt)
         g += h
         for k, v in list(h.namespaces()):
-            g.bind(k, v)
+            if k != '':
+                g.bind(k, v)
 
     types = []
     basens = next(Namespace(uri) for prefix, uri in list(g.namespaces()) if prefix == 'base')


### PR DESCRIPTION
extractType.py in the semantic OPCUA module is importing all ontologies defined in the OWL:Ontology RDF subject of the instance ontology. The ontology prefixes MUST be identical with the respective names in the @context file. In case of default ontologies, this requirement is violated, mainly by the base.ttl ontology. This problem was not showing up because in our testcases, base.ttl is processed before other ontolgoies. But in cases where base.ttl is processed as last ontology, the 'base' prefix is set to '' which breaks our assumptions. With this fix, default ontology names are ignored.