### PR TITLE
Add workflow_dispatch trigger to Docker cache cleanup

### DIFF
--- a/.github/workflows/docker-clean.yaml
+++ b/.github/workflows/docker-clean.yaml
@@ -5,6 +5,7 @@ on:
     # Runs every day at 11:00 UTC
     # ≈ 06:00 EST (winter). Adjust if you care about DST.
     - cron: '0 11 * * *'
+  workflow_dispatch:
 
 jobs:
   clean-docker:


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch:` trigger to `.github/workflows/docker-clean.yaml`
- Without this, the cleanup can only run on its daily schedule and cannot be invoked manually via `gh workflow run` or the GitHub UI

## Why

The CI monitoring process needs to run a Docker cache cleanup before each K8s test run to clear stale image layers from the self-hosted runner. The cleanup workflow currently only fires on a daily schedule (`0 11 * * *`), making it impossible to trigger on-demand.

## Test plan

- [ ] After merge, verify `gh workflow run "Docker cache cleanup" --repo IndustryFusion/DigitalTwin` completes without HTTP 422

🤖 Generated with [Claude Code](https://claude.com/claude-code)