### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/FlinkSqlGateway/gateway.js
+++ b/FlinkSqlGateway/gateway.js
@@ -143,7 +143,12 @@ function apppost (request, response) {
 function udfget (req, res) {
   const filename = req.params.filename;
   logger.debug('python_udf get was requested for: ' + filename);
-  const fullname = `${udfdir}/${filename}.py`;
+  const fullname = path.resolve(udfdir, `${filename}.py`);
+  if (!fullname.startsWith(udfdir)) {
+    res.status(400).send('Invalid filename');
+    logger.error(`Invalid filename: ${filename}`);
+    return;
+  }
   try {
     fs.readFileSync(fullname);
   } catch (err) {
@@ -163,7 +168,12 @@ function udfpost (req, res) {
     return;
   }
   logger.debug(`python_udf with name ${filename}`);
-  const fullname = `${udfdir}/${filename}.py`;
+  const fullname = path.resolve(udfdir, `${filename}.py`);
+  if (!fullname.startsWith(udfdir)) {
+    res.status(400).send('Invalid filename');
+    logger.error(`Invalid filename: ${filename}`);
+    return;
+  }
   try {
     fs.writeFileSync(fullname, body);
   } catch (err) {


### PR DESCRIPTION
Potential fix for [https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/3](https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/3)

To fix the issue, we need to validate and sanitize the `filename` parameter before using it to construct the `fullname` path. The best approach is to ensure that:
1. The `filename` does not contain any path traversal sequences (e.g., `../`).
2. The constructed `fullname` path is normalized and verified to reside within the `udfdir` directory.

We will:
- Use the `path` module to resolve and normalize the `fullname` path.
- Check that the resolved `fullname` starts with the `udfdir` directory.
- Reject the request with an appropriate error message if the validation fails.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
