### PR TITLE
Enable handling of array values in extractType.py

### DIFF
--- a/semantic-model/opcua/lib/utils.py
+++ b/semantic-model/opcua/lib/utils.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse
 from rdflib.namespace import RDFS, XSD, OWL, RDF
 from rdflib import URIRef, Namespace, Graph
 from pathlib import Path
+import json
 import re
 import os
 
@@ -157,6 +158,14 @@ def get_default_value(datatype):
 
 
 def get_value(value, datatype):
+    # values can be arrays, so check first for arrays and do later the scalar
+    # transformations
+    try:
+        decoded = json.loads(value)
+        if isinstance(decoded, list):
+            return decoded
+    except:
+        pass
     if datatype == XSD.integer:
         return int(value)
     if datatype == XSD.double:

--- a/semantic-model/opcua/tests/test_libutils.py
+++ b/semantic-model/opcua/tests/test_libutils.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 from rdflib import Graph, Namespace, URIRef, Literal, BNode
 from rdflib.namespace import RDFS, XSD, OWL
-from lib.utils import RdfUtils, downcase_string, isNodeId, convert_to_json_type, idtype2String, extract_namespaces, get_datatype, attributename_from_type, get_default_value, normalize_angle_bracket_name, contains_both_angle_brackets, get_typename, get_common_supertype
+from lib.utils import RdfUtils, downcase_string, isNodeId, convert_to_json_type, idtype2String, extract_namespaces, get_datatype, attributename_from_type, get_default_value, get_value, normalize_angle_bracket_name, contains_both_angle_brackets, get_typename, get_common_supertype
 
 class TestUtils(unittest.TestCase):
 
@@ -94,6 +94,14 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(get_default_value(XSD.string), '')
         self.assertEqual(get_default_value(XSD.boolean), False)
 
+    def test_get_value(self):
+        """Test getting the converted value for a datatype."""
+        self.assertEqual(get_value('99', XSD.integer), int(99))
+        self.assertEqual(get_value('0.123', XSD.double), float(0.123))
+        self.assertEqual(get_value('hello', XSD.string), str('hello'))
+        self.assertEqual(get_value('True', XSD.boolean), True)
+        self.assertEqual(get_value('[ 0.0, 0.1 ]', XSD.boolean), [ 0.0, 0.1 ])
+        
     def test_normalize_angle_bracket_name(self):
         """Test normalizing a name by removing angle bracket content."""
         input_str = "example<test>123"


### PR DESCRIPTION
the value parser is assuming scalar values which leads to parsing exception Now it is first checked whether it is an array and if not the special scalar transformations are done. What needs to be added a check whether the array/scalar fits to the Rank value of OPCUA.