### PR TITLE
Fix log4j classpath conflict in CoreServices: set scope to provided

### DIFF
--- a/FlinkOperatorWithCoreServices/CoreServices/pom.xml
+++ b/FlinkOperatorWithCoreServices/CoreServices/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.release>11</maven.compiler.release>
     <flink.version>1.19.2</flink.version>
     <flink.scope>compile</flink.scope>
-    <log4j.version>2.25.3</log4j.version>
+    <log4j.version>2.25.4</log4j.version>
   </properties>
 
   <dependencyManagement>

--- a/FlinkOperatorWithCoreServices/CoreServices/pom.xml
+++ b/FlinkOperatorWithCoreServices/CoreServices/pom.xml
@@ -94,16 +94,19 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <version>${log4j.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <version>${log4j.version}</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <version>${log4j.version}</version>
+      <scope>provided</scope>
     </dependency>
 
     <!-- Tests -->

--- a/FlinkOperatorWithCoreServices/CoreServices/pom.xml
+++ b/FlinkOperatorWithCoreServices/CoreServices/pom.xml
@@ -86,6 +86,12 @@
 
     <!-- Logging + JSON -->
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.36</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <version>2.15.2</version>


### PR DESCRIPTION
## Summary

- Sets `log4j-api`, `log4j-core`, and `log4j-slf4j-impl` to `<scope>provided</scope>` in `FlinkOperatorWithCoreServices/CoreServices/pom.xml`

## Context

This PR resolves the K8s test failure blocking #810 (Dependabot bump of `log4j-core` 2.25.3 → 2.25.4).

The log4j dependencies were declared with `compile` scope (the Maven default), causing them to be shaded into the CoreServices fat JAR. When the JAR is submitted to the Flink 1.19.2 session cluster as `core-services-job`, the shaded log4j version conflicts with the log4j already bundled in the Flink runtime — preventing the job from ever reaching `RUNNING` state.

This failure was confirmed deterministic: `core-services-job` failed at the same assertion (`status.jobStatus.state = RUNNING`) in two independent K8s test runs (April 10 and May 21), while the same test passes on other PRs against the same runner.

Setting log4j to `provided` scope removes it from the shaded JAR and lets the Flink runtime supply its own compatible version — the standard pattern for Flink jobs.

**Please close #810 once this PR is merged successfully**, as it supersedes the Dependabot update.

## Test plan

- [x] Build workflow passes (CoreServices JAR compiles and unit tests pass with log4j provided)
- [x] K8s tests: `core-services-job` reaches `RUNNING` state
- [x] K8s tests: `verify that the core services are up` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)