### PR TITLE
Add Shacl shapes for value-ranks

### DIFF
--- a/semantic-model/opcua/extractType.py
+++ b/semantic-model/opcua/extractType.py
@@ -153,6 +153,10 @@ parse nodeset instance and create ngsi-ld model')
                         help='List of Warnings which are to be suppressed.')
     parser.add_argument('-p', '--properties', help='Consider OPC UA Properties.', required=False, default=False,
                         action='store_true')
+    parser.add_argument('-vrs', '--value-rank-subshapes', help='Add ValueRank subshapes (instead of nest '
+                        'the whole expression).',
+                        required=False, default=False,
+                        action='store_true')
 
     parsed_args = parser.parse_args(args)
     return parsed_args
@@ -640,6 +644,7 @@ if __name__ == '__main__':
     context_url = args.context_url
     entity_namespace = args.entity_namespace
     parse_properties = args.properties
+    value_rank_subshapes_enabled = args.value_rank_subshapes
 
     # create the context_graph
     # Context graph is resolving the context_url and provides just the
@@ -681,7 +686,7 @@ if __name__ == '__main__':
     bindingsg = Bindings(namespace_prefix, basens)
     bindingsg.bind('base', basens)
     bindingsg.bind('binding', binding_namespace)
-    shaclg = Shacl(g, namespace_prefix, basens, opcuans)
+    shaclg = Shacl(g, namespace_prefix, basens, opcuans, value_rank_subshapes_enabled=value_rank_subshapes_enabled)
     shaclg.bind('shacl', shacl_namespace)
     shaclg.bind('ngsi-ld', ngsildns)
     shaclg.bind('sh', SH)

--- a/semantic-model/opcua/lib/utils.py
+++ b/semantic-model/opcua/lib/utils.py
@@ -103,6 +103,17 @@ def isNodeId(nodeId):
     return 'i=' in nodeId or 'g=' in nodeId or 's=' in nodeId
 
 
+def collection_to_list(collection, datagraph: Graph):
+    """Convert an RDF collection to a Python list."""
+    if collection is None:
+        return None
+    ad = Collection(datagraph, collection)
+    col_list = []
+    if len(ad) > 0:
+        col_list = [item.toPython() for item in ad]
+    return col_list
+
+
 def expand_term(graph: Graph, value: str):
     """
     Return a URIRef:
@@ -143,6 +154,36 @@ def create_node_ref(idtype, id, nsuri, basens):
 
 def rdfStringToPythonBool(literal):
     return str(literal).strip().lower() == "true"
+
+
+def rank_value_to_string(value):
+    """Convert an OPC UA rank value to its string representation.
+    ValueRank meanings:
+    -3: ScalarOrOneDimension
+    -2: Any
+    -1: Scalar
+     0: OneOrMoreDimensions
+     1: OneDimension
+     >1: nDimensions
+
+    Args:
+        value (int): str
+    """
+    rank = int(value)
+    if rank == -3:
+        return 'ScalarOrOneDimension'
+    elif rank == -2:
+        return 'Any'
+    elif rank == -1:
+        return 'Scalar'
+    elif rank == 0:
+        return 'OneOrMoreDimensions'
+    elif rank == 1:
+        return 'OneDimension'
+    elif rank > 1:
+        return f'{rank}Dimensions'
+    else:
+        return 'UnknownRank'
 
 
 def convert_to_json_type(result, basic_json_type):
@@ -187,13 +228,6 @@ def get_datatype(graph, node, typenode, templatenode, basens):
         if datatype is None and typenode is not None:
             datatype = next(graph.objects(typenode, basens['hasDatatype']), None)
     return datatype
-# def get_datatype(graph, node, typenode, templatenode, basens):
-#     datatype = next(graph.objects(node, basens['hasDatatype']), None)
-#     if datatype is None:
-#         datatype = next(graph.objects(templatenode, basens['hasDatatype']), None)
-#         if datatype is None:
-#             datatype = next(graph.objects(typenode, basens['hasDatatype']), None)
-#     return datatype
 
 
 def attributename_from_type(type):

--- a/semantic-model/opcua/shacl_valuerank_constraints.ttl
+++ b/semantic-model/opcua/shacl_valuerank_constraints.ttl
@@ -1,0 +1,94 @@
+@prefix base: <https://industryfusion.github.io/contexts/ontology/v0/base/> .
+@prefix opcua: <http://opcfoundation.org/UA/> .
+@prefix ngsi-ld: <https://uri.etsi.org/ngsi-ld/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix shacl: <http://my.test/shacl/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix opcvrc: <http://opcfoundation.org/constraints/valueRanks> .
+
+# Rankvalue for "any" for boolean datatype
+opcvrc:ValueRankContraint_any_Boolean
+    a sh:NodeShape ;
+    sh:message "ValueRank Constraint: any for Boolean datatype failed" ;
+    sh:or (
+        # Option 1: a node that has ngsi-ld:hasValue as exactly one boolean literal
+        [
+            sh:property [
+                sh:path ngsi-ld:hasValue ;
+                sh:nodeKind sh:Literal ;
+                sh:datatype xsd:boolean ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ]
+        ]
+
+        # Option 2: a node that has ngsi-ld:hasValueList with exactly one value,
+        # where that value is either:
+        #   - a blank node whose rdf:List elements are booleans, OR
+        #   - the empty list ()
+        [
+            sh:property [
+                sh:path ngsi-ld:hasValueList ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+
+                sh:or (
+                    [
+                        sh:nodeKind sh:BlankNode ;
+                        sh:property [
+                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+                            sh:datatype xsd:boolean ;
+                        ]
+                    ]
+                    [
+                        sh:hasValue () ;
+                    ]
+                ) ;
+            ]
+        ]
+    ) .
+
+# Rankvalue for "any" for double datatype
+opcvrc:ValueRankContraint_any_Double
+    a sh:NodeShape ;
+    sh:message "ValueRank Constraint: any for Double datatype failed" ;
+    sh:or (
+        # Option 1: a node that has ngsi-ld:hasValue as exactly one double literal
+        [
+            sh:property [
+                sh:path ngsi-ld:hasValue ;
+                sh:nodeKind sh:Literal ;
+                sh:datatype xsd:double ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+            ]
+        ]
+
+        # Option 2: a node that has ngsi-ld:hasValueList with exactly one value,
+        # where that value is either:
+        #   - a blank node whose rdf:List elements are doubles, OR
+        #   - the empty list ()
+        [
+            sh:property [
+                sh:path ngsi-ld:hasValueList ;
+                sh:minCount 1 ;
+                sh:maxCount 1 ;
+
+                sh:or (
+                    [
+                        sh:nodeKind sh:BlankNode ;
+                        sh:property [
+                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+                            sh:datatype xsd:double ;
+                        ]
+                    ]
+                    [
+                        sh:hasValue () ;
+                    ]
+                ) ;
+            ]
+        ]
+    ) .

--- a/semantic-model/opcua/tests/extractType/test.bash
+++ b/semantic-model/opcua/tests/extractType/test.bash
@@ -36,8 +36,10 @@ if [ "$DEBUG" = "true" ]; then
     DEBUG_CMDLINE="-m debugpy --listen 5678"
 fi
 TESTNODESETS=(
-    test_object_example.NodeSet2,${EXURI}AlphaType,,,,,${EXURI}
+    test_variable_arrays_vrs.NodeSet2,${TESTURI}AlphaType,,,-vrs
+    test_variable_arrays.NodeSet2,${TESTURI}AlphaType
     test_pumps_instanceexample,http://opcfoundation.org/UA/Pumps/PumpType,http://yourorganisation.org/InstanceExample/,pumps
+    test_object_example.NodeSet2,${EXURI}AlphaType,,,,,${EXURI}
     test_interfaces.NodeSet2,${TESTURI}AlphaType,,machinery,-p,INTERFACE_NOT_SUBTYPE_OF_INTERFACETYPE
     test_reference_types_properties.Nodeset2,${TESTURI}AlphaType,,,-p
     test_reference_types.Nodeset2,${TESTURI}AlphaType
@@ -45,7 +47,6 @@ TESTNODESETS=(
     test_object_foldertype_tree.NodeSet2,,,machinery,-ma
     test_object_subtypes_inheritance_wrong.Nodeset2,${TESTURI}AlphaSubType,,,,SUBCLASS_INCONSISTENCY
     test_object_subtypes_inheritance.Nodeset2,${TESTURI}AlphaType
-    test_variable_arrays.NodeSet2,${TESTURI}AlphaType
     test_object_wrong.NodeSet2,${TESTURI}AlphaType
     test_object_overwrite_type.NodeSet2,${TESTURI}AlphaType
     test_variable_enum.NodeSet2,${TESTURI}AlphaType

--- a/semantic-model/opcua/tests/extractType/test_variable_arrays.NodeSet2.pyshacl
+++ b/semantic-model/opcua/tests/extractType/test_variable_arrays.NodeSet2.pyshacl
@@ -9,26 +9,6 @@
 [] a sh:ValidationReport ;
     sh:conforms false ;
     sh:result [ a sh:ValidationResult ;
-            sh:focusNode ( 99 ) ;
-            sh:resultMessage "Less than 2 values on ( Literal(\"99\", datatype=xsd:integer) )->( [ sh:zeroOrMorePath rdf:rest ] rdf:first )" ;
-            sh:resultPath ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
-            sh:resultSeverity sh:Violation ;
-            sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
-            sh:sourceShape [ sh:datatype xsd:integer ;
-                    sh:maxCount 2 ;
-                    sh:minCount 2 ;
-                    sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ],
-        [ a sh:ValidationResult ;
-            sh:focusNode ( "x" "y" "z" ) ;
-            sh:resultMessage "More than 2 values on ( Literal(\"x\") Literal(\"y\") Literal(\"z\") )->( [ sh:zeroOrMorePath rdf:rest ] rdf:first )" ;
-            sh:resultPath ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
-            sh:resultSeverity sh:Violation ;
-            sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
-            sh:sourceShape [ sh:datatype xsd:string ;
-                    sh:maxCount 2 ;
-                    sh:minCount 2 ;
-                    sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ],
-        [ a sh:ValidationResult ;
             sh:focusNode [ a ngsi-ld:ListProperty ;
                     ngsi-ld:hasValueList () ] ;
             sh:resultMessage "Value is not of Node Kind sh:BlankNode" ;
@@ -45,19 +25,15 @@
                             sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ;
             sh:value () ],
         [ a sh:ValidationResult ;
-            sh:focusNode [ a ngsi-ld:ListProperty ;
-                    ngsi-ld:hasValueList ( 0e+00 1e+00 ) ] ;
-            sh:resultMessage "Node ( Literal(\"0.0\", datatype=xsd:double) Literal(\"1.0\", datatype=xsd:double) ) does not conform to one or more shapes in [ sh:nodeKind sh:BlankNode ; sh:property [ sh:datatype xsd:integer ; sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] , [ sh:hasValue rdf:nil ]" ;
-            sh:resultPath ngsi-ld:hasValueList ;
+            sh:focusNode ( "x" "y" "z" ) ;
+            sh:resultMessage "More than 2 values on ( Literal(\"x\") Literal(\"y\") Literal(\"z\") )->( [ sh:zeroOrMorePath rdf:rest ] rdf:first )" ;
+            sh:resultPath ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
             sh:resultSeverity sh:Violation ;
-            sh:sourceConstraintComponent sh:OrConstraintComponent ;
-            sh:sourceShape [ sh:maxCount 1 ;
-                    sh:minCount 1 ;
-                    sh:or ( [ sh:nodeKind sh:BlankNode ;
-                                sh:property [ sh:datatype xsd:integer ;
-                                        sh:path ( [ ] rdf:first ) ] ] [ sh:hasValue () ] ) ;
-                    sh:path ngsi-ld:hasValueList ] ;
-            sh:value ( 0e+00 1e+00 ) ],
+            sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
+            sh:sourceShape [ sh:datatype xsd:string ;
+                    sh:maxCount 2 ;
+                    sh:minCount 2 ;
+                    sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ],
         [ a sh:ValidationResult ;
             sh:focusNode <http://my.test/testid:i2012> ;
             sh:resultMessage "Node [ <https://uri.etsi.org/ngsi-ld/hasValue> Literal(\"1\", datatype=xsd:integer) ; rdf:type <https://uri.etsi.org/ngsi-ld/Property> ] does not conform to one or more shapes in [ sh:property [ sh:datatype xsd:double ; sh:maxCount Literal(\"1\", datatype=xsd:integer) ; sh:minCount Literal(\"1\", datatype=xsd:integer) ; sh:nodeKind sh:Literal ; sh:path ngsi-ld:hasValue ] ] , [ sh:property [ sh:maxCount Literal(\"1\", datatype=xsd:integer) ; sh:minCount Literal(\"1\", datatype=xsd:integer) ; sh:or ( [ sh:nodeKind sh:BlankNode ; sh:property [ sh:datatype xsd:double ; sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] [ sh:hasValue rdf:nil ] ) ; sh:path ngsi-ld:hasValueList ] ]" ;
@@ -80,8 +56,32 @@
             sh:value [ a ngsi-ld:Property ;
                     ngsi-ld:hasValue 1 ] ],
         [ a sh:ValidationResult ;
+            sh:focusNode [ a ngsi-ld:ListProperty ;
+                    ngsi-ld:hasValueList ( 0e+00 1e+00 ) ] ;
+            sh:resultMessage "Node ( Literal(\"0.0\", datatype=xsd:double) Literal(\"1.0\", datatype=xsd:double) ) does not conform to one or more shapes in [ sh:nodeKind sh:BlankNode ; sh:property [ sh:datatype xsd:integer ; sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] , [ sh:hasValue rdf:nil ]" ;
+            sh:resultPath ngsi-ld:hasValueList ;
+            sh:resultSeverity sh:Violation ;
+            sh:sourceConstraintComponent sh:OrConstraintComponent ;
+            sh:sourceShape [ sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:or ( [ sh:nodeKind sh:BlankNode ;
+                                sh:property [ sh:datatype xsd:integer ;
+                                        sh:path ( [ ] rdf:first ) ] ] [ sh:hasValue () ] ) ;
+                    sh:path ngsi-ld:hasValueList ] ;
+            sh:value ( 0e+00 1e+00 ) ],
+        [ a sh:ValidationResult ;
             sh:focusNode () ;
             sh:resultMessage "Less than 2 values on rdf:nil->( [ sh:zeroOrMorePath rdf:rest ] rdf:first )" ;
+            sh:resultPath ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+            sh:resultSeverity sh:Violation ;
+            sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+            sh:sourceShape [ sh:datatype xsd:integer ;
+                    sh:maxCount 2 ;
+                    sh:minCount 2 ;
+                    sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ],
+        [ a sh:ValidationResult ;
+            sh:focusNode ( 99 ) ;
+            sh:resultMessage "Less than 2 values on ( Literal(\"99\", datatype=xsd:integer) )->( [ sh:zeroOrMorePath rdf:rest ] rdf:first )" ;
             sh:resultPath ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
             sh:resultSeverity sh:Violation ;
             sh:sourceConstraintComponent sh:MinCountConstraintComponent ;

--- a/semantic-model/opcua/tests/extractType/test_variable_arrays_vrs.NodeSet2.instances
+++ b/semantic-model/opcua/tests/extractType/test_variable_arrays_vrs.NodeSet2.instances
@@ -1,0 +1,1 @@
+test_variable_arrays.NodeSet2.instances

--- a/semantic-model/opcua/tests/extractType/test_variable_arrays_vrs.NodeSet2.pyshacl
+++ b/semantic-model/opcua/tests/extractType/test_variable_arrays_vrs.NodeSet2.pyshacl
@@ -1,0 +1,166 @@
+@prefix base: <https://industryfusion.github.io/contexts/ontology/v0/base/> .
+@prefix ngsi-ld: <https://uri.etsi.org/ngsi-ld/> .
+@prefix opcua: <http://opcfoundation.org/UA/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix shacl: <http://my.test/shacl/> .
+@prefix test: <http://my.test/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+[] a sh:ValidationReport ;
+    sh:conforms false ;
+    sh:result [ a sh:ValidationResult ;
+            sh:detail [ a sh:ValidationResult ;
+                    sh:focusNode ( 99 ) ;
+                    sh:resultMessage "Less than 2 values on ( Literal(\"99\", datatype=xsd:integer) )->( [ sh:zeroOrMorePath rdf:rest ] rdf:first )" ;
+                    sh:resultPath _:n31706d49d34148b084f4b0c470e5cd0fb112 ;
+                    sh:resultSeverity sh:Violation ;
+                    sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+                    sh:sourceShape _:n31706d49d34148b084f4b0c470e5cd0fb110 ] ;
+            sh:focusNode <http://my.test/testid:i2012> ;
+            sh:resultMessage "Value does not conform to Shape shacl:ValueRankShape_OneDimension_integer_2. See details for more information." ;
+            sh:resultPath test:hasMyVariable12 ;
+            sh:resultSeverity sh:Violation ;
+            sh:sourceConstraintComponent sh:NodeConstraintComponent ;
+            sh:sourceShape [ sh:maxCount 1 ;
+                    sh:minCount 0 ;
+                    sh:node shacl:ValueRankShape_OneDimension_integer_2 ;
+                    sh:nodeKind sh:BlankNode ;
+                    sh:path test:hasMyVariable12 ;
+                    base:hasReferenceType opcua:HasComponent ] ;
+            sh:value [ a ngsi-ld:ListProperty ;
+                    ngsi-ld:hasValueList ( 99 ) ] ],
+        [ a sh:ValidationResult ;
+            sh:detail [ a sh:ValidationResult ;
+                    sh:focusNode ( "x" "y" "z" ) ;
+                    sh:resultMessage "More than 2 values on ( Literal(\"x\") Literal(\"y\") Literal(\"z\") )->( [ sh:zeroOrMorePath rdf:rest ] rdf:first )" ;
+                    sh:resultPath ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ;
+                    sh:resultSeverity sh:Violation ;
+                    sh:sourceConstraintComponent sh:MaxCountConstraintComponent ;
+                    sh:sourceShape [ sh:datatype xsd:string ;
+                            sh:maxCount 2 ;
+                            sh:minCount 2 ;
+                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ;
+            sh:focusNode <http://my.test/testid:i2012> ;
+            sh:resultMessage "Value does not conform to Shape shacl:ValueRankShape_OneDimension_string_2. See details for more information." ;
+            sh:resultPath test:hasMyVariable11 ;
+            sh:resultSeverity sh:Violation ;
+            sh:sourceConstraintComponent sh:NodeConstraintComponent ;
+            sh:sourceShape [ sh:maxCount 1 ;
+                    sh:minCount 0 ;
+                    sh:node shacl:ValueRankShape_OneDimension_string_2 ;
+                    sh:nodeKind sh:BlankNode ;
+                    sh:path test:hasMyVariable11 ;
+                    base:hasReferenceType opcua:HasComponent ] ;
+            sh:value [ a ngsi-ld:ListProperty ;
+                    ngsi-ld:hasValueList ( "x" "y" "z" ) ] ],
+        [ a sh:ValidationResult ;
+            sh:detail [ a sh:ValidationResult ;
+                    sh:focusNode _:N26abcc5540c44a338e4429cdddce5e18 ;
+                    sh:resultMessage "Node ( Literal(\"0.0\", datatype=xsd:double) Literal(\"1.0\", datatype=xsd:double) ) does not conform to one or more shapes in [ sh:nodeKind sh:BlankNode ; sh:property [ sh:datatype xsd:integer ; sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] , [ sh:hasValue rdf:nil ]" ;
+                    sh:resultPath ngsi-ld:hasValueList ;
+                    sh:resultSeverity sh:Violation ;
+                    sh:sourceConstraintComponent sh:OrConstraintComponent ;
+                    sh:sourceShape [ sh:maxCount 1 ;
+                            sh:minCount 1 ;
+                            sh:or ( [ sh:nodeKind sh:BlankNode ;
+                                        sh:property [ sh:datatype xsd:integer ;
+                                                sh:path ( [ ] rdf:first ) ] ] [ sh:hasValue () ] ) ;
+                            sh:path ngsi-ld:hasValueList ] ;
+                    sh:value ( 0e+00 1e+00 ) ] ;
+            sh:focusNode <http://my.test/testid:i2012> ;
+            sh:resultMessage "Value does not conform to Shape shacl:ValueRankShape_OneDimension_integer. See details for more information." ;
+            sh:resultPath test:hasMyVariable9 ;
+            sh:resultSeverity sh:Violation ;
+            sh:sourceConstraintComponent sh:NodeConstraintComponent ;
+            sh:sourceShape [ sh:maxCount 1 ;
+                    sh:minCount 0 ;
+                    sh:node shacl:ValueRankShape_OneDimension_integer ;
+                    sh:nodeKind sh:BlankNode ;
+                    sh:path test:hasMyVariable9 ;
+                    base:hasReferenceType opcua:HasComponent ] ;
+            sh:value _:N26abcc5540c44a338e4429cdddce5e18 ],
+        [ a sh:ValidationResult ;
+            sh:detail [ a sh:ValidationResult ;
+                    sh:focusNode _:N9aafbaf143b54c3aa3ee5f3c9db4d84a ;
+                    sh:resultMessage "Value is not of Node Kind sh:BlankNode" ;
+                    sh:resultPath ngsi-ld:hasValueList ;
+                    sh:resultSeverity sh:Violation ;
+                    sh:sourceConstraintComponent sh:NodeKindConstraintComponent ;
+                    sh:sourceShape [ sh:maxCount 1 ;
+                            sh:minCount 1 ;
+                            sh:nodeKind sh:BlankNode ;
+                            sh:path ngsi-ld:hasValueList ;
+                            sh:property [ sh:datatype xsd:integer ;
+                                    sh:maxCount 2 ;
+                                    sh:minCount 2 ;
+                                    sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] ;
+                    sh:value () ],
+                [ a sh:ValidationResult ;
+                    sh:focusNode () ;
+                    sh:resultMessage "Less than 2 values on rdf:nil->( [ sh:zeroOrMorePath rdf:rest ] rdf:first )" ;
+                    sh:resultPath _:n31706d49d34148b084f4b0c470e5cd0fb112 ;
+                    sh:resultSeverity sh:Violation ;
+                    sh:sourceConstraintComponent sh:MinCountConstraintComponent ;
+                    sh:sourceShape _:n31706d49d34148b084f4b0c470e5cd0fb110 ] ;
+            sh:focusNode <http://my.test/testid:i2012> ;
+            sh:resultMessage "Value does not conform to Shape shacl:ValueRankShape_OneDimension_integer_2. See details for more information." ;
+            sh:resultPath test:hasMyVariable14 ;
+            sh:resultSeverity sh:Violation ;
+            sh:sourceConstraintComponent sh:NodeConstraintComponent ;
+            sh:sourceShape [ sh:maxCount 1 ;
+                    sh:minCount 0 ;
+                    sh:node shacl:ValueRankShape_OneDimension_integer_2 ;
+                    sh:nodeKind sh:BlankNode ;
+                    sh:path test:hasMyVariable14 ;
+                    base:hasReferenceType opcua:HasComponent ] ;
+            sh:value _:N9aafbaf143b54c3aa3ee5f3c9db4d84a ],
+        [ a sh:ValidationResult ;
+            sh:detail [ a sh:ValidationResult ;
+                    sh:focusNode _:Nda681d85da9f4ce494ff4b2d4f92b25e ;
+                    sh:resultMessage "ValueRank constraint for valuerank=Any(-2) with datatype=double." ;
+                    sh:resultSeverity sh:Violation ;
+                    sh:sourceConstraintComponent sh:OrConstraintComponent ;
+                    sh:sourceShape shacl:ValueRankShape_Any_double ;
+                    sh:value _:Nda681d85da9f4ce494ff4b2d4f92b25e ] ;
+            sh:focusNode <http://my.test/testid:i2012> ;
+            sh:resultMessage "Value does not conform to Shape shacl:ValueRankShape_Any_double. See details for more information." ;
+            sh:resultPath test:hasMyVariable10 ;
+            sh:resultSeverity sh:Violation ;
+            sh:sourceConstraintComponent sh:NodeConstraintComponent ;
+            sh:sourceShape [ sh:maxCount 1 ;
+                    sh:minCount 0 ;
+                    sh:node shacl:ValueRankShape_Any_double ;
+                    sh:nodeKind sh:BlankNode ;
+                    sh:path test:hasMyVariable10 ;
+                    base:hasReferenceType opcua:HasComponent ] ;
+            sh:value _:Nda681d85da9f4ce494ff4b2d4f92b25e ] .
+
+_:N48662e009c18422591aa18244f4afcac rdf:first [ sh:zeroOrMorePath rdf:rest ] ;
+    rdf:rest ( rdf:first ) .
+
+_:N4b70e8ca32f9458083b270d4d8fd4118 rdf:first 0e+00 ;
+    rdf:rest ( 1e+00 ) .
+
+_:N84f1926d936145a1912ed7974c404e9d sh:zeroOrMorePath rdf:rest .
+
+_:Nb3258189862f42c1b655a5acd3af9965 rdf:first rdf:first ;
+    rdf:rest () .
+
+_:N26abcc5540c44a338e4429cdddce5e18 a ngsi-ld:ListProperty ;
+    ngsi-ld:hasValueList _:N4b70e8ca32f9458083b270d4d8fd4118 .
+
+_:N9aafbaf143b54c3aa3ee5f3c9db4d84a a ngsi-ld:ListProperty ;
+    ngsi-ld:hasValueList () .
+
+_:n31706d49d34148b084f4b0c470e5cd0fb110 sh:datatype xsd:integer ;
+    sh:maxCount 2 ;
+    sh:minCount 2 ;
+    sh:path _:N48662e009c18422591aa18244f4afcac .
+
+_:n31706d49d34148b084f4b0c470e5cd0fb112 rdf:first _:N84f1926d936145a1912ed7974c404e9d ;
+    rdf:rest _:Nb3258189862f42c1b655a5acd3af9965 .
+
+_:Nda681d85da9f4ce494ff4b2d4f92b25e a ngsi-ld:Property ;
+    ngsi-ld:hasValue 1 .
+

--- a/semantic-model/opcua/tests/extractType/test_variable_arrays_vrs.NodeSet2.shacl
+++ b/semantic-model/opcua/tests/extractType/test_variable_arrays_vrs.NodeSet2.shacl
@@ -1,0 +1,270 @@
+@prefix base: <https://industryfusion.github.io/contexts/ontology/v0/base/> .
+@prefix ngsi-ld: <https://uri.etsi.org/ngsi-ld/> .
+@prefix opcua: <http://opcfoundation.org/UA/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix shacl: <http://my.test/shacl/> .
+@prefix test: <http://my.test/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+shacl:AlphaTypeShape a sh:NodeShape ;
+    sh:property [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_Any_double ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasC ;
+            sh:property [ sh:maxCount 1 ;
+                    sh:minCount 0 ;
+                    sh:node shacl:ValueRankShape_Any_double ;
+                    sh:nodeKind sh:BlankNode ;
+                    sh:path test:hasE ;
+                    base:hasReferenceType opcua:HasComponent ] ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ a base:SubComponentRelationship ;
+            sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasB ;
+            sh:property [ sh:class test:BType ;
+                    sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:nodeKind sh:IRI ;
+                    sh:path ngsi-ld:hasObject ] ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ a base:PeerRelationship ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:X ;
+            sh:property [ sh:class test:BType ;
+                    sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:nodeKind sh:IRI ;
+                    sh:path ngsi-ld:hasObject ] ;
+            base:hasReferenceType test:X ] ;
+    sh:targetClass test:AlphaType .
+
+shacl:BTypeShape a sh:NodeShape ;
+    sh:property [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_Scalar_string ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable6 ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_2Dimensions_double_6 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable2 ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_OneDimension_integer ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable9 ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_Any_string ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable7 ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_Any_JSON ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable16 ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_OneOrMoreDimensions_boolean_2 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable3 ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_OneDimension_integer_2 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable14 ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_OneDimension_string_2 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable11 ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_OneDimension_string ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable8 ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_Any_double ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable10 ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_Any_JSON ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable15 ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_OneOrMoreDimensions_integer ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable13 ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_OneDimension_integer_2 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable12 ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_Scalar_integer ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable4 ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_OneDimension_integer_2 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:node shacl:ValueRankShape_OneDimension_string ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable5 ;
+            base:hasReferenceType opcua:HasComponent ] ;
+    sh:targetClass test:BType .
+
+shacl:ValueRankShape_2Dimensions_double_6 a sh:NodeShape ;
+    sh:message "ValueRank constraint for valuerank=2Dimensions(2) with datatype=double and multiplied arraydimensions=6." ;
+    sh:property [ sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path ngsi-ld:hasValueList ;
+            sh:property [ sh:datatype xsd:double ;
+                    sh:maxCount 6 ;
+                    sh:minCount 6 ;
+                    sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] .
+
+shacl:ValueRankShape_Any_string a sh:NodeShape ;
+    sh:message "ValueRank constraint for valuerank=Any(-2) with datatype=string." ;
+    sh:or ( [ sh:property [ sh:datatype xsd:string ;
+                        sh:maxCount 1 ;
+                        sh:minCount 1 ;
+                        sh:nodeKind sh:Literal ;
+                        sh:path ngsi-ld:hasValue ] ] [ sh:property [ sh:maxCount 1 ;
+                        sh:minCount 1 ;
+                        sh:or ( [ sh:nodeKind sh:BlankNode ;
+                                    sh:property [ sh:datatype xsd:string ;
+                                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] [ sh:hasValue () ] ) ;
+                        sh:path ngsi-ld:hasValueList ] ] ) .
+
+shacl:ValueRankShape_OneDimension_integer a sh:NodeShape ;
+    sh:message "ValueRank constraint for valuerank=OneDimension(1) with datatype=integer." ;
+    sh:property [ sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:or ( [ sh:nodeKind sh:BlankNode ;
+                        sh:property [ sh:datatype xsd:integer ;
+                                sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] [ sh:hasValue () ] ) ;
+            sh:path ngsi-ld:hasValueList ] .
+
+shacl:ValueRankShape_OneDimension_string_2 a sh:NodeShape ;
+    sh:message "ValueRank constraint for valuerank=OneDimension(1) with datatype=string and multiplied arraydimensions=2." ;
+    sh:property [ sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path ngsi-ld:hasValueList ;
+            sh:property [ sh:datatype xsd:string ;
+                    sh:maxCount 2 ;
+                    sh:minCount 2 ;
+                    sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] .
+
+shacl:ValueRankShape_OneOrMoreDimensions_boolean_2 a sh:NodeShape ;
+    sh:message "ValueRank constraint for valuerank=OneOrMoreDimensions(0) with datatype=boolean and multiplied arraydimensions=2." ;
+    sh:property [ sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path ngsi-ld:hasValueList ;
+            sh:property [ sh:datatype xsd:boolean ;
+                    sh:maxCount 2 ;
+                    sh:minCount 2 ;
+                    sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] .
+
+shacl:ValueRankShape_OneOrMoreDimensions_integer a sh:NodeShape ;
+    sh:message "ValueRank constraint for valuerank=OneOrMoreDimensions(0) with datatype=integer." ;
+    sh:property [ sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:or ( [ sh:nodeKind sh:BlankNode ;
+                        sh:property [ sh:datatype xsd:integer ;
+                                sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] [ sh:hasValue () ] ) ;
+            sh:path ngsi-ld:hasValueList ] .
+
+shacl:ValueRankShape_Scalar_integer a sh:NodeShape ;
+    sh:message "ValueRank constraint for valuerank=Scalar(-1) with datatype=integer." ;
+    sh:property [ sh:datatype xsd:integer ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ngsi-ld:hasValue ] .
+
+shacl:ValueRankShape_Scalar_string a sh:NodeShape ;
+    sh:message "ValueRank constraint for valuerank=Scalar(-1) with datatype=string." ;
+    sh:property [ sh:datatype xsd:string ;
+            sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:Literal ;
+            sh:path ngsi-ld:hasValue ] .
+
+shacl:ValueRankShape_Any_JSON a sh:NodeShape ;
+    sh:message "ValueRank constraint for valuerank=Any(-2) with datatype=JSON." ;
+    sh:or ( [ sh:property [ sh:maxCount 1 ;
+                        sh:minCount 1 ;
+                        sh:or ( [ sh:nodeKind sh:BlankNode ;
+                                    sh:property [ sh:datatype rdf:JSON ;
+                                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] [ sh:hasValue () ] ) ;
+                        sh:path ngsi-ld:hasValueList ] ] [ sh:property [ sh:datatype rdf:JSON ;
+                        sh:maxCount 1 ;
+                        sh:minCount 1 ;
+                        sh:nodeKind sh:Literal ;
+                        sh:path ngsi-ld:hasJSON ] ] ) .
+
+shacl:ValueRankShape_OneDimension_string a sh:NodeShape ;
+    sh:message "ValueRank constraint for valuerank=OneDimension(1) with datatype=string." ;
+    sh:property [ sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:or ( [ sh:nodeKind sh:BlankNode ;
+                        sh:property [ sh:datatype xsd:string ;
+                                sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] [ sh:hasValue () ] ) ;
+            sh:path ngsi-ld:hasValueList ] .
+
+shacl:ValueRankShape_Any_double a sh:NodeShape ;
+    sh:message "ValueRank constraint for valuerank=Any(-2) with datatype=double." ;
+    sh:or ( [ sh:property [ sh:datatype xsd:double ;
+                        sh:maxCount 1 ;
+                        sh:minCount 1 ;
+                        sh:nodeKind sh:Literal ;
+                        sh:path ngsi-ld:hasValue ] ] [ sh:property [ sh:maxCount 1 ;
+                        sh:minCount 1 ;
+                        sh:or ( [ sh:nodeKind sh:BlankNode ;
+                                    sh:property [ sh:datatype xsd:double ;
+                                            sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] [ sh:hasValue () ] ) ;
+                        sh:path ngsi-ld:hasValueList ] ] ) .
+
+shacl:ValueRankShape_OneDimension_integer_2 a sh:NodeShape ;
+    sh:message "ValueRank constraint for valuerank=OneDimension(1) with datatype=integer and multiplied arraydimensions=2." ;
+    sh:property [ sh:maxCount 1 ;
+            sh:minCount 1 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path ngsi-ld:hasValueList ;
+            sh:property [ sh:datatype xsd:integer ;
+                    sh:maxCount 2 ;
+                    sh:minCount 2 ;
+                    sh:path ( [ sh:zeroOrMorePath rdf:rest ] rdf:first ) ] ] .
+

--- a/semantic-model/opcua/tests/extractType/test_variable_arrays_vrs.NodeSet2.xml
+++ b/semantic-model/opcua/tests/extractType/test_variable_arrays_vrs.NodeSet2.xml
@@ -1,0 +1,460 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+
+-->
+
+<UANodeSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd" xmlns:xsd="http://www.w3.org/2001/XMLSchema" LastModified="2024-07-15T00:00:00Z" xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <Models>
+    <Model ModelUri="http://my.test/" XmlSchemaUri="http://opcfoundation.org/UA/2008/02/Types.xsd" Version="1.05.03" PublicationDate="2024-07-29T00:00:00Z" ModelVersion="1.5.3" />
+  </Models>
+  <NamespaceUris>
+    <Uri>http://my.test/</Uri>
+  </NamespaceUris>
+  <Aliases>
+    <Alias Alias="Boolean">i=1</Alias>
+    <Alias Alias="SByte">i=2</Alias>
+    <Alias Alias="Byte">i=3</Alias>
+    <Alias Alias="Int16">i=4</Alias>
+    <Alias Alias="UInt16">i=5</Alias>
+    <Alias Alias="Int32">i=6</Alias>
+    <Alias Alias="UInt32">i=7</Alias>
+    <Alias Alias="Int64">i=8</Alias>
+    <Alias Alias="UInt64">i=9</Alias>
+    <Alias Alias="Float">i=10</Alias>
+    <Alias Alias="Double">i=11</Alias>
+    <Alias Alias="DateTime">i=13</Alias>
+    <Alias Alias="String">i=12</Alias>
+    <Alias Alias="ByteString">i=15</Alias>
+    <Alias Alias="Guid">i=14</Alias>
+    <Alias Alias="XmlElement">i=16</Alias>
+    <Alias Alias="NodeId">i=17</Alias>
+    <Alias Alias="ExpandedNodeId">i=18</Alias>
+    <Alias Alias="QualifiedName">i=20</Alias>
+    <Alias Alias="LocalizedText">i=21</Alias>
+    <Alias Alias="StatusCode">i=19</Alias>
+    <Alias Alias="Structure">i=22</Alias>
+    <Alias Alias="Number">i=26</Alias>
+    <Alias Alias="Integer">i=27</Alias>
+    <Alias Alias="UInteger">i=28</Alias>
+    <Alias Alias="HasComponent">i=47</Alias>
+    <Alias Alias="HasProperty">i=46</Alias>
+    <Alias Alias="Organizes">i=35</Alias>
+    <Alias Alias="HasEventSource">i=36</Alias>
+    <Alias Alias="HasNotifier">i=48</Alias>
+    <Alias Alias="HasSubtype">i=45</Alias>
+    <Alias Alias="HasTypeDefinition">i=40</Alias>
+    <Alias Alias="HasModellingRule">i=37</Alias>
+    <Alias Alias="HasEncoding">i=38</Alias>
+    <Alias Alias="HasDescription">i=39</Alias>
+    <Alias Alias="HasCause">i=53</Alias>
+    <Alias Alias="ToState">i=52</Alias>
+    <Alias Alias="FromState">i=51</Alias>
+    <Alias Alias="HasEffect">i=54</Alias>
+    <Alias Alias="HasTrueSubState">i=9004</Alias>
+    <Alias Alias="HasFalseSubState">i=9005</Alias>
+    <Alias Alias="HasDictionaryEntry">i=17597</Alias>
+    <Alias Alias="HasCondition">i=9006</Alias>
+    <Alias Alias="HasGuard">i=15112</Alias>
+    <Alias Alias="HasAddIn">i=17604</Alias>
+    <Alias Alias="HasInterface">i=17603</Alias>
+  </Aliases>
+ 
+  <UAReferenceType NodeId="ns=1;i=100" BrowseName="1:X" IsAbstract="true" Symmetric="false">
+    <DisplayName>X Reference</DisplayName>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=32</Reference>
+    </References>
+  </UAReferenceType>
+  <UAReferenceType NodeId="ns=1;i=101" BrowseName="1:Y" IsAbstract="true" Symmetric="false">
+    <DisplayName>Y Reference</DisplayName>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=32</Reference>
+    </References>
+  </UAReferenceType>
+  <UAVariableType NodeId="ns=1;i=200" BrowseName="1:TestVariableType" IsAbstract="false" ValueRank="-2">
+    <DisplayName>TestVariableType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=63</Reference>
+    </References>
+  </UAVariableType>
+  <UAObjectType NodeId="ns=1;i=1001" BrowseName="1:AlphaType">
+    <DisplayName>AlphaType</DisplayName>
+    <Description>A custom object type Alpha</Description>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+      <Reference ReferenceType="ns=1;i=101" IsForward="true">ns=1;i=2001</Reference>
+      <Reference ReferenceType="ns=1;i=100" IsForward="true">ns=1;i=1003</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1003</Reference>
+    </References>
+  </UAObjectType>
+  <UAObjectType NodeId="ns=1;i=1002" BrowseName="1:BType">
+    <DisplayName>B Type</DisplayName>
+    <Description>A custom object type B</Description>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1011</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1015</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="ns=1;i=1003" BrowseName="1:B">
+    <DisplayName>Object B</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=1002</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1004</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1005</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1006</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1007</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1008</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1009</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1010</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1012</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1013</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1014</Reference>
+
+      <Reference ReferenceType="HasComponent">ns=1;i=1016</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1017</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1018</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1019</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=1004" BrowseName="1:MyVariable" DataType="Int32" ValueRank="1" ArrayDimensions="2">
+    <DisplayName>Variable of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=1005" BrowseName="1:MyVariable2" DataType="Float" ValueRank="2" ArrayDimensions="2,3">
+    <DisplayName>Variable2 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=1006" BrowseName="1:MyVariable3" DataType="Boolean" ValueRank="0" ArrayDimensions="2">
+    <DisplayName>Variable3 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=1007" BrowseName="1:MyVariable4" DataType="Int32" ValueRank="-1">
+    <DisplayName>Variable4 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+  </UAVariable>
+    <UAVariable NodeId="ns=1;i=1008" BrowseName="1:MyVariable5" DataType="String" ValueRank="1">
+    <DisplayName>Variable5 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+  </UAVariable>
+    <UAVariable NodeId="ns=1;i=1009" BrowseName="1:MyVariable6" DataType="String" ValueRank="-1">
+    <DisplayName>Variable5 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=1010" BrowseName="1:MyVariable7" DataType="String" ValueRank="-2">
+    <DisplayName>Variable5 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+  </UAVariable>
+    <UAVariable NodeId="ns=1;i=1011" BrowseName="1:MyVariable8" DataType="String" ValueRank="1">
+    <DisplayName>Variable5 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+  </UAVariable>
+    <UAVariable NodeId="ns=1;i=1012" BrowseName="1:MyVariable9" DataType="Int32" ValueRank="1">
+    <DisplayName>Variable5 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=1013" BrowseName="1:MyVariable10" DataType="Float" ValueRank="-2">
+    <DisplayName>Variable5 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=1014" BrowseName="1:MyVariable11" DataType="String" ValueRank="1" ArrayDimensions="2">
+    <DisplayName>Variable2 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=1015" BrowseName="1:MyVariable12" DataType="Int32" ValueRank="1" ArrayDimensions="2">
+    <DisplayName>Variable2 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=1016" BrowseName="1:MyVariable13" DataType="Int32" ValueRank="0">
+    <DisplayName>Variable2 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=1017" BrowseName="1:MyVariable14" DataType="Int32" ValueRank="1" ArrayDimensions="2">
+    <DisplayName>Variable2 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=1018" BrowseName="1:MyVariable15" DataType="NodeId" ValueRank="-2">
+    <DisplayName>Variable15 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=1019" BrowseName="1:MyVariable16" DataType="NodeId" ValueRank="-2">
+    <DisplayName>Variable16 of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+  </UAVariable>
+
+  <UAVariable NodeId="ns=1;i=2001" BrowseName="1:C" DataType="i=11">
+    <DisplayName>Variable of AlphaType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1001</Reference>
+    </References>
+  </UAVariable>  
+  <UAVariable NodeId="ns=1;i=2002" BrowseName="1:E" DataType="i=11">
+    <DisplayName>Variable of Variable C</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=2001</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=2003" BrowseName="1:B">
+    <DisplayName>Object B</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=1002</Reference>
+    </References>
+  </UAObject>
+ <UAObject NodeId="ns=1;i=2010" BrowseName="1:AlphaInstance">
+    <DisplayName>Alpha Instance</DisplayName>
+    <References>
+      <Reference ReferenceType="HasComponent" IsForward="true">ns=1;i=2011</Reference>
+       <Reference ReferenceType="HasComponent" IsForward="true">ns=1;i=2012</Reference>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=1001</Reference>
+      <Reference ReferenceType="ns=1;i=101" IsForward="true">ns=1;i=2012</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=2011" BrowseName="1:C" DataType="i=11">
+    <DisplayName>C Variable of AlphaType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=2010</Reference>
+      <Reference ReferenceType="ns=1;i=100" IsForward="true">ns=1;i=2011</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=2012" BrowseName="1:B">
+    <DisplayName>Object B</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=1002</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2013</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2014</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2015</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2016</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2017</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2018</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2019</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2020</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2021</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2022</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2023</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2024</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2025</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2026</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2027</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2028</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=2013" BrowseName="1:MyVariable" DataType="Int32">
+    <DisplayName>Int32 Array Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+      <Value>
+        <uax:ListOfInt32>
+          <uax:Int32>0</uax:Int32>
+          <uax:Int32>1</uax:Int32>
+        </uax:ListOfInt32>
+      </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=2014" BrowseName="1:MyVariable2" DataType="Float">
+    <DisplayName>Double 2x Array Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+      <Value>
+        <uax:ListOfFloat>
+          <uax:Float>0</uax:Float>
+          <uax:Float>1</uax:Float>
+          <uax:Float>2</uax:Float>
+          <uax:Float>3</uax:Float>
+          <uax:Float>4</uax:Float>
+          <uax:Float>5</uax:Float>
+        </uax:ListOfFloat>
+      </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=2015" BrowseName="1:MyVariable3" DataType="Boolean">
+    <DisplayName>Boolean Array Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+      <Value>
+        <uax:ListOfBoolean>
+          <uax:Boolean>true</uax:Boolean>
+          <uax:Boolean>false</uax:Boolean>
+        </uax:ListOfBoolean>
+      </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=2016" BrowseName="1:MyVariable4" DataType="Int32">
+    <DisplayName>Scalar Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+      <Value>
+      <uax:Int32>42</uax:Int32>
+      </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=2017" BrowseName="1:MyVariable5" DataType="String">
+    <DisplayName>Scalar or array Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+    <Value>
+      <uax:ListOfString>
+        <uax:String>42</uax:String>
+      </uax:ListOfString>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=2018" BrowseName="1:MyVariable6" DataType="String">
+    <DisplayName>Scalar or array Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+      <Value>
+      <uax:String>42</uax:String>
+      </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=2019" BrowseName="1:MyVariable7" DataType="String">
+    <DisplayName>Scalar or array Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+      <Value>
+      <uax:ListOfString>
+      </uax:ListOfString>
+      </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=2020" BrowseName="1:MyVariable8" DataType="String">
+    <DisplayName>Scalar or array Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+      <uax:ListOfString>
+      </uax:ListOfString>
+  </UAVariable>
+    <UAVariable NodeId="ns=1;i=2021" BrowseName="1:MyVariable9" DataType="Int32">
+    <DisplayName>Int32 Array Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+      <Value>
+        <uax:ListOfFloat>
+          <uax:Float>0.0</uax:Float>
+          <uax:Float>1.0</uax:Float>
+        </uax:ListOfFloat>
+      </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=2022" BrowseName="1:MyVariable10" DataType="Float" ValueRank="-2">
+    <DisplayName>Scalar Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+      <Value>
+      <uax:Int32>1</uax:Int32>
+      </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=2023" BrowseName="1:MyVariable11" DataType="String">
+    <DisplayName>Scalar or array Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+    <Value>
+      <uax:ListOfString>
+      <uax:String>x</uax:String>
+      <uax:String>y</uax:String>
+      <uax:String>z</uax:String>
+      </uax:ListOfString>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=2024" BrowseName="1:MyVariable12">
+    <DisplayName>Scalar or array Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+    <Value>
+      <uax:ListOfInt32>
+      <uax:Int32>99</uax:Int32>
+      </uax:ListOfInt32>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=2025" BrowseName="1:MyVariable13">
+    <DisplayName>Scalar or array Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+    <Value>
+      <uax:ListOfInt32>
+      </uax:ListOfInt32>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=2026" BrowseName="1:MyVariable14">
+    <DisplayName>Scalar or array Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+    <Value>
+      <uax:ListOfInt32>
+      </uax:ListOfInt32>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=2027" BrowseName="1:MyVariable15" DataType="NodeId">
+    <DisplayName>Scalar or array Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+    <Value>
+    <uax:ListOfNodeIds>
+    </uax:ListOfNodeIds>
+    </Value>
+  </UAVariable>
+  <UAVariable NodeId="ns=1;i=2028" BrowseName="1:MyVariable16" DataType="NodeId">
+    <DisplayName>Scalar or array Variable</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=200</Reference>
+    </References>
+    <Value>
+    <uax:ListOfNodeIds>
+      <uax:NodeId>
+        <uax:Identifier>ns=1;i=1001</uax:Identifier>
+      </uax:NodeId>
+      <uax:NodeId>
+        <uax:Identifier>ns=2;s=TemperatureSensor</uax:Identifier>
+      </uax:NodeId>
+      <uax:NodeId>
+        <uax:Identifier>ns=3;g=123e4567-e89b-12d3-a456-426614174000</uax:Identifier>
+      </uax:NodeId>
+      <uax:NodeId>
+        <uax:Identifier>ns=4;x=0A0B0C0D</uax:Identifier>
+      </uax:NodeId>
+    </uax:ListOfNodeIds>
+    </Value>
+  </UAVariable>
+</UANodeSet>

--- a/semantic-model/opcua/tests/test_libutils.py
+++ b/semantic-model/opcua/tests/test_libutils.py
@@ -14,7 +14,7 @@ from lib.utils import RdfUtils, downcase_string, isNodeId, convert_to_json_type,
                                 contains_both_angle_brackets, get_typename, get_common_supertype, rdfStringToPythonBool, \
                                 get_rank_dimensions, get_type_and_template, OntologyLoader, file_path_to_uri, create_list, \
                                 extract_subgraph, dump_without_prefixes, get_contentclass, quote_url, merge_attributes, dump_graph, \
-                                is_subclass, create_list, get_contentclass, expand_term, RdfUtils
+                                is_subclass, create_list, get_contentclass, expand_term, RdfUtils, rank_value_to_string
 
 class TestIsSubclass(unittest.TestCase):
     def test_direct_subclass(self):
@@ -865,6 +865,36 @@ class TestOntologyLoader(unittest.TestCase):
                 mock_print.assert_called_with(
                    'Importing http://example.org/ont2 from url ont2.'
                 )
+
+class TestRankValueToString(unittest.TestCase):
+    def test_scalar_or_one_dimension(self):
+        self.assertEqual(rank_value_to_string(-3), 'ScalarOrOneDimension')
+        self.assertEqual(rank_value_to_string('-3'), 'ScalarOrOneDimension')
+
+    def test_any(self):
+        self.assertEqual(rank_value_to_string(-2), 'Any')
+        self.assertEqual(rank_value_to_string('-2'), 'Any')
+
+    def test_scalar(self):
+        self.assertEqual(rank_value_to_string(-1), 'Scalar')
+        self.assertEqual(rank_value_to_string('-1'), 'Scalar')
+
+    def test_one_or_more_dimensions(self):
+        self.assertEqual(rank_value_to_string(0), 'OneOrMoreDimensions')
+        self.assertEqual(rank_value_to_string('0'), 'OneOrMoreDimensions')
+
+    def test_one_dimension(self):
+        self.assertEqual(rank_value_to_string(1), 'OneDimension')
+        self.assertEqual(rank_value_to_string('1'), 'OneDimension')
+
+    def test_n_dimensions(self):
+        self.assertEqual(rank_value_to_string(2), '2Dimensions')
+        self.assertEqual(rank_value_to_string('3'), '3Dimensions')
+        self.assertEqual(rank_value_to_string(10), '10Dimensions')
+
+    def test_unknown_rank(self):
+        self.assertEqual(rank_value_to_string(-99), 'UnknownRank')
+        self.assertEqual(rank_value_to_string('-99'), 'UnknownRank')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Pull request overview

This PR adds support for SHACL value rank subshapes as an optional feature in the OPC UA semantic model extraction tool. The main purpose is to enable generation of standalone, reusable SHACL shapes for value rank constraints instead of nesting them inline, which improves readability and reduces duplication.

**Key Changes:**
- Added a new `-vrs` command-line argument to enable value rank subshapes
- Implemented utility functions to convert value rank integers to descriptive strings and RDF collections to Python lists
- Created new test files to validate the value rank subshapes functionality

