### PR TITLE
Remove direct dependency of NGSI-LD Agent on tar library 

### DIFF
--- a/NgsildAgent/package.json
+++ b/NgsildAgent/package.json
@@ -19,7 +19,6 @@
     "mqtt": "^5.3.4",
     "node-gyp": "^12.1.0",
     "sqlite3": "npm:@appthreat/sqlite3@^6.0.9",
-    "tar": "^7.5.3",
     "validate-iri": "^1.0.1",
     "winston": "^3.7.2"
   },


### PR DESCRIPTION
Remove the direct tar npm dependency from the NgsildAgent package
This PR removes the direct tar npm dependency from the NgsildAgent package, reducing the dependency surface area for the agent’s Node.js runtime.

Changes:

   - Removed tar from dependencies in NgsildAgent/package.json.