### PR TITLE
Clarify warning of extract type when no proper match for placeholders…

### DIFF
--- a/semantic-model/opcua/extractType.py
+++ b/semantic-model/opcua/extractType.py
@@ -365,8 +365,9 @@ def scan_entitiy_recursive(node, id, instance, node_id, o):
         is_placeholder = False
     if is_placeholder:
         if original_attributename is None:
-            print(f"Warning: No original_attributename given but datasetId neeeded for {decoded_attributename}. \
-Chosing default datasetId.")
+            print(f"Warning: Cannot find proper match in SHACL description for placeholder value \
+{decoded_attributename}. Will keep it with default datasetId. But it is very likely that the SHACL validation \
+will flag this.")
             datasetId = "@none"
         else:
             datasetId = f'{datasetid_urn}:{original_attributename}'


### PR DESCRIPTION
… is found

In extractType.py, when instance is parsed and a placeholder is found, it tries to find it in the shacl description. If it is not found, then this warning is issued. It means, that the attribute is kept in the instance, but it is already likely that it is not compliant with the SHACL description.