### PR TITLE
Extract type+semantic bridge

### DIFF
--- a/semantic-model/opcua/extractType.py
+++ b/semantic-model/opcua/extractType.py
@@ -157,6 +157,10 @@ parse nodeset instance and create ngsi-ld model')
                         'the whole expression).',
                         required=False, default=False,
                         action='store_true')
+    parser.add_argument('-sb', '--semantic-bridge', help='Add Semantic Bridge in JSON-LD to allow convenient '
+                        'mapping back to OWL',
+                        required=False, default=False,
+                        action='store_true')
 
     parsed_args = parser.parse_args(args)
     return parsed_args
@@ -429,6 +433,10 @@ def scan_entity(node, instancetype, id, optional=False):
     prefixed_type = utils.get_prefixed(context_graph, instancetype)
     instance['type'] = prefixed_type
     instance['id'] = node_id
+    if semantic_bridge_enabled:
+        noderef_key = utils.get_prefixed(context_graph, basens['hasNodeRef'])
+        noderef_value = utils.get_prefixed(context_graph, node)
+        instance[noderef_key] = jsonld.get_ngsild_vocab(noderef_value)
     instance['@context'] = [
         context_url
     ]
@@ -645,6 +653,7 @@ if __name__ == '__main__':
     entity_namespace = args.entity_namespace
     parse_properties = args.properties
     value_rank_subshapes_enabled = args.value_rank_subshapes
+    semantic_bridge_enabled = args.semantic_bridge
 
     # create the context_graph
     # Context graph is resolving the context_url and provides just the

--- a/semantic-model/opcua/lib/jsonld.py
+++ b/semantic-model/opcua/lib/jsonld.py
@@ -270,6 +270,13 @@ class JsonLd:
         }
 
     @staticmethod
+    def get_ngsild_vocab(vocabulary_term):
+        return {
+            'type': 'VocabProperty',
+            'vocab': vocabulary_term
+        }
+
+    @staticmethod
     def get_default_value(datatypes, orig_datatype=None, value_rank=None, array_dimensions=None, g=Graph()):
         datatype = None
         if isinstance(datatypes, list) and len(datatypes) > 0:

--- a/semantic-model/opcua/tests/extractType/test.bash
+++ b/semantic-model/opcua/tests/extractType/test.bash
@@ -36,6 +36,7 @@ if [ "$DEBUG" = "true" ]; then
     DEBUG_CMDLINE="-m debugpy --listen 5678"
 fi
 TESTNODESETS=(
+    test_semantic_bridge.Nodeset2,${EXURI}AlphaType,,,-sb,,${EXURI}
     test_variable_arrays_vrs.NodeSet2,${TESTURI}AlphaType,,,-vrs
     test_variable_arrays.NodeSet2,${TESTURI}AlphaType
     test_pumps_instanceexample,http://opcfoundation.org/UA/Pumps/PumpType,http://yourorganisation.org/InstanceExample/,pumps

--- a/semantic-model/opcua/tests/extractType/test_semantic_bridge.Nodeset2.instances
+++ b/semantic-model/opcua/tests/extractType/test_semantic_bridge.Nodeset2.instances
@@ -1,0 +1,38 @@
+[
+    {
+        "type": "http://example.org/BSubType",
+        "id": "http://example.org/testid:i2012",
+        "base:hasNodeRef": {
+            "type": "VocabProperty",
+            "vocab": "http://example.org/nodei2012"
+        },
+        "@context": [
+            "http://localhost:8099/context.jsonld"
+        ],
+        "http://example.org/hasMyVariable": {
+            "type": "Property",
+            "value": false
+        }
+    },
+    {
+        "type": "http://example.org/AlphaType",
+        "id": "http://example.org/testid:i2010",
+        "base:hasNodeRef": {
+            "type": "VocabProperty",
+            "vocab": "http://example.org/nodei2010"
+        },
+        "@context": [
+            "http://localhost:8099/context.jsonld"
+        ],
+        "http://example.org/hasC": {
+            "type": "Property",
+            "value": 0.0
+        },
+        "http://example.org/hasB": [
+            {
+                "type": "Relationship",
+                "object": "http://example.org/testid:i2012"
+            }
+        ]
+    }
+]

--- a/semantic-model/opcua/tests/extractType/test_semantic_bridge.Nodeset2.shacl
+++ b/semantic-model/opcua/tests/extractType/test_semantic_bridge.Nodeset2.shacl
@@ -1,0 +1,45 @@
+@prefix base: <https://industryfusion.github.io/contexts/ontology/v0/base/> .
+@prefix ngsi-ld: <https://uri.etsi.org/ngsi-ld/> .
+@prefix opcua: <http://opcfoundation.org/UA/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix shacl: <http://example.org/shacl/> .
+@prefix test: <http://example.org/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+shacl:AlphaTypeShape a sh:NodeShape ;
+    sh:property [ a base:SubComponentRelationship ;
+            sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasB ;
+            sh:property [ sh:class test:BType ;
+                    sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:nodeKind sh:IRI ;
+                    sh:path ngsi-ld:hasObject ] ;
+            base:hasReferenceType opcua:HasComponent ],
+        [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasC ;
+            sh:property [ sh:datatype xsd:double ;
+                    sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:nodeKind sh:Literal ;
+                    sh:path ngsi-ld:hasValue ] ;
+            base:hasReferenceType opcua:HasComponent ] ;
+    sh:targetClass test:AlphaType .
+
+shacl:BTypeShape a sh:NodeShape ;
+    sh:property [ sh:maxCount 1 ;
+            sh:minCount 0 ;
+            sh:nodeKind sh:BlankNode ;
+            sh:path test:hasMyVariable ;
+            sh:property [ sh:datatype xsd:boolean ;
+                    sh:maxCount 1 ;
+                    sh:minCount 1 ;
+                    sh:nodeKind sh:Literal ;
+                    sh:path ngsi-ld:hasValue ] ;
+            base:hasReferenceType opcua:HasComponent ] ;
+    sh:targetClass test:BType .
+

--- a/semantic-model/opcua/tests/extractType/test_semantic_bridge.Nodeset2.xml
+++ b/semantic-model/opcua/tests/extractType/test_semantic_bridge.Nodeset2.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--
+
+-->
+
+<UANodeSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" LastModified="2024-07-15T00:00:00Z" xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <Models>
+    <Model ModelUri="http://example.org/" XmlSchemaUri="http://opcfoundation.org/UA/2008/02/Types.xsd" Version="1.05.03" PublicationDate="2024-07-29T00:00:00Z" ModelVersion="1.5.3" />
+  </Models>
+  <NamespaceUris>
+    <Uri>http://example.org/</Uri>
+  </NamespaceUris>
+  <Aliases>
+    <Alias Alias="Boolean">i=1</Alias>
+    <Alias Alias="SByte">i=2</Alias>
+    <Alias Alias="Byte">i=3</Alias>
+    <Alias Alias="Int16">i=4</Alias>
+    <Alias Alias="UInt16">i=5</Alias>
+    <Alias Alias="Int32">i=6</Alias>
+    <Alias Alias="UInt32">i=7</Alias>
+    <Alias Alias="Int64">i=8</Alias>
+    <Alias Alias="UInt64">i=9</Alias>
+    <Alias Alias="Float">i=10</Alias>
+    <Alias Alias="Double">i=11</Alias>
+    <Alias Alias="DateTime">i=13</Alias>
+    <Alias Alias="String">i=12</Alias>
+    <Alias Alias="ByteString">i=15</Alias>
+    <Alias Alias="Guid">i=14</Alias>
+    <Alias Alias="XmlElement">i=16</Alias>
+    <Alias Alias="NodeId">i=17</Alias>
+    <Alias Alias="ExpandedNodeId">i=18</Alias>
+    <Alias Alias="QualifiedName">i=20</Alias>
+    <Alias Alias="LocalizedText">i=21</Alias>
+    <Alias Alias="StatusCode">i=19</Alias>
+    <Alias Alias="Structure">i=22</Alias>
+    <Alias Alias="Number">i=26</Alias>
+    <Alias Alias="Integer">i=27</Alias>
+    <Alias Alias="UInteger">i=28</Alias>
+    <Alias Alias="HasComponent">i=47</Alias>
+    <Alias Alias="HasProperty">i=46</Alias>
+    <Alias Alias="Organizes">i=35</Alias>
+    <Alias Alias="HasEventSource">i=36</Alias>
+    <Alias Alias="HasNotifier">i=48</Alias>
+    <Alias Alias="HasSubtype">i=45</Alias>
+    <Alias Alias="HasTypeDefinition">i=40</Alias>
+    <Alias Alias="HasModellingRule">i=37</Alias>
+    <Alias Alias="HasEncoding">i=38</Alias>
+    <Alias Alias="HasDescription">i=39</Alias>
+    <Alias Alias="HasCause">i=53</Alias>
+    <Alias Alias="ToState">i=52</Alias>
+    <Alias Alias="FromState">i=51</Alias>
+    <Alias Alias="HasEffect">i=54</Alias>
+    <Alias Alias="HasTrueSubState">i=9004</Alias>
+    <Alias Alias="HasFalseSubState">i=9005</Alias>
+    <Alias Alias="HasDictionaryEntry">i=17597</Alias>
+    <Alias Alias="HasCondition">i=9006</Alias>
+    <Alias Alias="HasGuard">i=15112</Alias>
+    <Alias Alias="HasAddIn">i=17604</Alias>
+    <Alias Alias="HasInterface">i=17603</Alias>
+  </Aliases>
+ 
+
+  <UAObjectType NodeId="ns=1;i=1001" BrowseName="1:AlphaType">
+    <DisplayName>AlphaType</DisplayName>
+    <Description>A custom object type Alpha</Description>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=1003</Reference>
+    </References>
+  </UAObjectType>
+  <UAObjectType NodeId="ns=1;i=1002" BrowseName="1:BType">
+    <DisplayName>B Type</DisplayName>
+    <Description>A custom object type B</Description>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">i=58</Reference>
+    </References>
+  </UAObjectType>
+  <UAObject NodeId="ns=1;i=1003" BrowseName="1:B">
+    <DisplayName>Object B</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=1002</Reference>
+       <Reference ReferenceType="HasComponent">ns=1;i=1004</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=1004" BrowseName="1:MyVariable" DataType="Boolean" ValueRank="-1">
+    <DisplayName>Variable of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+  </UAVariable>
+ <UAObjectType NodeId="ns=1;i=1005" BrowseName="1:BSubType">
+    <DisplayName>B Sub Type</DisplayName>
+    <Description>A custom subobject of type B</Description>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">ns=1;i=1002</Reference>
+    </References>
+  </UAObjectType>
+  <UAVariable NodeId="ns=1;i=1006" BrowseName="1:C" DataType="i=11" ValueRank="-1">
+    <DisplayName>C Variable of AlphaType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=1001</Reference>
+    </References>
+  </UAVariable>
+
+ <UAObject NodeId="ns=1;i=2010" BrowseName="1:AlphaInstance">
+    <DisplayName>Alpha Instance</DisplayName>
+    <References>
+      <Reference ReferenceType="HasComponent" IsForward="true">ns=1;i=2011</Reference>
+       <Reference ReferenceType="HasComponent" IsForward="true">ns=1;i=2012</Reference>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=1001</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=2011" BrowseName="1:C" DataType="i=11">
+    <DisplayName>C Variable of AlphaType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+      <Reference ReferenceType="HasComponent" IsForward="false">ns=1;i=2010</Reference>
+    </References>
+  </UAVariable>
+  <UAObject NodeId="ns=1;i=2012" BrowseName="1:B">
+    <DisplayName>Object B subtype</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">ns=1;i=1005</Reference>
+       <Reference ReferenceType="HasComponent">ns=1;i=2013</Reference>
+    </References>
+  </UAObject>
+  <UAVariable NodeId="ns=1;i=2013" BrowseName="1:MyVariable" DataType="Boolean">
+    <DisplayName>Variable of B-object</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition" IsForward="true">i=63</Reference>
+    </References>
+  </UAVariable>
+</UANodeSet>

--- a/semantic-model/opcua/tests/test_libjsonld.py
+++ b/semantic-model/opcua/tests/test_libjsonld.py
@@ -113,6 +113,11 @@ class TestJsonLd(unittest.TestCase):
         rel = JsonLd.get_ngsild_relationship(rel_obj)
         self.assertEqual(rel, {'type': 'Relationship', 'object': rel_obj})
 
+    def test_get_ngsild_vocab(self):
+        vocab_term = "someTerm"
+        vocab = JsonLd.get_ngsild_vocab(vocab_term)
+        self.assertEqual(vocab, {'type': 'VocabProperty', 'vocab': vocab_term})
+
     def test_get_default_value_scalars(self):
         # integer
         self.assertEqual(JsonLd.get_default_value([XSD.integer]), 0)


### PR DESCRIPTION
This PR introduces a "semantic bridge" feature that adds vocabulary properties to JSON-LD instances to enable convenient mapping back to OWL. The implementation adds a new command-line flag -sb/--semantic-bridge and includes the necessary logic to populate instances with node references when enabled.

Changes:

    Added get_ngsild_vocab method to create VocabProperty structures in JSON-LD
    Implemented semantic bridge logic to add hasNodeRef properties to instances
    Added comprehensive test coverage including new test files and a unit test
