### PR TITLE
Run Docker cache cleanup before K8s tests and raise kubelet eviction threshold to 98%

### DIFF
--- a/.github/workflows/docker-clean.yaml
+++ b/.github/workflows/docker-clean.yaml
@@ -6,6 +6,7 @@ on:
     # ≈ 06:00 EST (winter). Adjust if you care about DST.
     - cron: '0 11 * * *'
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   clean-docker:

--- a/.github/workflows/k8s-tests.yaml
+++ b/.github/workflows/k8s-tests.yaml
@@ -11,7 +11,11 @@ env:
   SELF_HOSTED_RUNNER: true
 
 jobs:
+  clean-docker:
+    uses: ./.github/workflows/docker-clean.yaml
+
   build:
+    needs: clean-docker
     runs-on: private
     steps:
     - uses: actions/checkout@v2

--- a/test/prepare-platform-for-self-hosted-runner.sh
+++ b/test/prepare-platform-for-self-hosted-runner.sh
@@ -23,7 +23,8 @@ echo ----------------------
 ## k3d cluster with 2 nodes
 k3d registry create iff.localhost -p 12345
 k3d cluster list | grep iff-cluster > /dev/null && k3d cluster delete iff-cluster
-k3d cluster create --image ${K3S_IMAGE} -a 2 --registry-use k3d-iff.localhost:12345 iff-cluster
+k3d cluster create --image ${K3S_IMAGE} -a 2 --registry-use k3d-iff.localhost:12345 iff-cluster \
+  --k3s-arg "--kubelet-arg=eviction-hard=imagefs.available<2%,nodefs.available<2%,nodefs.inodesFree<2%@all"
 
 echo Install Helm diff plugin
 echo ------------------------ 

--- a/test/prepare-platform.sh
+++ b/test/prepare-platform.sh
@@ -67,7 +67,8 @@ echo ----------------------
 ## k3d cluster with 2 nodes
 curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v5.8.3 bash
 k3d registry create iff.localhost -p 12345
-k3d cluster create --image ${K3S_IMAGE} -a 2 --registry-use k3d-iff.localhost:12345 iff-cluster
+k3d cluster create --image ${K3S_IMAGE} -a 2 --registry-use k3d-iff.localhost:12345 iff-cluster \
+  --k3s-arg "--kubelet-arg=eviction-hard=imagefs.available<2%,nodefs.available<2%,nodefs.inodesFree<2%@all"
 
 if [ -z "$BUILDONLY" ];then
     echo Install Helm v3.10.3


### PR DESCRIPTION
## Summary

- Add `workflow_call` trigger to `docker-clean.yaml` so it can be used as a reusable workflow
- Add a `clean-docker` pre-job to `k8s-tests.yaml` that calls `docker-clean.yaml`; the `build` job now has `needs: clean-docker` so the Docker cache is always purged before cluster setup begins
- Pass `--kubelet-arg=eviction-hard=imagefs.available<2%,nodefs.available<2%,nodefs.inodesFree<2%` to both `k3d cluster create` calls so K8s does not apply disk pressure or reject volume creation until the disk is 98% full (default threshold is 90%)

## Test plan

- [ ] Build workflow passes
- [ ] K8s tests workflow shows a `clean-docker` job running before `build`
- [ ] Cluster starts without disk-pressure taint even when disk usage exceeds 90%

🤖 Generated with [Claude Code](https://claude.com/claude-code)