### PR TITLE
Semantic bridge datasetid

### DIFF
--- a/semantic-model/opcua/extractType.py
+++ b/semantic-model/opcua/extractType.py
@@ -527,7 +527,7 @@ def scan_entity_recursive(node, id, instance, node_id, o, type=None, is_property
 will flag this.")
             datasetId = "@none"
         else:
-            datasetId = f'{datasetid_urn}:{original_attributename}'
+            datasetId = rdfutils.get_semantic_bridge(g, node, o)
 
     if rdfutils.isObjectNodeClass(nodeclass):
         shacl_rule['is_property'] = False

--- a/semantic-model/opcua/tests/extractType/test_pumps_instanceexample.instances
+++ b/semantic-model/opcua/tests/extractType/test_pumps_instanceexample.instances
@@ -393,7 +393,7 @@
             {
                 "type": "Relationship",
                 "object": "http://yourorganisation.org/InstanceExample/testid:i5019",
-                "datasetId": "urn:iff:datasetId:Sensor1"
+                "datasetId": "http://yourorganisation.org/InstanceExample/hasSensor1"
             }
         ],
         "pumps:hasSpeed": {


### PR DESCRIPTION
This PR adds semantic bridge functionality to enable convenient mapping back to OWL by including node references in the JSON-LD output. This is controlled by a new -sb command-line flag.

Changes:

    Added get_ngsild_vocab method to create VocabProperty entries for semantic bridging
    Updated datasetId generation to use semantic bridge URIs instead of URN-based identifiers
    Added new test files to validate semantic bridge functionality
