### PR TITLE
Potential fix for code scanning alert no. 7: Missing rate limiting

### DIFF
--- a/FlinkSqlGateway/gateway.js
+++ b/FlinkSqlGateway/gateway.js
@@ -193,7 +193,7 @@ app.get('/health', appget);
 app.get('/v1/python_udf/:filename', limiter, udfget);
 
 app.post('/v1/sessions/:session_id/statements', apppost);
-app.post('/v1/python_udf/:filename', bodyParser.text(), udfpost);
+app.post('/v1/python_udf/:filename', limiter, bodyParser.text(), udfpost);
 
 if (runningAsMain) {
   if (!fs.existsSync(udfdir)) {


### PR DESCRIPTION
Potential fix for [https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/7](https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/7)

To fix the problem, we need to apply rate limiting to the `udfpost` endpoint to prevent potential denial-of-service attacks. This can be achieved by using the `express-rate-limit` middleware, which is already imported and configured in the provided code snippet. We will apply the existing `limiter` middleware to the `udfpost` endpoint.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
