### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/FlinkSqlGateway/gateway.js
+++ b/FlinkSqlGateway/gateway.js
@@ -142,6 +142,11 @@ function apppost (request, response) {
 
 function udfget (req, res) {
   const filename = req.params.filename;
+  if (!isValidUdfFilename(filename)) {
+    res.status(400).send('Invalid filename');
+    logger.info('Rejected invalid python_udf get filename: ' + filename);
+    return;
+  }
   logger.debug('python_udf get was requested for: ' + filename);
   const fullname = `${udfdir}/${filename}.py`;
   try {
@@ -156,6 +161,11 @@ function udfget (req, res) {
 
 function udfpost (req, res) {
   const filename = req.params.filename;
+  if (!isValidUdfFilename(filename)) {
+    res.status(400).send('Invalid filename');
+    logger.info('Rejected invalid python_udf post filename: ' + filename);
+    return;
+  }
   const body = req.body;
   if (body === undefined || body === null) {
     res.status(500);
@@ -185,6 +195,11 @@ function getLocalPythonUdfs () {
   files.forEach(x => { verfiles[x[0]] = x[1]; });
   const result = Object.keys(verfiles).map(x => `${x}_v${verfiles[x]}.py`).map(x => `${udfdir}/${x}`);
   return result;
+}
+
+function isValidUdfFilename (name) {
+  // Allow only letters, digits, underscores, and hyphens to avoid path traversal and unsafe filenames.
+  return typeof name === 'string' && /^[A-Za-z0-9_-]+$/.test(name);
 }
 
 app.use(express.json({ limit: '10mb' }));


### PR DESCRIPTION
Potential fix for [https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/2](https://github.com/IndustryFusion/DigitalTwin/security/code-scanning/2)

In general, to fix this type of issue you must constrain user-controlled path components so they cannot escape an intended root directory or reference unexpected files. For REST endpoints that are meant to work with named resources (like UDF names), the simplest and safest option is to restrict the allowed filename pattern (for example, only letters, digits, underscores, and hyphens) and reject anything else. This prevents `..`, slashes, and other special characters from being used to traverse directories or craft surprising filenames.

For this code, the best minimally invasive fix is to validate `req.params.filename` in both `udfget` and `udfpost` before constructing `fullname`. We can enforce a conservative regex such as `/^[A-Za-z0-9_\-]+$/`, returning HTTP 400 if the parameter does not match. This keeps existing behavior for valid names (still stored under `udfdir` with a `.py` extension) and only blocks unsafe values. We do not need extra libraries; a small helper function defined in this file is enough.

Concretely:
- Add a small helper `isValidUdfFilename(name)` near the other helper functions that tests the filename against a safe regex.
- In `udfget`, immediately after reading `const filename = req.params.filename;`, check `if (!isValidUdfFilename(filename)) { ... }` and respond with a `400` status and an explanatory message, then `return`.
- Do the same in `udfpost` just after getting `const filename = req.params.filename;`.
- Leave the rest of the logic, including `fullname` construction and filesystem operations, unchanged.

All required pieces fit within `FlinkSqlGateway/gateway.js`; no new imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
