### PR TITLE
Flink Operator 1.14.0 update, fix for coredns setup patch

### DIFF
--- a/helm/airgap-deployment/prepare-airgap.bash
+++ b/helm/airgap-deployment/prepare-airgap.bash
@@ -114,5 +114,5 @@ wget -O- https://github.com/strimzi/strimzi-kafka-operator/releases/download/${S
 ( cd ${OFFLINE_DIR} && rm -rf postgres-operator && git clone https://github.com/zalando/postgres-operator.git && cd postgres-operator && git checkout ${POSTGRES_OPERATOR_VERSION} )
 ( cd ${OFFLINE_DIR} && rm -rf helm-charts && git clone https://github.com/vmware-tanzu/helm-charts.git && cd helm-charts && git checkout ${VELERO_HELM_VERSION})
 ( cd ${OFFLINE_DIR} && rm -rf Reloader && git clone https://github.com/stakater/Reloader.git && cd Reloader && git checkout ${RELOADER_HELM_VERSION})
-( cd ${OFFLINE_DIR} && rm -rf kubernetes-flink-operator && wget -r --no-parent -e robots=off https://downloads.apache.org/flink/flink-kubernetes-operator-1.11.0/ && 
+( cd ${OFFLINE_DIR} && rm -rf kubernetes-flink-operator && wget -r --no-parent -e robots=off https://downloads.apache.org/flink/flink-kubernetes-operator-1.14.0/ && 
   mv downloads.apache.org/flink/flink-kubernetes-operator-* flink-kubernetes-operator)

--- a/helm/install_operators.sh
+++ b/helm/install_operators.sh
@@ -119,6 +119,7 @@ printf -- "------------------------\033[0m\n"
 if [ "$OFFLINE" = "true" ]; then
   ( cd ${OFFLINE_DIR}/postgres-operator && helm -n iff upgrade --install postgres-operator ./charts/postgres-operator --set image.registry=${EXT_REGISTRY3} --set configGeneral.docker_image=${EXT_REGISTRY4}/zalando/spilo-15:2.1-p9)
 else
+  rm -rf postgres-operator
   git clone https://github.com/zalando/postgres-operator.git
   ( cd postgres-operator && git fetch && git checkout ${POSTGRES_OPERATOR_VERSION} && helm -n iff upgrade --install postgres-operator ./charts/postgres-operator )
 fi
@@ -179,10 +180,10 @@ if [ "$LOCAL" = "true" ]; then
   echo selected local image for flink operator: ${FLINK_OPERATOR_IMAGE_REGISTRY}
 fi
 if [ "$OFFLINE" = "true" ]; then
-  ( cd ${OFFLINE_DIR}/flink-kubernetes-operator && helm -n ${NAMESPACE} upgrade --install flink-kubernetes-operator flink-kubernetes-operator-1.11.0-helm.tgz \
+  ( cd ${OFFLINE_DIR}/flink-kubernetes-operator && helm -n ${NAMESPACE} upgrade --install flink-kubernetes-operator flink-kubernetes-operator-1.14.0-helm.tgz \
       --set image.repository="${FLINK_OPERATOR_IMAGE_REGISTRY}/flink-operator" --set image.tag="${DOCKER_TAG}" )
 else
-  helm repo add flink-kubernetes-operator https://downloads.apache.org/flink/flink-kubernetes-operator-1.11.0
+  helm repo add flink-kubernetes-operator https://downloads.apache.org/flink/flink-kubernetes-operator-1.14.0
   helm repo update
   helm -n ${NAMESPACE} install flink-kubernetes-operator flink-kubernetes-operator/flink-kubernetes-operator --set image.repository="${FLINK_OPERATOR_IMAGE_REGISTRY}/flink-operator" --set image.tag="${DOCKER_TAG}"
 

--- a/test/setup-local-ingress.sh
+++ b/test/setup-local-ingress.sh
@@ -18,20 +18,28 @@ if [ -z "${SELF_HOSTED_RUNNER}" ]; then
     SUDO=sudo
 fi
 
-# Patch Coredns to add keyloak.local
+# Create custom CoreDNS ConfigMap
 # ----------------------------------
-kubectl -n kube-system get cm/coredns -o jsonpath=\{".data.Corefile"\} > /tmp/Corefile || exit 1
-kubectl -n kube-system get cm/coredns -o jsonpath=\{".data.NodeHosts"\} > /tmp/NodeHosts || exit 1
-
 while [ -z "$INGRESS_IP" ]; do
     INGRESS_IP=$(kubectl -n iff get ingress/keycloak-iff-ingress -o jsonpath=\{".status.loadBalancer.ingress[0].ip"\})
     echo waiting for ingress to provide IP-Address
     sleep 1
 done
-echo "$INGRESS_IP" keycloak.local >> /tmp/NodeHosts || exit 1
 
-kubectl -n kube-system create cm coredns  --from-file=/tmp/NodeHosts --from-file=/tmp/Corefile --dry-run=client -o yaml | kubectl replace -f -
-kubectl -n kube-system patch cm coredns -p '{"immutable":true}'
+kubectl apply -f - <<EOF
+apiVersion: v1
+data:
+  customhosts.override: |
+    template IN A {
+      match (keycloak|ngsild|mqtt|alerta|pgrest)\.local\.$
+      answer "{{ .Name }} 60 IN A $INGRESS_IP"
+      fallthrough
+    }
+kind: ConfigMap
+metadata:  
+  name: coredns-custom
+  namespace: kube-system
+EOF
 # Restart coredns
 # ---------------
 COREDNS_POD=$(kubectl -n kube-system get pod --selector=k8s-app=kube-dns -o jsonpath=\{".items[0].metadata.name"\})


### PR DESCRIPTION
1. Upgrades Flink Operator version from 1.11.0 to 1.14.0 in install operators.
2. Adds postgres-operator folder cleanup for reinstallation.
3. Updates setup of local ingress with coredns custom configmap instaed of editing the main coredns configmap. Main configmap will reset on restart: https://github.com/k3s-io/k3s/pull/4397#discussion_r743207524