### PR TITLE
Remove sqlite3 vulnerability

### DIFF
--- a/NgsildAgent/package.json
+++ b/NgsildAgent/package.json
@@ -17,7 +17,9 @@
     "json-schema": "^0.4.0",
     "jwt-decode": "^2.2.0",
     "mqtt": "^5.3.4",
-    "sqlite3": "^5.1.6",
+    "node-gyp": "^12.1.0",
+    "sqlite3": "npm:@appthreat/sqlite3@^6.0.9",
+    "tar": "^7.5.3",
     "validate-iri": "^1.0.1",
     "winston": "^3.7.2"
   },
@@ -26,9 +28,9 @@
     "chai": "^4.5.0",
     "eslint": "^9.11.0",
     "globals": "^15.9.0",
-    "mocha": "^10.7.3",
+    "mocha": "^11.7.5",
     "proxyquire": "^2.1.3",
-    "sinon": "^15.2.0",
+    "sinon": "^21.0.1",
     "sinon-chai": "^3.7.0"
   }
 }


### PR DESCRIPTION
This PR addresses security vulnerabilities by replacing the sqlite3 dependency with a more secure fork (@appthreat/sqlite3) and updating related development dependencies.

Changes:

- Migrated from sqlite3 to @appthreat/sqlite3 for improved security
- Added node-gyp and tar as explicit dependencies to support the new sqlite3 fork
- Updated testing dependencies (mocha and sinon) to their latest versions