### PR TITLE
Potential fix for code scanning alert no. 32: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,4 +1,7 @@
 name: Nigthly
+permissions:
+  contents: read
+  packages: write
 on:
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
Potential fix for [https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/32](https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/32)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required. Since the workflow involves actions like checking out the repository and pushing Docker images, we will set `contents: read` for basic repository access and `packages: write` for pushing Docker images. This ensures that the workflow has only the permissions it needs.

The `permissions` block will be added at the top of the workflow, just below the `name` field, to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
