### PR TITLE
Update validate.py tool to manage default settings for 'instance' mode.

### DIFF
--- a/semantic-model/opcua/tests/validation/test.bash
+++ b/semantic-model/opcua/tests/validation/test.bash
@@ -23,8 +23,8 @@ RESULTFILE=result.txt
 # Each test is defined as:
 # "TestName SHACLFILE TESTFILE [extra options]"
 tests=(
-  "RankValueTest ../../validation/ontology/rankValue.shacl.ttl ./rankValueTest.ttl -ni"
-  "HasComponentTest ../../validation/ontology/hasComponent.shacl.ttl ./hasComponentTest.ttl"
+  "RankValueTest ../../validation/ontology/rankValue.shacl.ttl ./rankValueTest.ttl -ni -m ontology"
+  "HasComponentTest ../../validation/ontology/hasComponent.shacl.ttl ./hasComponentTest.ttl -m ontology -ni"
 )
 
 for test in "${tests[@]}"; do


### PR DESCRIPTION
The tool has two modes, "ontology" and "instance"
"ontology" is for combination of *.ttl files whereas "instance" is for expanding context information for the regular pyshacl tests. The "instance" mode assumes now that the "exact" pyshacl mode is used, the input type (json-ld, ttl) is now derived from the filename if not given explicitly. In addition, when -e extra.ttl is not given, it is assumed to be "entities.ttl". This makes the default calling of validation in instance mode more convenient.