### PR TITLE
Expand HTTP Request handling of @context fields in NGSILD Bridge

### DIFF
--- a/KafkaBridge/lib/ngsild.js
+++ b/KafkaBridge/lib/ngsild.js
@@ -318,6 +318,12 @@ function fiwareApi (conf) {
    */
   this.createEntities = function (entities) {
     const data = entities;
+    let contentType = 'application/json';
+    const hasJsonLdContext = entities.some(entity => entity && entity['@context'] !== undefined);
+
+    if (hasJsonLdContext) {
+      contentType = 'application/ld+json';
+    }
 
     // return new Promise(function(resolve, reject) {
     const options = {
@@ -326,7 +332,7 @@ function fiwareApi (conf) {
       port: config.ngsildServer.port,
       path: '/ngsi-ld/v1/entityOperations/create',
       headers: {
-        'Content-Type': 'application/ld+json'
+        'Content-Type': contentType
       },
       method: 'POST'
     };
@@ -361,11 +367,18 @@ function fiwareApi (conf) {
    */
   this.replaceEntities = function (entities, isReplace, { headers }) {
     let queryString = '?options=replace';
+    let contentType = 'application/json';
     if (!isReplace) {
       queryString = '?options=update';
     }
+    const hasJsonLdContext = entities.some(entity => entity && entity['@context'] !== undefined);
+
+    if (hasJsonLdContext) {
+      contentType = 'application/ld+json';
+    }
+
     headers = headers || {};
-    headers['Content-Type'] = 'application/ld+json';
+    headers['Content-Type'] = contentType;
     const options = {
       hostname: config.ngsildServer.hostname,
       protocol: config.ngsildServer.protocol,
@@ -385,11 +398,17 @@ function fiwareApi (conf) {
    */
   this.updateEntities = function (entities, isOverwrite, { headers }) {
     let queryString = '';
+    let contentType = 'application/json';
+    const hasJsonLdContext = entities.some(entity => entity && entity['@context'] !== undefined);
+
+    if (hasJsonLdContext) {
+      contentType = 'application/ld+json';
+    }
     if (!isOverwrite) {
       queryString = '?options=noOverwrite';
     }
     headers = headers || {};
-    headers['Content-Type'] = 'application/ld+json';
+    headers['Content-Type'] = contentType;
     const options = {
       hostname: config.ngsildServer.hostname,
       protocol: config.ngsildServer.protocol,
@@ -505,8 +524,14 @@ function fiwareApi (conf) {
    * @param {array[Object]} headers - additional headers
    */
   this.batchMerge = function (entities, { headers }) {
+    let contentType = 'application/json';
+    const hasJsonLdContext = entities.some(entity => entity && entity['@context'] !== undefined);
+
+    if (hasJsonLdContext) {
+      contentType = 'application/ld+json';
+    }
     headers = headers || {};
-    headers['Content-Type'] = 'application/ld+json';
+    headers['Content-Type'] = contentType;
 
     const options = {
       hostname: config.ngsildServer.hostname,

--- a/KafkaBridge/test/testLibNgsild.js
+++ b/KafkaBridge/test/testLibNgsild.js
@@ -340,7 +340,7 @@ describe('Test createEntities', function () {
       method: 'POST',
       path: '/ngsi-ld/v1/entityOperations/create',
       headers: {
-        'Content-Type': 'application/ld+json'
+        'Content-Type': 'application/json'
       }
     };
     const rest = {
@@ -384,7 +384,7 @@ describe('Test replaceEntities', function () {
       method: 'POST',
       path: '/ngsi-ld/v1/entityOperations/upsert?options=replace',
       headers: {
-        'Content-Type': 'application/ld+json',
+        'Content-Type': 'application/json',
         header: 'header'
       }
     };
@@ -429,7 +429,7 @@ describe('Test replaceEntities', function () {
       method: 'POST',
       path: '/ngsi-ld/v1/entityOperations/upsert?options=update',
       headers: {
-        'Content-Type': 'application/ld+json',
+        'Content-Type': 'application/json',
         header: 'header'
       }
     };
@@ -895,7 +895,7 @@ describe('Test updateEntities', function () {
       method: 'POST',
       path: '/ngsi-ld/v1/entityOperations/update',
       headers: {
-        'Content-Type': 'application/ld+json',
+        'Content-Type': 'application/json',
         header: 'header'
       }
     };
@@ -940,7 +940,7 @@ describe('Test updateEntities', function () {
       method: 'POST',
       path: '/ngsi-ld/v1/entityOperations/update?options=noOverwrite',
       headers: {
-        'Content-Type': 'application/ld+json',
+        'Content-Type': 'application/json',
         header: 'header'
       }
     };
@@ -1000,8 +1000,8 @@ describe('Test batchMerge', function () {
     };
 
     const entities = [
-      { id: 'id1', type: 'type1', attr1: 'value1' },
-      { id: 'id2', type: 'type2', attr2: 'value2' }
+      { id: 'id1', type: 'type1', '@context': 'https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld', attr1: 'value1' },
+      { id: 'id2', type: 'type2', '@context': 'https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld', attr2: 'value2' }
     ];
 
     const revert = ToTest.__set__('Logger', Logger);

--- a/helm/install_operators.sh
+++ b/helm/install_operators.sh
@@ -185,7 +185,7 @@ if [ "$OFFLINE" = "true" ]; then
 else
   helm repo add flink-kubernetes-operator https://downloads.apache.org/flink/flink-kubernetes-operator-1.11.0
   helm repo update
-  helm -n ${NAMESPACE} install flink-kubernetes-operator flink-operator-repo/flink-kubernetes-operator --set image.repository="${FLINK_OPERATOR_IMAGE_REGISTRY}/flink-operator" --set image.tag="${DOCKER_TAG}"
+  helm -n ${NAMESPACE} install flink-kubernetes-operator flink-kubernetes-operator/flink-kubernetes-operator --set image.repository="${FLINK_OPERATOR_IMAGE_REGISTRY}/flink-operator" --set image.tag="${DOCKER_TAG}"
 
 fi
 

--- a/test/bats/test-bridges/test-debezium-bridge.bats
+++ b/test/bats/test-bridges/test-debezium-bridge.bats
@@ -24,9 +24,10 @@ KAFKACAT_ENTITY_PLASMACUTTER_NAME=plasmacutter_test
 KAFKACAT_ENTITY_PLASMACUTTER_TOPIC=iff.ngsild.entities
 PLASMACUTTER_ID=urn:plasmacutter-test:12345
 GEOCUTTER_ID=urn:geocutter-test:12345
+CONTEXT=https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld
 cat << EOF > ${CUTTER}
 {
-    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "@context": "${CONTEXT}",
     "id": "${PLASMACUTTER_ID}",
     "type": "https://industry-fusion.com/types/v0.9/${KAFKACAT_ENTITY_PLASMACUTTER_NAME}",
     "https://industry-fusion.com/types/v0.9/state": [
@@ -94,7 +95,7 @@ EOF
 
 cat << EOF > ${CUTTER_TIMESTAMPED}
 {
-    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+    "@context": "${CONTEXT}",
     "id": "${PLASMACUTTER_ID}",
     "type": "https://industry-fusion.com/types/v0.9/${KAFKACAT_ENTITY_PLASMACUTTER_NAME}",
     "https://industry-fusion.com/types/v0.9/state": [
@@ -128,7 +129,7 @@ EOF
 
 cat << EOF > ${CUTTER_SUBATTRIBUTES}
 {
-    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+    "@context": "${CONTEXT}",
     "id": "${PLASMACUTTER_ID}",
     "type": "https://industry-fusion.com/types/v0.9/${KAFKACAT_ENTITY_PLASMACUTTER_NAME}",
     "https://industry-fusion.com/types/v0.9/state": [
@@ -192,7 +193,7 @@ EOF
 
 cat << EOF > ${GEOCUTTER_ATTRIBUTES}
 {
-    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+    "@context": "${CONTEXT}",
     "id": "${GEOCUTTER_ID}",
     "type": "https://industry-fusion.com/types/v0.9/${KAFKACAT_ENTITY_PLASMACUTTER_NAME}",
     "https://uri.etsi.org/ngsi-ld/location": [

--- a/test/bats/test-bridges/test-ngsild-updates-bridge.bats
+++ b/test/bats/test-bridges/test-ngsild-updates-bridge.bats
@@ -34,7 +34,6 @@ cat << EOF | tr -d '\n' > ${UPSERT_FILTER}
     "overwriteOrReplace": "false",
     "entities": [
         {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
         "id": "${FILTER_ID}",
         "type": "${FILTER_TYPE}",
         "https://industry-fusion.com/types/v0.9/state": {
@@ -63,7 +62,6 @@ cat << EOF | tr -d '\n' > ${UPSERT_FILTER_TIMESTAMPED}
     "overwriteOrReplace": "false",
     "entities": [
         {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
         "id": "${FILTER_ID}",
         "type": "${FILTER_TYPE}",
         "https://industry-fusion.com/types/v0.9/state": {
@@ -94,7 +92,6 @@ cat << EOF | tr -d '\n' > ${UPSERT_FILTER_OVERWRITE}
     "overwriteOrReplace": "true",
     "entities": [
         {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
         "id": "${FILTER_ID}",
         "type": "${FILTER_TYPE}",
         "https://industry-fusion.com/types/v0.9/state": {
@@ -127,7 +124,6 @@ cat << EOF | tr -d '\n' > ${UPSERT_FILTER_NON_OVERWRITE}
     "overwriteOrReplace": false,
     "entities": [
         {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
         "id": "${FILTER_ID}",
         "type": "${FILTER_TYPE}",
         "https://industry-fusion.com/types/v0.9/state": {
@@ -166,7 +162,6 @@ cat << EOF | tr -d '\n' > ${UPDATE_FILTER}
     "overwriteOrReplace": "true",
     "entities": [
         {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
         "id": "${FILTER_ID}",
         "type": "${FILTER_TYPE}",
         "https://industry-fusion.com/types/v0.9/state": {
@@ -193,7 +188,6 @@ cat << EOF | tr -d '\n' > ${UPDATE_FILTER_NO_OVERWRITE}
     "overwriteOrReplace": false,
     "entities": [
         {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
         "id": "${FILTER_ID}",
         "type": "${FILTER_TYPE}",
         "https://industry-fusion.com/types/v0.9/state": {
@@ -225,7 +219,6 @@ cat << EOF | tr -d '\n' > ${UPDATE_FILTER_MERGE}
     "overwriteOrReplace": "false",
     "entities": [
         {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
         "id": "${FILTER_ID}",
         "https://industry-fusion.com/types/v0.9/strength": {
           "datasetId": "https://example.com/source1",
@@ -249,7 +242,6 @@ timestamp_upsert_2_entities(){
     "overwriteOrReplace": "false",
     "entities": [
         {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
         "id": "${FILTER_ID}",
         "type": "${FILTER_TYPE}",
         "https://industry-fusion.com/types/v0.9/state": {
@@ -271,7 +263,6 @@ timestamp_upsert_2_entities(){
         }
       },
       {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
         "id": "${CUTTER_ID}",
         "type": "${PLASMACUTTER_TYPE}",
         "https://industry-fusion.com/types/v0.9/state": {
@@ -303,7 +294,6 @@ timestamp_upsert_2_entities2(){
     "overwriteOrReplace": "false",
     "entities": [
         {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
         "id": "${FILTER_ID}",
         "type": "https://industry-fusion.com/types/v0.9/filter",
         "https://industry-fusion.com/types/v0.9/state": {
@@ -324,7 +314,6 @@ timestamp_upsert_2_entities2(){
         }
       },
       {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
         "id": "${CUTTER_ID}",
         "type": "${PLASMACUTTER_TYPE}",
         "https://industry-fusion.com/types/v0.9/state": {
@@ -356,7 +345,6 @@ timestamp_update_2_entities(){
     "overwriteOrReplace": "true",
     "entities": [
         {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
         "id": "${FILTER_ID}",
         "type": "${FILTER_TYPE}",
         "https://industry-fusion.com/types/v0.9/state": {
@@ -377,7 +365,6 @@ timestamp_update_2_entities(){
         }
       },
       {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
         "id": "${CUTTER_ID}",
         "type": "${PLASMACUTTER_TYPE}",
         "https://industry-fusion.com/types/v0.9/state": {
@@ -409,7 +396,6 @@ timestamp_update_2_entities2(){
     "overwriteOrReplace": "true",
     "entities": [
         {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
         "id": "${FILTER_ID}",
         "type": "${FILTER_TYPE}",
         "https://industry-fusion.com/types/v0.9/state": {
@@ -430,7 +416,6 @@ timestamp_update_2_entities2(){
         }
       },
       {
-        "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
         "id": "${CUTTER_ID}",
         "type": "${PLASMACUTTER_TYPE}",
         "https://industry-fusion.com/types/v0.9/state": {


### PR DESCRIPTION
Now dynamically adapts the Content-Type header based on the presence of @context key in any entity when batch operations are run. Also includes a typo fix for install_operators.sh script.

Closes: #723
Closes: #724
Closes: #728