### PR TITLE
Potential fix for code scanning alert no. 25: Missing rate limiting

### DIFF
--- a/FlinkSqlGateway/gateway.js
+++ b/FlinkSqlGateway/gateway.js
@@ -192,7 +192,7 @@ app.use(express.json({ limit: '10mb' }));
 app.get('/health', appget);
 app.get('/v1/python_udf/:filename', limiter, udfget);
 
-app.post('/v1/sessions/:session_id/statements', apppost);
+app.post('/v1/sessions/:session_id/statements', limiter, apppost);
 app.post('/v1/python_udf/:filename', limiter, bodyParser.text(), udfpost);
 
 if (runningAsMain) {


### PR DESCRIPTION
Potential fix for [https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/25](https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/25)

To address the issue, we will apply the `express-rate-limit` middleware to the `apppost` route. This will limit the number of requests that can be made to this route within a specified time window, mitigating the risk of a DoS attack. The rate limiter is already defined in the code (`limiter`), so we will reuse it.

The changes will involve:
1. Adding the `limiter` middleware to the `apppost` route on line 195.
2. Ensuring no other functionality of the route is altered.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
