### PR TITLE
Potential fix for code scanning alert no. 40: Incomplete URL substring sanitization

### DIFF
--- a/KafkaBridge/lib/debeziumBridge.js
+++ b/KafkaBridge/lib/debeziumBridge.js
@@ -177,7 +177,12 @@ module.exports = function DebeziumBridge (conf) {
                 }
               }
             }
-          } else if (refObj['@type'].includes('https://uri.etsi.org/ngsi-ld/GeoProperty')) {
+          } else if (
+            (Array.isArray(refObj['@type']) &&
+              refObj['@type'].includes('https://uri.etsi.org/ngsi-ld/GeoProperty')) ||
+            (!Array.isArray(refObj['@type']) &&
+              refObj['@type'] === 'https://uri.etsi.org/ngsi-ld/GeoProperty')
+          ) {
             if ('https://uri.etsi.org/ngsi-ld/hasValue' in refObj && refObj['https://uri.etsi.org/ngsi-ld/hasValue'].length > 0) {
               const obj = refObj['https://uri.etsi.org/ngsi-ld/hasValue'][0];
               if (typeof (obj) !== 'object') {
@@ -195,7 +200,12 @@ module.exports = function DebeziumBridge (conf) {
               attribute.type = 'https://uri.etsi.org/ngsi-ld/GeoProperty';
               attribute.nodeType = '@json';
             }
-          } else if (refObj['@type'].includes('https://uri.etsi.org/ngsi-ld/JsonProperty')) {
+          } else if (
+            (Array.isArray(refObj['@type']) &&
+              refObj['@type'].includes('https://uri.etsi.org/ngsi-ld/JsonProperty')) ||
+            (!Array.isArray(refObj['@type']) &&
+              refObj['@type'] === 'https://uri.etsi.org/ngsi-ld/JsonProperty')
+          ) {
             if ('https://uri.etsi.org/ngsi-ld/hasJSON' in refObj && refObj['https://uri.etsi.org/ngsi-ld/hasJSON'].length > 0) {
               const obj = refObj['https://uri.etsi.org/ngsi-ld/hasJSON'][0]['@value'];
               if (typeof (obj) !== 'object') {
@@ -206,7 +216,12 @@ module.exports = function DebeziumBridge (conf) {
               attribute.type = 'https://uri.etsi.org/ngsi-ld/JsonProperty';
               attribute.nodeType = '@json';
             }
-          } else if (refObj['@type'].includes('https://uri.etsi.org/ngsi-ld/ListProperty')) {
+          } else if (
+            (Array.isArray(refObj['@type']) &&
+              refObj['@type'].includes('https://uri.etsi.org/ngsi-ld/ListProperty')) ||
+            (!Array.isArray(refObj['@type']) &&
+              refObj['@type'] === 'https://uri.etsi.org/ngsi-ld/ListProperty')
+          ) {
             if ('https://uri.etsi.org/ngsi-ld/hasValueList' in refObj && refObj['https://uri.etsi.org/ngsi-ld/hasValueList'].length > 0) {
               let lst = refObj['https://uri.etsi.org/ngsi-ld/hasValueList'][0]['@list'];
               if (!Array.isArray(lst)) {
@@ -218,7 +233,12 @@ module.exports = function DebeziumBridge (conf) {
               attribute.type = 'https://uri.etsi.org/ngsi-ld/JsonProperty';
               attribute.nodeType = '@list';
             }
-          } else if (refObj['@type'].includes('https://uri.etsi.org/ngsi-ld/Relationship')) {
+          } else if (
+            (Array.isArray(refObj['@type']) &&
+              refObj['@type'].includes('https://uri.etsi.org/ngsi-ld/Relationship')) ||
+            (!Array.isArray(refObj['@type']) &&
+              refObj['@type'] === 'https://uri.etsi.org/ngsi-ld/Relationship')
+          ) {
             if ('https://uri.etsi.org/ngsi-ld/hasObject' in refObj && refObj['https://uri.etsi.org/ngsi-ld/hasObject'].length > 0) {
               attribute.type = 'https://uri.etsi.org/ngsi-ld/Relationship';
               attribute.attributeValue = refObj['https://uri.etsi.org/ngsi-ld/hasObject'][0]['@id'];


### PR DESCRIPTION
Potential fix for [https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/40](https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/40)

In general, to fix incomplete URL substring sanitization, avoid substring checks like `str.includes("https://trusted")` when deciding if a value is one of a trusted set. Instead, compare the parsed and normalized value (host, full IRI, etc.) against an explicit whitelist using exact equality or clearly defined prefix rules.

Here, `refObj['@type']` is either a string or an array of strings. The intent is to check if the exact type `'https://uri.etsi.org/ngsi-ld/ListProperty'` is present, not whether that substring appears anywhere. The safest and most precise fix is:

- Ensure `refObj['@type']` is always an array of strings (the code already does this just above).
- Replace `.includes('https://uri.etsi.org/ngsi-ld/ListProperty')` with an exact membership test on that array, e.g. `refObj['@type'].indexOf('...ListProperty') !== -1` or, in modern Node, `Array.prototype.includes` on the array. That checks for equality of array elements, not for substrings within a URL.

We should apply this same pattern consistently to the other type checks (`Property`, `GeoProperty`, `JsonProperty`, `Relationship`) to keep semantics uniform and to avoid similar static-analysis flags there, but the minimal necessary fix is at least to correct line 209. No new methods or imports are required; we only switch from string-`includes` semantics to array-membership semantics.

Concretely in `KafkaBridge/lib/debeziumBridge.js` around lines 154–222:

- Replace each `refObj['@type'].includes('https://uri.etsi.org/ngsi-ld/...')` with `Array.isArray(refObj['@type']) ? refObj['@type'].includes('https://uri.etsi.org/ngsi-ld/...') : refObj['@type'] === 'https://uri.etsi.org/ngsi-ld/...'`.

This preserves existing behavior for the common case (where `@type` is an array, ensured by lines 154–156), and still works defensively if that invariant changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
