### PR TITLE
Improve validation of rankValue/arrayDimensions

### DIFF
--- a/semantic-model/opcua/Makefile
+++ b/semantic-model/opcua/Makefile
@@ -33,7 +33,7 @@ setup-dev: requirements-dev.txt
 	$(PIP) install -r requirements-dev.txt
 
 test:
-	${PYTEST} tests --cov . --cov-fail-under=80
+	${PYTEST} tests --cov=lib . --cov-fail-under=80
 	(cd tests/nodeset2owl; bash ./test.bash)
 	(cd tests/extractType; bash ./test.bash)
 	(cd tests/nodeset-dump; bash ./test.bash)

--- a/semantic-model/opcua/extractType.py
+++ b/semantic-model/opcua/extractType.py
@@ -273,7 +273,7 @@ def scan_type_recursive(o, node, instancetype, shapename):
         if isAbstract:
             return False
         shacl_rule['is_property'] = True
-        shaclg.get_shacl_iri_and_contentclass(g, o, shacl_rule)
+        shaclg.get_shacl_iri_and_contentclass(g, o, node, shacl_rule)
         shaclg.create_shacl_property(shapename,
                                      shacl_rule['path'],
                                      shacl_rule['optional'],
@@ -408,7 +408,7 @@ will flag this.")
             shacl_rule['contentclass'] = classtype
     elif rdfutils.isVariableNodeClass(nodeclass):
         shacl_rule['is_property'] = True
-        shaclg.get_shacl_iri_and_contentclass(g, o, shacl_rule)
+        shaclg.get_shacl_iri_and_contentclass(g, o, node, shacl_rule)
         if shacl_rule['isAbstract']:
             print(f"Warning: Abstract OPCUA DataType {str(shacl_rule.get('orig_datatype'))} \
 in attribute {entity_ontology_prefix}:{attributename}.")
@@ -424,7 +424,7 @@ in attribute {entity_ontology_prefix}:{attributename}.")
                 value = utils.get_default_value(shacl_rule['datatype'],
                                                 shacl_rule.get('orig_datatype'),
                                                 shacl_rule.get('value_rank'),
-                                                shacl_rule.get('array_dimensions'))
+                                                shacl_rule.get('array_dimensions'), g=g)
             else:
                 value = e.get_default_contentclass(shacl_rule['contentclass'])
         has_components = True

--- a/semantic-model/opcua/lib/entity.py
+++ b/semantic-model/opcua/lib/entity.py
@@ -75,18 +75,6 @@ class Entity:
         self.e.bind('ngsi-ld', self.ngsildns)
         self.types = []
 
-    # def scan_type(self, g, node, instancetype):
-    #     # Implementation of the scan_type logic
-    #     pass
-
-    # def scan_entity(self, g, node, instancetype, id, optional=False):
-    #     # Implementation of the scan_entity logic
-    #     pass
-
-    # def generate_node_id(self, g, node, id, instancetype):
-    #     # Implementation for generating node ID
-    #     pass
-
     def bind(self, prefix, namespace):
         self.e.bind(prefix, namespace)
 
@@ -102,31 +90,6 @@ class Entity:
         self.e.add((iri, RDFS.domain, URIRef(instancetype)))
         self.e.add((iri, RDF.type, OWL.NamedIndividual))
 
-    # def add_relationship(self, attributename):
-    #     if isinstance(attributename, URIRef):
-    #         self.e.add((attributename, RDFS.range, ngsildns['Relationship']))
-    #     else:
-    #         self.e.add((self.entity_namespace[attributename], RDFS.range, ngsildns['Relationship']))
-
-    # def add_subcomponent(self, attributename):
-    #     self.e.add((self.entity_namespace[attributename], RDF.type, self.basens['SubComponentRelationship']))
-
-    # def add_placeholder(self, attributename):
-    #     self.e.add((self.entity_namespace[attributename], self.basens['isPlaceHolder'], Literal(True)))
-
-    # def add_property(self, attributename):
-    #     if isinstance(attributename, URIRef):
-    #         self.e.add((attributename, RDFS.range, ngsildns['Property']))
-    #     else:
-    #         self.e.add((self.entity_namespace[attributename], RDFS.range, ngsildns['Property']))
-
-    # def is_typematch(self, full_attribute_name, type):
-    #     try:
-    #         if len(list(self.e.triples((full_attribute_name, RDFS.domain, type)))) > 0:
-    #             return True
-    #     except:
-    #         return False
-
     def add_subclass(self, type):
         self.e.add((type, RDF.type, OWL.Class))
         self.e.add((type, RDF.type, OWL.NamedIndividual))
@@ -141,19 +104,8 @@ class Entity:
     def add(self, triple):
         self.e.add(triple)
 
-    # def attritube_instance_exists(self, attributename):
-    #     return len(list(self.e.objects(attributename, RDF.type))) > 0
-
     def get_graph(self):
         return self.e
-
-    # def add_opcdatatype(self, attribute_name, data_type):
-    #     self.e.add((attribute_name, self.basens['hasOPCUADatatype'], data_type))
-
-    # def add_datatype(self, g, node, attribute_name):
-    #     data_type = utils.get_datatype(g, node, self.basens)
-    #     if data_type is not None:
-    #         self.e.add((self.entity_namespace[attribute_name], self.basens['hasOPCUADatatype'], data_type))
 
     def create_ontolgoy_header(self, entity_namespace, version=0.1, versionIRI=None):
         self.e.add((URIRef(entity_namespace), RDF.type, OWL.Ontology))

--- a/semantic-model/opcua/tests/extractType/test_variable_arrays.NodeSet2.instances
+++ b/semantic-model/opcua/tests/extractType/test_variable_arrays.NodeSet2.instances
@@ -30,6 +30,12 @@
             "type": "Property",
             "value": 42
         },
+        "uaentity:hasMyVariable8": {
+            "type": "Property",
+            "value": {
+                "@list": []
+            }
+        },
         "uaentity:hasMyVariable": {
             "type": "Property",
             "value": {
@@ -51,6 +57,10 @@
                     false
                 ]
             }
+        },
+        "uaentity:hasMyVariable7": {
+            "type": "Property",
+            "value": ""
         }
     },
     {

--- a/semantic-model/opcua/tests/extractType/test_variable_arrays.NodeSet2.shacl
+++ b/semantic-model/opcua/tests/extractType/test_variable_arrays.NodeSet2.shacl
@@ -7,7 +7,16 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 shacl:AlphaTypeShape a sh:NodeShape ;
-    sh:property [ a base:PeerRelationship ;
+    sh:property [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path <http://my.test/entity/hasC> ;
+            sh:property [ sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:or ( [ sh:datatype xsd:double ] [ sh:property [ sh:datatype xsd:double ;
+                                        sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ) ;
+                    sh:path ngsi-ld:hasValue ] ],
+        [ a base:PeerRelationship ;
             sh:maxCount 1 ;
             sh:minCount 0 ;
             sh:nodeKind sh:BlankNode ;
@@ -26,42 +35,11 @@ shacl:AlphaTypeShape a sh:NodeShape ;
                     sh:maxCount 1 ;
                     sh:minCount 1 ;
                     sh:nodeKind sh:IRI ;
-                    sh:path ngsi-ld:hasObject ] ],
-        [ sh:maxCount 1 ;
-            sh:minCount 0 ;
-            sh:nodeKind sh:BlankNode ;
-            sh:path <http://my.test/entity/hasC> ;
-            sh:property [ sh:maxCount 1 ;
-                    sh:minCount 1 ;
-                    sh:or ( [ sh:datatype xsd:double ] [ sh:property [ sh:datatype xsd:double ;
-                                        sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ) ;
-                    sh:path ngsi-ld:hasValue ] ] ;
+                    sh:path ngsi-ld:hasObject ] ] ;
     sh:targetClass test:AlphaType .
 
 shacl:BTypeShape a sh:NodeShape ;
     sh:property [ sh:maxCount 1 ;
-            sh:minCount 0 ;
-            sh:nodeKind sh:BlankNode ;
-            sh:path <http://my.test/entity/hasMyVariable3> ;
-            sh:property [ sh:maxCount 1 ;
-                    sh:minCount 1 ;
-                    sh:path ngsi-ld:hasValue ;
-                    sh:property [ sh:datatype xsd:boolean ;
-                            sh:maxCount 2 ;
-                            sh:minCount 2 ;
-                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ],
-        [ sh:maxCount 1 ;
-            sh:minCount 0 ;
-            sh:nodeKind sh:BlankNode ;
-            sh:path <http://my.test/entity/hasMyVariable2> ;
-            sh:property [ sh:maxCount 1 ;
-                    sh:minCount 1 ;
-                    sh:path ngsi-ld:hasValue ;
-                    sh:property [ sh:datatype xsd:double ;
-                            sh:maxCount 6 ;
-                            sh:minCount 6 ;
-                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ],
-        [ sh:maxCount 1 ;
             sh:minCount 0 ;
             sh:nodeKind sh:BlankNode ;
             sh:path <http://my.test/entity/hasMyVariable4> ;
@@ -70,6 +48,62 @@ shacl:BTypeShape a sh:NodeShape ;
                     sh:minCount 1 ;
                     sh:nodeKind sh:Literal ;
                     sh:path ngsi-ld:hasValue ] ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path <http://my.test/entity/hasMyVariable2> ;
+            sh:property [ sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:or ( [ sh:nodeKind sh:BlankNode ] [ sh:hasValue () ] ) ;
+                    sh:path ngsi-ld:hasValue ;
+                    sh:property [ sh:datatype xsd:double ;
+                            sh:maxCount 6 ;
+                            sh:minCount 6 ;
+                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path <http://my.test/entity/hasMyVariable5> ;
+            sh:property [ sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:or ( [ sh:nodeKind sh:BlankNode ] [ sh:hasValue () ] ) ;
+                    sh:path ngsi-ld:hasValue ;
+                    sh:property [ sh:datatype xsd:string ;
+                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path <http://my.test/entity/hasMyVariable3> ;
+            sh:property [ sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:or ( [ sh:nodeKind sh:BlankNode ] [ sh:hasValue () ] ) ;
+                    sh:path ngsi-ld:hasValue ;
+                    sh:property [ sh:datatype xsd:boolean ;
+                            sh:maxCount 2 ;
+                            sh:minCount 2 ;
+                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path <http://my.test/entity/hasMyVariable8> ;
+            sh:property [ sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:or ( [ sh:nodeKind sh:BlankNode ] [ sh:hasValue () ] ) ;
+                    sh:path ngsi-ld:hasValue ;
+                    sh:property [ sh:datatype xsd:string ;
+                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path <http://my.test/entity/hasMyVariable> ;
+            sh:property [ sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:or ( [ sh:nodeKind sh:BlankNode ] [ sh:hasValue () ] ) ;
+                    sh:path ngsi-ld:hasValue ;
+                    sh:property [ sh:datatype xsd:integer ;
+                            sh:maxCount 2 ;
+                            sh:minCount 2 ;
+                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ],
         [ sh:maxCount 1 ;
             sh:minCount 0 ;
             sh:nodeKind sh:BlankNode ;
@@ -82,22 +116,11 @@ shacl:BTypeShape a sh:NodeShape ;
         [ sh:maxCount 1 ;
             sh:minCount 0 ;
             sh:nodeKind sh:BlankNode ;
-            sh:path <http://my.test/entity/hasMyVariable> ;
+            sh:path <http://my.test/entity/hasMyVariable7> ;
             sh:property [ sh:maxCount 1 ;
                     sh:minCount 1 ;
-                    sh:path ngsi-ld:hasValue ;
-                    sh:property [ sh:datatype xsd:integer ;
-                            sh:maxCount 2 ;
-                            sh:minCount 2 ;
-                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ],
-        [ sh:maxCount 1 ;
-            sh:minCount 0 ;
-            sh:nodeKind sh:BlankNode ;
-            sh:path <http://my.test/entity/hasMyVariable5> ;
-            sh:property [ sh:maxCount 1 ;
-                    sh:minCount 1 ;
-                    sh:path ngsi-ld:hasValue ;
-                    sh:property [ sh:datatype xsd:string ;
-                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ] ;
+                    sh:or ( [ sh:datatype xsd:string ] [ sh:property [ sh:datatype xsd:string ;
+                                        sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ) ;
+                    sh:path ngsi-ld:hasValue ] ] ;
     sh:targetClass test:BType .
 

--- a/semantic-model/opcua/tests/extractType/test_variable_arrays.NodeSet2.xml
+++ b/semantic-model/opcua/tests/extractType/test_variable_arrays.NodeSet2.xml
@@ -92,6 +92,7 @@
     <Description>A custom object type B</Description>
     <References>
       <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1011</Reference>
     </References>
   </UAObjectType>
   <UAObject NodeId="ns=1;i=1003" BrowseName="1:B">
@@ -104,6 +105,8 @@
       <Reference ReferenceType="HasComponent">ns=1;i=1007</Reference>
       <Reference ReferenceType="HasComponent">ns=1;i=1008</Reference>
       <Reference ReferenceType="HasComponent">ns=1;i=1009</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1010</Reference>
+
     </References>
   </UAObject>
   <UAVariable NodeId="ns=1;i=1004" BrowseName="MyVariable" DataType="Int32" ValueRank="1" ArrayDimensions="2">
@@ -142,7 +145,18 @@
       <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
     </References>
   </UAVariable>
-
+  <UAVariable NodeId="ns=1;i=1010" BrowseName="MyVariable7" DataType="String" ValueRank="-2">
+    <DisplayName>Variable5 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+  </UAVariable>
+    <UAVariable NodeId="ns=1;i=1011" BrowseName="MyVariable8" DataType="String" ValueRank="1">
+    <DisplayName>Variable5 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+  </UAVariable>
 
 
 
@@ -193,6 +207,8 @@
       <Reference ReferenceType="HasComponent">ns=1;i=2016</Reference>
       <Reference ReferenceType="HasComponent">ns=1;i=2017</Reference>
       <Reference ReferenceType="HasComponent">ns=1;i=2018</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2019</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2020</Reference>
     </References>
   </UAObject>
   <UAVariable NodeId="ns=1;i=2013" BrowseName="MyVariable" DataType="Int32">
@@ -263,5 +279,21 @@
       <Value>
       <uax:String>42</uax:String>
       </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=2019" BrowseName="MyVariable7" DataType="String">
+    <DisplayName>Scalar or array Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+      <uax:ListOfString>
+      </uax:ListOfString>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=2020" BrowseName="MyVariable8" DataType="String">
+    <DisplayName>Scalar or array Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+      <uax:ListOfString>
+      </uax:ListOfString>
   </UAVariable>
 </UANodeSet>

--- a/semantic-model/opcua/tests/test_libentity.py
+++ b/semantic-model/opcua/tests/test_libentity.py
@@ -3,8 +3,14 @@ import unittest
 from unittest.mock import MagicMock, patch
 from rdflib import Graph, Namespace, URIRef, Literal
 from rdflib.namespace import RDF, OWL, RDFS
-from lib.entity import Entity
+from lib.entity import Entity, query_instance, query_default_instance
 import lib.utils as utils
+
+class DummyRow:
+    """Helper class to simulate a query result row with an 'instance' attribute."""
+    def __init__(self, instance):
+        self.instance = instance
+
 
 class TestEntity(unittest.TestCase):
 
@@ -62,5 +68,111 @@ class TestEntity(unittest.TestCase):
         self.assertIn((URIRef("http://example.org/s"), URIRef("http://example.org/p"), URIRef("http://example.org/o")), triples)
         graph.query.assert_called_once()
 
+
+    def test_get_contentclass_found(self):
+        """Test get_contentclass when a matching instance is found."""
+        # Create a dummy instance URI that the query should return.
+        dummy_instance = URIRef("http://example.org/instance")
+        dummy_result = [DummyRow(dummy_instance)]
+
+        # Patch the query method on the internal graph to return our dummy result.
+        self.entity_instance.e.query = MagicMock(return_value=dummy_result)
+
+        contentclass = URIRef("http://example.org/enumClass")
+        value = Literal("some value")
+
+        result = self.entity_instance.get_contentclass(contentclass, value)
+
+        # Verify that the query was called with the proper bindings.
+        expected_bindings = {'c': contentclass, 'value': value}
+        self.entity_instance.e.query.assert_called_once_with(
+            query_instance,
+            initBindings=expected_bindings,
+            initNs={'base': self.basens, 'opcua': self.opcuans}
+        )
+
+        # The method should return our dummy instance.
+        self.assertEqual(result, dummy_instance)
+
+    def test_get_contentclass_not_found(self):
+        """Test get_contentclass when no matching instance is found."""
+        # Simulate an empty query result.
+        self.entity_instance.e.query = MagicMock(return_value=[])
+
+        contentclass = URIRef("http://example.org/enumClass")
+        value = Literal("some value")
+
+        # Use the patch context manager to intercept print calls.
+        with patch('builtins.print') as mock_print:
+            result = self.entity_instance.get_contentclass(contentclass, value)
+
+        # Verify that the result is None.
+        self.assertIsNone(result)
+
+        # Verify that the warning message was printed.
+        mock_print.assert_called_once_with(
+            f'Warning: no instance found for class {contentclass} with value {value}'
+        )
+
+    def test_get_default_contentclass_found(self):
+        """Test get_default_contentclass when a default instance is found."""
+        dummy_instance = URIRef("http://example.org/default_instance")
+        dummy_result = [DummyRow(dummy_instance)]
+
+        self.entity_instance.e.query = MagicMock(return_value=dummy_result)
+
+        contentclass = URIRef("http://example.org/enumClass")
+        result = self.entity_instance.get_default_contentclass(contentclass)
+
+        expected_bindings = {'c': contentclass}
+        self.entity_instance.e.query.assert_called_once_with(
+            query_default_instance,
+            initBindings=expected_bindings,
+            initNs={'base': self.basens, 'opcua': self.opcuans}
+        )
+        self.assertEqual(result, dummy_instance)
+
+    def test_get_default_contentclass_not_found(self):
+        """Test get_default_contentclass when no default instance is found."""
+        self.entity_instance.e.query = MagicMock(return_value=[])
+
+        contentclass = URIRef("http://example.org/enumClass")
+        with patch('builtins.print') as mock_print:
+            result = self.entity_instance.get_default_contentclass(contentclass)
+
+        self.assertIsNone(result)
+        mock_print.assert_called_once_with(
+            f'Warning: no default instance found for class {contentclass}'
+        )
+
+    def test_create_ontolgoy_header_default(self):
+        """Test create_ontolgoy_header without providing a versionIRI."""
+        entity_ns = "http://example.org/ontology"
+        # Call the method without versionIRI.
+        self.entity_instance.create_ontolgoy_header(entity_ns)
+        graph = list(self.entity_instance.get_graph())
+
+        # Check that the ontology triple was added.
+        self.assertIn((URIRef(entity_ns), RDF.type, OWL.Ontology), graph)
+        # Check that the versionInfo triple was added.
+        self.assertIn((URIRef(entity_ns), OWL.versionInfo, Literal(0.1)), graph)
+        # Verify that no versionIRI triple was added.
+        versionIRI_triples = [triple for triple in graph if triple[0] == URIRef(entity_ns) and triple[1] == OWL.versionIRI]
+        self.assertEqual(len(versionIRI_triples), 0)
+
+    def test_create_ontolgoy_header_with_versionIRI(self):
+        """Test create_ontolgoy_header when a versionIRI is provided."""
+        entity_ns = "http://example.org/ontology"
+        versionIRI_value = URIRef("http://example.org/version")
+        # Call the method with a versionIRI.
+        self.entity_instance.create_ontolgoy_header(entity_ns, version=0.1, versionIRI=versionIRI_value)
+        graph = list(self.entity_instance.get_graph())
+
+        # Check that the ontology triple was added.
+        self.assertIn((URIRef(entity_ns), RDF.type, OWL.Ontology), graph)
+        # Check that the versionInfo triple was added.
+        self.assertIn((URIRef(entity_ns), OWL.versionInfo, Literal(0.1)), graph)
+        # Check that the versionIRI triple was added.
+        self.assertIn((URIRef(entity_ns), OWL.versionIRI, versionIRI_value), graph)
 if __name__ == "__main__":
     unittest.main()

--- a/semantic-model/opcua/tests/test_libshacl.py
+++ b/semantic-model/opcua/tests/test_libshacl.py
@@ -177,11 +177,14 @@ class TestShacl(unittest.TestCase):
         mock_serialize.assert_called_once_with(destination)
 
     @patch('lib.utils.get_datatype', return_value=URIRef("http://example.org/datatype"))
-    @patch('lib.jsonld.JsonLd.map_datatype_to_jsonld', return_value=Literal("xsd:string"))
-    def test_get_shacl_iri_and_contentclass(self, mock_map_datatype_to_jsonld, mock_get_datatype):
+    @patch('lib.jsonld.JsonLd.map_datatype_to_jsonld', return_value=(Literal("xsd:string"), None))
+    @patch('lib.utils.get_type_and_template', return_value=(URIRef("http://example.rog/typenode"), URIRef("http://example.rog/templatenode")))
+    @patch('lib.utils.get_rank_dimensions', return_value=(Literal(-1), RDF.nil))
+    def test_get_shacl_iri_and_contentclass(self, moch_get_rank_dimensions, mocK_get_type_and_templat, mock_map_datatype_to_jsonld, mock_get_datatype):
         """Test retrieving SHACL IRI and content class."""
         g = Graph()
         node = URIRef("http://example.org/node")
+        parentnode = URIRef("http://example.org/parentnode")
         shacl_rule = {}
 
         # Mocking graph objects - Case 1: Enumeration type
@@ -189,7 +192,7 @@ class TestShacl(unittest.TestCase):
             iter([URIRef("http://example.org/Enumeration")]),  # RDFS.subClassOf
         ])
 
-        self.shacl_instance.get_shacl_iri_and_contentclass(g, node, shacl_rule)
+        self.shacl_instance.get_shacl_iri_and_contentclass(g, node, parentnode, shacl_rule)
 
         self.assertFalse(shacl_rule['is_iri'])
         self.assertEqual(shacl_rule['contentclass'], None)
@@ -201,7 +204,7 @@ class TestShacl(unittest.TestCase):
         ])
         shacl_rule = {}
 
-        self.shacl_instance.get_shacl_iri_and_contentclass(g, node, shacl_rule)
+        self.shacl_instance.get_shacl_iri_and_contentclass(g, node, parentnode, shacl_rule)
 
         self.assertFalse(shacl_rule['is_iri'])
         self.assertIsNone(shacl_rule['contentclass'])
@@ -211,7 +214,7 @@ class TestShacl(unittest.TestCase):
         mock_get_datatype.return_value = None
         shacl_rule = {}
 
-        self.shacl_instance.get_shacl_iri_and_contentclass(g, node, shacl_rule)
+        self.shacl_instance.get_shacl_iri_and_contentclass(g, node, parentnode, shacl_rule)
 
         self.assertFalse(shacl_rule['is_iri'])
         self.assertIsNone(shacl_rule['contentclass'])
@@ -222,7 +225,7 @@ class TestShacl(unittest.TestCase):
         g.objects = MagicMock(side_effect=Exception("Mocked exception"))
         shacl_rule = {}
 
-        self.shacl_instance.get_shacl_iri_and_contentclass(g, node, shacl_rule)
+        self.shacl_instance.get_shacl_iri_and_contentclass(g, node, parentnode, shacl_rule)
 
         self.assertFalse(shacl_rule['is_iri'])
         self.assertIsNone(shacl_rule['contentclass'])

--- a/test/bats/test-bridges/test-alerta-bridge.bats
+++ b/test/bats/test-bridges/test-alerta-bridge.bats
@@ -104,7 +104,7 @@ teardown(){
     delete_all_test_alerts "$key"
     echo "# Alerta key: $key"
     send_to_kafka_bridge ${ALERTA_MSG} ${ALERTA_TOPIC}
-    sleep 2
+    sleep 3
     alerts=$(get_alerts "$key")
     length=$(echo "$alerts" | jq ".alerts | length ")
     id=$(echo "$alerts" | jq ".alerts[0].id"| tr -d '"')


### PR DESCRIPTION
This PR improves the lookup of template nodes and typenodes to make sure that missing attributes can be inherited.
For every node, in addition to the instance node it looks up the respective type node and template node. it then resolve the missing attributes in the order instance=>template=>type
The problem with the fully inherited instance declaration is that a type-node can only overwrite its direct descendents. All further descendents must have a template node starting from its parent type node. e.g. typeA=>B=>C can only overwrite B but not C. To make sure to inherit all C attributes correctly one has to check typeB=>C. Therefore the respective nodes must be retrieve with a sparql query.