### PR TITLE
Fix path injection in FlinkSqlGateway udfget/udfpost

### DIFF
--- a/FlinkSqlGateway/gateway.js
+++ b/FlinkSqlGateway/gateway.js
@@ -148,7 +148,12 @@ function udfget (req, res) {
     return;
   }
   logger.debug('python_udf get was requested for: ' + filename);
-  const fullname = `${udfdir}/${filename}.py`;
+  const basedir = path.resolve(udfdir);
+  const fullname = path.resolve(udfdir, `${filename}.py`);
+  if (!fullname.startsWith(basedir + path.sep)) {
+    res.status(400).send('Invalid filename');
+    return;
+  }
   try {
     fs.readFileSync(fullname);
   } catch (err) {
@@ -173,7 +178,12 @@ function udfpost (req, res) {
     return;
   }
   logger.debug(`python_udf with name ${filename}`);
-  const fullname = `${udfdir}/${filename}.py`;
+  const basedir = path.resolve(udfdir);
+  const fullname = path.resolve(udfdir, `${filename}.py`);
+  if (!fullname.startsWith(basedir + path.sep)) {
+    res.status(400).send('Invalid filename');
+    return;
+  }
   try {
     fs.writeFileSync(fullname, body);
   } catch (err) {


### PR DESCRIPTION
## Summary

Fixes two high-severity CodeQL path-injection alerts in `FlinkSqlGateway/gateway.js`:

- Alert #2 — `fs.readFileSync` with user-controlled path (line 153)
- Alert #3 — `fs.writeFileSync` with user-controlled path (line 178)

Both `udfget` and `udfpost` already validate `filename` against a strict allowlist (`^[A-Za-z0-9_-]+$`) via `isValidUdfFilename`. This PR adds the explicit `path.resolve` + `startsWith(basedir + path.sep)` canonicalisation check that CodeQL requires to confirm the constructed path remains within `udfdir`.

PR #651 proposes a similar fix but has two issues: it removes the existing allowlist guard, and its `startsWith(udfdir)` check is missing the path separator (allowing `/tmp/udfmalicious/…` to pass).

Supersedes #651.

## Test plan

- [x] Paths containing `../` or absolute paths are rejected by the resolve/startsWith check
- [x] Valid filenames (`[A-Za-z0-9_-]+`) continue to work
- [ ] Build and unit tests pass in CI
- [ ] CodeQL scan clears alerts #2 and #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)