### PR TITLE
Fix high-severity security vulnerability in datamodel/tools

### DIFF
--- a/semantic-model/datamodel/tools/package-lock.json
+++ b/semantic-model/datamodel/tools/package-lock.json
@@ -9369,14 +9369,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -10309,11 +10301,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-static": {

--- a/semantic-model/datamodel/tools/package.json
+++ b/semantic-model/datamodel/tools/package.json
@@ -24,5 +24,8 @@
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",
     "rewire": "^7.0.0"
+  },
+  "overrides": {
+    "serialize-javascript": ">=7.0.3"
   }
 }


### PR DESCRIPTION
## Summary

Fixes the high-severity Dependabot security alert for `serialize-javascript` in `semantic-model/datamodel/tools`:

| Package | Before | After | Alert |
|---|---|---|---|
| `serialize-javascript` | 6.0.2 | 7.0.5 | #189 |

`serialize-javascript` is a transitive dependency pulled in by `nyc`. Since `mocha`'s declared range still allows 6.x, a simple `npm audit fix` cannot resolve it; an `overrides` entry in `package.json` is required to force the patched version.

## Test plan

- [x] `npm audit` reports zero high/critical vulnerabilities after fix
- [ ] Lint and unit tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)