### PR TITLE
Allow null valued in attribute table of tsdb database

### DIFF
--- a/KafkaBridge/timescaledb/model/attribute_history.js
+++ b/KafkaBridge/timescaledb/model/attribute_history.js
@@ -48,7 +48,8 @@ const attributeHistoryTable = sequelize.define(config.timescaledb.attributeTable
 
   nodeType: { type: Sequelize.TEXT, allowNull: false },
 
-  value: { type: Sequelize.TEXT, allowNull: false },
+  // Value can be null, when row is deleted
+  value: { type: Sequelize.TEXT, allowNull: true },
 
   // In future can be used for literals value types
   valueType: { type: Sequelize.TEXT, allowNull: true },


### PR DESCRIPTION
The value field in the attribute table was not allowed to be null. This is creating an issue when attributes are deleted, since in this case there is no value. To allow recording of attribute deltions.