### PR TITLE
Potential fix for code scanning alert no. 41: Incomplete URL substring sanitization

### DIFF
--- a/KafkaBridge/lib/debeziumBridge.js
+++ b/KafkaBridge/lib/debeziumBridge.js
@@ -23,6 +23,19 @@ module.exports = function DebeziumBridge (conf) {
   const logger = new Logger(config);
   const syncOnAttribute = config.bridgeCommon.kafkaSyncOnAttribute;
 
+  function hasType(typeField, expectedType) {
+    if (!typeField) {
+      return false;
+    }
+    if (Array.isArray(typeField)) {
+      return typeField.includes(expectedType);
+    }
+    if (typeof typeField === 'string') {
+      return typeField === expectedType;
+    }
+    return false;
+  }
+
   /**
    *
    * @param {object} body - object from stateUpdate
@@ -218,7 +231,7 @@ module.exports = function DebeziumBridge (conf) {
               attribute.type = 'https://uri.etsi.org/ngsi-ld/JsonProperty';
               attribute.nodeType = '@list';
             }
-          } else if (refObj['@type'].includes('https://uri.etsi.org/ngsi-ld/Relationship')) {
+          } else if (hasType(refObj['@type'], 'https://uri.etsi.org/ngsi-ld/Relationship')) {
             if ('https://uri.etsi.org/ngsi-ld/hasObject' in refObj && refObj['https://uri.etsi.org/ngsi-ld/hasObject'].length > 0) {
               attribute.type = 'https://uri.etsi.org/ngsi-ld/Relationship';
               attribute.attributeValue = refObj['https://uri.etsi.org/ngsi-ld/hasObject'][0]['@id'];


### PR DESCRIPTION
Potential fix for [https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/41](https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/41)

In general, the problem should be fixed by avoiding substring checks on URL/IRI-looking values and instead performing exact comparisons on parsed or clearly delimited values. For `@type`, that means normalizing it to an array of strings and checking whether any entry equals the expected NGSI‑LD URI, rather than whether the whole field “includes” the URI substring.

The best targeted fix here is to introduce a small helper that, given a `typeField` and an expected URI string, returns `true` if and only if `typeField` represents a single type or an array of types that contains that URI as a full element. Then replace the existing `.includes('https://uri.etsi.org/ngsi-ld/Relationship')` check with a call to this helper. This avoids changing the observable behavior for the normal case (where `@type` is either a string equal to that URI or an array that contains it) but prevents accidental matches where the URI appears only as a substring. Concretely:

- Add a helper function, e.g. `function hasType(typeField, expectedType) { ... }`, near the top of `DebeziumBridge` (within the same file, before `this.parse` or at least before it is first used).
- This helper will:
  - Return `false` if `typeField` is `null`/`undefined`.
  - If `Array.isArray(typeField)`, return `typeField.includes(expectedType)`.
  - If `typeof typeField === 'string'`, return `typeField === expectedType`.
  - Otherwise return `false`.
- Change the condition on line 221 from `refObj['@type'].includes('https://uri.etsi.org/ngsi-ld/Relationship')` to `hasType(refObj['@type'], 'https://uri.etsi.org/ngsi-ld/Relationship')`.

No external packages are needed; we can use native JavaScript array and string operations. This minimizes surface area of the change and keeps semantics tight.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
