### PR TITLE
Replacement for port forward while deploying flink jobs, runner cleanup job

### DIFF
--- a/.github/workflows/docker-clean.yaml
+++ b/.github/workflows/docker-clean.yaml
@@ -1,0 +1,27 @@
+name: Docker cache cleanup
+
+on:
+  schedule:
+    # Runs every day at 11:00 UTC
+    # ≈ 06:00 EST (winter). Adjust if you care about DST.
+    - cron: '0 11 * * *'
+
+jobs:
+  clean-docker:
+    runs-on: [self-hosted]  # <-- use your runner's labels
+    steps:
+      - name: Docker usage before prune (for logging)
+        run: |
+          docker ps -a
+          docker images
+          docker volume ls || true
+
+      - name: Hard prune docker
+        run: |
+          docker system prune -af --volumes
+
+      - name: Docker usage after prune (for logging)
+        run: |
+          docker ps -a
+          docker images
+          docker volume ls || true

--- a/semantic-model/shacl2flink/Makefile
+++ b/semantic-model/shacl2flink/Makefile
@@ -188,23 +188,22 @@ ontology2kms:
 	/bin/bash -O extglob -c 'echo creating knowledge.ttl with $${ontpattern} $(ONTDIR)/!(*_shacl.ttl|*.html|*.jsonld|*.txt); rdfpipe -i ttl -o ttl $${ontpattern} $(ONTDIR)/!(*_shacl.ttl|*.html|*.jsonld|*.txt) > ../kms/knowledge.ttl'; \
 	echo creating shacl.ttl with $${shaclpattern}; rdfpipe -i ttl -o ttl $${shaclpattern} > ../kms/shacl.ttl
 
-start-database-service:
-	POD=$$(kubectl -n $(NAMESPACE) get ep $(FLINK_DATABASE_SERVICE)   -o jsonpath='{.subsets[0].addresses[0].targetRef.name}') && \
-	kubectl -n $(NAMESPACE) port-forward pod/$${POD} $(FLINK_DATABASE_PORT):$(FLINK_DATABASE_PORT) &
+# start-database-service:
+# 	POD=$$(kubectl -n $(NAMESPACE) get ep $(FLINK_DATABASE_SERVICE)   -o jsonpath='{.subsets[0].addresses[0].targetRef.name}') && \
+# 	kubectl -n $(NAMESPACE) port-forward pod/$${POD} $(FLINK_DATABASE_PORT):$(FLINK_DATABASE_PORT) &
 
-stop-database-service:
-	killall -9 kubectl >/dev/null 2>&1 || echo "No database service found to stop"
+# stop-database-service:
+# 	killall -9 kubectl >/dev/null 2>&1 || echo "No database service found to stop"
 
 submit-postgres-tables:
 	@echo Create RDF table in database
-	make start-database-service
 	@FLINK_USER_SECRET=$$(kubectl -n $(NAMESPACE) get secrets | grep $(FLINK_DATABASE_USER) | cut -d " " -f 1) && \
 	echo usersecret $${FLINK_USER_SECRET} from $(FLINK_DATABASE_USER) which is transformed from $(FLINK_DATABASE_USER_NAME) && \
-	PGPASSWORD=$$(kubectl -n $(NAMESPACE) get secret $${FLINK_USER_SECRET} -o go-template='{{index .data "password" | base64decode}}') && export PGPASSWORD=$${PGPASSWORD} && \
-	cat $(OUTPUTDIR)/rdf.postgres | PGSSLMODE=require psql -h localhost -U $(FLINK_DATABASE_USER_NAME) -d $(FLINK_DATABASE) && \
-	cat $(OUTPUTDIR)/ngsild.postgres | PGSSLMODE=require psql -h localhost -U $(FLINK_DATABASE_USER_NAME) -d $(FLINK_DATABASE) && \
-	cat $(OUTPUTDIR)/shacl-constraints.postgres | PGSSLMODE=require psql -h localhost -U $(FLINK_DATABASE_USER_NAME) -d $(FLINK_DATABASE)
-	make stop-database-service
+	PGPASSWORD=$$(kubectl -n $(NAMESPACE) get secret $${FLINK_USER_SECRET} -o go-template='{{index .data "password" | base64decode}}') && \
+	POD=$$(kubectl -n $(NAMESPACE) get ep $(FLINK_DATABASE_SERVICE) -o jsonpath='{.subsets[0].addresses[0].targetRef.name}') && \
+	kubectl -n $(NAMESPACE) exec -i $${POD} -- bash -c "PGPASSWORD='$${PGPASSWORD}' PGSSLMODE=require psql -h localhost -U $(FLINK_DATABASE_USER_NAME) -d $(FLINK_DATABASE)" < $(OUTPUTDIR)/rdf.postgres && \
+	kubectl -n $(NAMESPACE) exec -i $${POD} -- bash -c "PGPASSWORD='$${PGPASSWORD}' PGSSLMODE=require psql -h localhost -U $(FLINK_DATABASE_USER_NAME) -d $(FLINK_DATABASE)" < $(OUTPUTDIR)/ngsild.postgres && \
+	kubectl -n $(NAMESPACE) exec -i $${POD} -- bash -c "PGPASSWORD='$${PGPASSWORD}' PGSSLMODE=require psql -h localhost -U $(FLINK_DATABASE_USER_NAME) -d $(FLINK_DATABASE)" < $(OUTPUTDIR)/shacl-constraints.postgres
 
 clean:
 	@rm -rf $(OUTPUTDIR)


### PR DESCRIPTION
1. Adds a CRON action to clean the docker cache in the self-hosted runners every day at 6AM to avoid failures in pushing images.
2. Replaces "kubectl port-forward" of acid-cluster with"kubectl exec" in "flink-deploy" Makefile step.