### PR TITLE
Remove Blank Node constraint of opcua data arrays

### DIFF
--- a/semantic-model/opcua/lib/shacl.py
+++ b/semantic-model/opcua/lib/shacl.py
@@ -164,7 +164,6 @@ class Shacl:
                                                                          array_dimensions)
                 pred, obj = self.shacl_or([array_validation_shape])
                 self.shaclg.add((innerproperty, pred, obj))
-                self.shaclg.add((innerproperty, SH.nodeKind, SH.BlankNode))
             elif int(value_rank) < -1:
                 dt_array = self.create_datatype_shapes(datatype)
                 array_validation_shape = self.get_array_validation_shape(datatype,

--- a/semantic-model/opcua/tests/extractType/test_variable_arrays.NodeSet2.shacl
+++ b/semantic-model/opcua/tests/extractType/test_variable_arrays.NodeSet2.shacl
@@ -7,16 +7,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 shacl:AlphaTypeShape a sh:NodeShape ;
-    sh:property [ sh:maxCount 1 ;
-            sh:minCount 0 ;
-            sh:nodeKind sh:BlankNode ;
-            sh:path <http://my.test/entity/hasC> ;
-            sh:property [ sh:maxCount 1 ;
-                    sh:minCount 1 ;
-                    sh:or ( [ sh:datatype xsd:double ] [ sh:property [ sh:datatype xsd:double ;
-                                        sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ) ;
-                    sh:path ngsi-ld:hasValue ] ],
-        [ a base:PeerRelationship ;
+    sh:property [ a base:PeerRelationship ;
             sh:maxCount 1 ;
             sh:minCount 0 ;
             sh:nodeKind sh:BlankNode ;
@@ -35,29 +26,25 @@ shacl:AlphaTypeShape a sh:NodeShape ;
                     sh:maxCount 1 ;
                     sh:minCount 1 ;
                     sh:nodeKind sh:IRI ;
-                    sh:path ngsi-ld:hasObject ] ] ;
+                    sh:path ngsi-ld:hasObject ] ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path <http://my.test/entity/hasC> ;
+            sh:property [ sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:or ( [ sh:datatype xsd:double ] [ sh:property [ sh:datatype xsd:double ;
+                                        sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ) ;
+                    sh:path ngsi-ld:hasValue ] ] ;
     sh:targetClass test:AlphaType .
 
 shacl:BTypeShape a sh:NodeShape ;
     sh:property [ sh:maxCount 1 ;
             sh:minCount 0 ;
             sh:nodeKind sh:BlankNode ;
-            sh:path <http://my.test/entity/hasMyVariable> ;
-            sh:property [ sh:maxCount 1 ;
-                    sh:minCount 1 ;
-                    sh:nodeKind sh:BlankNode ;
-                    sh:path ngsi-ld:hasValue ;
-                    sh:property [ sh:datatype xsd:integer ;
-                            sh:maxCount 2 ;
-                            sh:minCount 2 ;
-                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ],
-        [ sh:maxCount 1 ;
-            sh:minCount 0 ;
-            sh:nodeKind sh:BlankNode ;
             sh:path <http://my.test/entity/hasMyVariable3> ;
             sh:property [ sh:maxCount 1 ;
                     sh:minCount 1 ;
-                    sh:nodeKind sh:BlankNode ;
                     sh:path ngsi-ld:hasValue ;
                     sh:property [ sh:datatype xsd:boolean ;
                             sh:maxCount 2 ;
@@ -69,7 +56,6 @@ shacl:BTypeShape a sh:NodeShape ;
             sh:path <http://my.test/entity/hasMyVariable2> ;
             sh:property [ sh:maxCount 1 ;
                     sh:minCount 1 ;
-                    sh:nodeKind sh:BlankNode ;
                     sh:path ngsi-ld:hasValue ;
                     sh:property [ sh:datatype xsd:double ;
                             sh:maxCount 6 ;
@@ -87,21 +73,31 @@ shacl:BTypeShape a sh:NodeShape ;
         [ sh:maxCount 1 ;
             sh:minCount 0 ;
             sh:nodeKind sh:BlankNode ;
-            sh:path <http://my.test/entity/hasMyVariable5> ;
-            sh:property [ sh:maxCount 1 ;
-                    sh:minCount 1 ;
-                    sh:nodeKind sh:BlankNode ;
-                    sh:path ngsi-ld:hasValue ;
-                    sh:property [ sh:datatype xsd:string ;
-                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ],
-        [ sh:maxCount 1 ;
-            sh:minCount 0 ;
-            sh:nodeKind sh:BlankNode ;
             sh:path <http://my.test/entity/hasMyVariable6> ;
             sh:property [ sh:datatype xsd:string ;
                     sh:maxCount 1 ;
                     sh:minCount 1 ;
                     sh:nodeKind sh:Literal ;
-                    sh:path ngsi-ld:hasValue ] ] ;
+                    sh:path ngsi-ld:hasValue ] ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path <http://my.test/entity/hasMyVariable> ;
+            sh:property [ sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:path ngsi-ld:hasValue ;
+                    sh:property [ sh:datatype xsd:integer ;
+                            sh:maxCount 2 ;
+                            sh:minCount 2 ;
+                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path <http://my.test/entity/hasMyVariable5> ;
+            sh:property [ sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:path ngsi-ld:hasValue ;
+                    sh:property [ sh:datatype xsd:string ;
+                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ] ;
     sh:targetClass test:BType .
 


### PR DESCRIPTION
Assumption that all arrays start with a Blank Node is wrong. Empty array only consists of rdf:nil. Therefore, a proper check must evaluate sh:BlankNode or sh:hasValue rdf:nil. We will reconsider this in next sprint.