### PR TITLE
Add factory user MQTT subscribe-only access via Keycloak scorpio roles

### DIFF
--- a/KafkaBridge/lib/authService/acl.js
+++ b/KafkaBridge/lib/authService/acl.js
@@ -39,6 +39,7 @@ class Acl {
     }
     const topic = req.query.topic;
     const clientid = req.query.clientid;
+    const action = req.query.action;
     this.logger.debug('ACL request for username ' + username + ' and topic ' + topic);
     // allow all $SYS topics
     if (topic.startsWith('$SYS/')) {
@@ -63,14 +64,25 @@ class Acl {
           this.logger.warn('Gateway id not permitted for this token/session. Use a token which has device_id==gateway_id.');
         }
       }
-      if (allowed === undefined || allowed !== clientid) {
-        this.logger.info('Connection rejected for realm ' + spBAccountId + ' and device ' + spBdevId);
-        return res.status(200).json({ result: 'deny' });
-      } else {
+      if (allowed !== undefined && allowed === clientid) {
         return res.status(200).json({ result: 'allow' });
       }
+      if (action === 'subscribe') {
+        const factoryRealm = await this.cache.getValue(`_factory_reader/${clientid}`, 'realm');
+        if (factoryRealm !== undefined && factoryRealm === spBAccountId) {
+          return res.status(200).json({ result: 'allow' });
+        }
+      }
+      this.logger.info('Connection rejected for realm ' + spBAccountId + ' and device ' + spBdevId);
+      return res.status(200).json({ result: 'deny' });
     } else {
-      this.logger.warn('Topic sructure not valid.');
+      if (action === 'subscribe') {
+        const factoryRealm = await this.cache.getValue(`_factory_reader/${clientid}`, 'realm');
+        if (factoryRealm !== undefined) {
+          return res.status(200).json({ result: 'allow' });
+        }
+      }
+      this.logger.warn('Topic structure not valid.');
       return res.status(200).json({ result: 'deny' });
     }
   }

--- a/KafkaBridge/lib/authService/authenticate.js
+++ b/KafkaBridge/lib/authService/authenticate.js
@@ -39,6 +39,12 @@ function validate (token, username) {
   return true;
 }
 
+function isFactoryUser (token) {
+  const roles = token.resource_access?.scorpio?.roles;
+  if (!Array.isArray(roles)) return false;
+  return roles.includes('Factory-Admin') || roles.includes('Factory-Reader');
+}
+
 class Authenticate {
   constructor (config) {
     this.config = config;
@@ -87,6 +93,19 @@ class Authenticate {
     if (decodedToken === null) {
       this.logger.info('Could not decode token.');
       res.status(200).json({ result: 'deny' });
+      return;
+    }
+    if (isFactoryUser(decodedToken)) {
+      const realm = getRealm(decodedToken);
+      if (!realm) {
+        this.logger.warn('Validation failed: realm not found in factory user token.');
+        res.status(200).json({ result: 'deny' });
+        return;
+      }
+      await this.cache.deleteKeysWithValue('acl', clientid);
+      await this.cache.setValue(`_factory_reader/${clientid}`, 'acl', clientid);
+      await this.cache.setValue(`_factory_reader/${clientid}`, 'realm', realm);
+      res.status(200).json({ result: 'allow', is_superuser: 'false' });
       return;
     }
     if (!validate(decodedToken, username)) {

--- a/KafkaBridge/test/lib_authServiceTest.js
+++ b/KafkaBridge/test/lib_authServiceTest.js
@@ -345,6 +345,144 @@ describe(fileToTest, function () {
     auth.verifyAndDecodeToken(token).then(result => result.should.deep.equal(decodedToken));
     done();
   });
+
+  it('Factory user with Factory-Admin role shall be authenticated', function (done) {
+    const decodedToken = {
+      iss: 'http://keycloak-url/auth/realms/iff',
+      resource_access: {
+        scorpio: {
+          roles: ['Factory-Admin']
+        }
+      }
+    };
+    const config = {
+      mqtt: {
+        adminUsername: 'admin',
+        adminPassword: 'password'
+      }
+    };
+    const cacheEntries = {};
+    const Cache = class {
+      init () {}
+      async deleteKeysWithValue () {}
+      async setValue (key, valueKey, value) {
+        if (!cacheEntries[key]) cacheEntries[key] = {};
+        cacheEntries[key][valueKey] = value;
+      }
+    };
+    ToTest.__set__('Cache', Cache);
+    const Authenticate = ToTest.__get__('Authenticate');
+    const auth = new Authenticate(config);
+    auth.keycloakAdapter = {
+      grantManager: {
+        createGrant: () => Promise.resolve({ access_token: { content: decodedToken } })
+      }
+    };
+    const req = {
+      query: { username: 'realm_user', password: 'token', clientid: 'clientid-factory' }
+    };
+    const res = {
+      status: function (status) {
+        assert.equal(status, 200, 'Received wrong status');
+        return this;
+      },
+      json: function (resultObj) {
+        resultObj.should.deep.equal({ result: 'allow', is_superuser: 'false' });
+        assert.equal(cacheEntries['_factory_reader/clientid-factory'].acl, 'clientid-factory');
+        assert.equal(cacheEntries['_factory_reader/clientid-factory'].realm, 'iff');
+        done();
+      }
+    };
+    auth.authenticate(req, res);
+  });
+
+  it('Factory user with Factory-Reader role shall be authenticated', function (done) {
+    const decodedToken = {
+      iss: 'http://keycloak-url/auth/realms/iff',
+      resource_access: {
+        scorpio: {
+          roles: ['Factory-Reader']
+        }
+      }
+    };
+    const config = {
+      mqtt: {
+        adminUsername: 'admin',
+        adminPassword: 'password'
+      }
+    };
+    const Cache = class {
+      init () {}
+      async deleteKeysWithValue () {}
+      async setValue () {}
+    };
+    ToTest.__set__('Cache', Cache);
+    const Authenticate = ToTest.__get__('Authenticate');
+    const auth = new Authenticate(config);
+    auth.keycloakAdapter = {
+      grantManager: {
+        createGrant: () => Promise.resolve({ access_token: { content: decodedToken } })
+      }
+    };
+    const req = {
+      query: { username: 'realm_user', password: 'token', clientid: 'clientid-factory' }
+    };
+    const res = {
+      status: function (status) {
+        assert.equal(status, 200, 'Received wrong status');
+        return this;
+      },
+      json: function (resultObj) {
+        resultObj.should.deep.equal({ result: 'allow', is_superuser: 'false' });
+        done();
+      }
+    };
+    auth.authenticate(req, res);
+  });
+
+  it('User without factory roles shall be rejected by device validation', function (done) {
+    const decodedToken = {
+      iss: 'http://keycloak-url/auth/realms/iff',
+      resource_access: {
+        scorpio: {
+          roles: ['some-other-role']
+        }
+      }
+    };
+    const config = {
+      mqtt: {
+        adminUsername: 'admin',
+        adminPassword: 'password'
+      }
+    };
+    const Cache = class {
+      init () {}
+      async deleteKeysWithValue () {}
+      async setValue () {}
+    };
+    ToTest.__set__('Cache', Cache);
+    const Authenticate = ToTest.__get__('Authenticate');
+    const auth = new Authenticate(config);
+    auth.keycloakAdapter = {
+      grantManager: {
+        createGrant: () => Promise.resolve({ access_token: { content: decodedToken } })
+      }
+    };
+    const req = {
+      query: { username: 'realm_user', password: 'token', clientid: 'clientid-1' }
+    };
+    const res = {
+      status: function (status) {
+        assert.equal(status, 200, 'Received wrong status');
+        return this;
+      },
+      json: function (resultObj) {
+        resultObj.should.deep.equal({ result: 'deny' });
+        done();
+      }
+    };
+    auth.authenticate(req, res);
+  });
 });
 
 fileToTest = '../lib/authService/acl.js';
@@ -490,6 +628,212 @@ describe(fileToTest, function () {
       query: {
         username: 'username',
         topic: 'spBv1.0/accountId/DBIRTH/eonID/deviceId'
+      }
+    };
+    const res = {
+      status: function (status) {
+        assert.equal(status, 200, 'Received wrong status');
+        return this;
+      },
+      json: function (resultObj) {
+        resultObj.should.deep.equal({ result: 'deny' });
+        done();
+      }
+    };
+    acl.acl(req, res);
+  });
+
+  it('Factory user shall be allowed to subscribe to arbitrary SparkplugB topic', function (done) {
+    const Cache = class {
+      constructor () {}
+      async getValue (key, valueKey) {
+        if (key === '_factory_reader/clientid' && valueKey === 'realm') return 'iff';
+        return undefined;
+      }
+    };
+    ToTest.__set__('Cache', Cache);
+    const config = {
+      mqtt: { adminUsername: 'superuser', adminPassword: 'password' }
+    };
+    const Acl = ToTest.__get__('Acl');
+    const acl = new Acl(config);
+    const req = {
+      query: {
+        username: 'realm_user',
+        clientid: 'clientid',
+        topic: 'spBv1.0/iff/DDATA/anygateway/anydevice',
+        action: 'subscribe'
+      }
+    };
+    const res = {
+      status: function (status) {
+        assert.equal(status, 200, 'Received wrong status');
+        return this;
+      },
+      json: function (resultObj) {
+        resultObj.should.deep.equal({ result: 'allow' });
+        done();
+      }
+    };
+    acl.acl(req, res);
+  });
+
+  it('Factory user shall be denied to publish to SparkplugB topic', function (done) {
+    const Cache = class {
+      constructor () {}
+      async getValue (key, valueKey) {
+        if (key === '_factory_reader/clientid' && valueKey === 'realm') return 'iff';
+        return undefined;
+      }
+    };
+    ToTest.__set__('Cache', Cache);
+    const config = {
+      mqtt: { adminUsername: 'superuser', adminPassword: 'password' }
+    };
+    const Acl = ToTest.__get__('Acl');
+    const acl = new Acl(config);
+    const req = {
+      query: {
+        username: 'realm_user',
+        clientid: 'clientid',
+        topic: 'spBv1.0/iff/DDATA/anygateway/anydevice',
+        action: 'publish'
+      }
+    };
+    const res = {
+      status: function (status) {
+        assert.equal(status, 200, 'Received wrong status');
+        return this;
+      },
+      json: function (resultObj) {
+        resultObj.should.deep.equal({ result: 'deny' });
+        done();
+      }
+    };
+    acl.acl(req, res);
+  });
+
+  it('Factory user shall be denied access to topic in a different realm', function (done) {
+    const Cache = class {
+      constructor () {}
+      async getValue (key, valueKey) {
+        if (key === '_factory_reader/clientid' && valueKey === 'realm') return 'iff';
+        return undefined;
+      }
+    };
+    ToTest.__set__('Cache', Cache);
+    const config = {
+      mqtt: { adminUsername: 'superuser', adminPassword: 'password' }
+    };
+    const Acl = ToTest.__get__('Acl');
+    const acl = new Acl(config);
+    const req = {
+      query: {
+        username: 'realm_user',
+        clientid: 'clientid',
+        topic: 'spBv1.0/other-realm/DDATA/anygateway/anydevice',
+        action: 'subscribe'
+      }
+    };
+    const res = {
+      status: function (status) {
+        assert.equal(status, 200, 'Received wrong status');
+        return this;
+      },
+      json: function (resultObj) {
+        resultObj.should.deep.equal({ result: 'deny' });
+        done();
+      }
+    };
+    acl.acl(req, res);
+  });
+
+  it('Factory user shall be denied when action is not provided', function (done) {
+    const Cache = class {
+      constructor () {}
+      async getValue (key, valueKey) {
+        if (key === '_factory_reader/clientid' && valueKey === 'realm') return 'iff';
+        return undefined;
+      }
+    };
+    ToTest.__set__('Cache', Cache);
+    const config = {
+      mqtt: { adminUsername: 'superuser', adminPassword: 'password' }
+    };
+    const Acl = ToTest.__get__('Acl');
+    const acl = new Acl(config);
+    const req = {
+      query: {
+        username: 'realm_user',
+        clientid: 'clientid',
+        topic: 'spBv1.0/iff/DDATA/anygateway/anydevice'
+      }
+    };
+    const res = {
+      status: function (status) {
+        assert.equal(status, 200, 'Received wrong status');
+        return this;
+      },
+      json: function (resultObj) {
+        resultObj.should.deep.equal({ result: 'deny' });
+        done();
+      }
+    };
+    acl.acl(req, res);
+  });
+
+  it('Factory user shall be allowed to subscribe to non-SparkplugB topic', function (done) {
+    const Cache = class {
+      constructor () {}
+      async getValue (key, valueKey) {
+        if (key === '_factory_reader/clientid' && valueKey === 'realm') return 'iff';
+        return undefined;
+      }
+    };
+    ToTest.__set__('Cache', Cache);
+    const config = {
+      mqtt: { adminUsername: 'superuser', adminPassword: 'password' }
+    };
+    const Acl = ToTest.__get__('Acl');
+    const acl = new Acl(config);
+    const req = {
+      query: {
+        username: 'realm_user',
+        clientid: 'clientid',
+        action: 'subscribe',
+        topic: 'scorpio-test'
+      }
+    };
+    const res = {
+      status: function (status) {
+        assert.equal(status, 200, 'Received wrong status');
+        return this;
+      },
+      json: function (resultObj) {
+        resultObj.should.deep.equal({ result: 'allow' });
+        done();
+      }
+    };
+    acl.acl(req, res);
+  });
+
+  it('Non-factory user shall be denied on non-SparkplugB topic', function (done) {
+    const Cache = class {
+      constructor () {}
+      async getValue () { return undefined; }
+    };
+    ToTest.__set__('Cache', Cache);
+    const config = {
+      mqtt: { adminUsername: 'superuser', adminPassword: 'password' }
+    };
+    const Acl = ToTest.__get__('Acl');
+    const acl = new Acl(config);
+    const req = {
+      query: {
+        username: 'realm_user',
+        clientid: 'clientid',
+        action: 'subscribe',
+        topic: 'scorpio-test'
       }
     };
     const res = {

--- a/helm/charts/emqx/templates/emxq.yaml
+++ b/helm/charts/emqx/templates/emxq.yaml
@@ -61,6 +61,7 @@ spec:
                         username = "${username}"
                         topic = "${topic}"
                         clientid = "${clientid}"
+                        action = "${action}"
                     }
                     headers {
                         "X-Request-Source" = "EMQX"

--- a/helm/charts/keycloak/templates/keycloak-realm.yaml
+++ b/helm/charts/keycloak/templates/keycloak-realm.yaml
@@ -578,6 +578,14 @@ spec:
         {{- range .Values.keycloak.alerta.defaultClientScopes}}
         - {{.}}
         {{- end }}
+        protocolMappers:
+        - name: mqtt-broker-audience
+          protocol: openid-connect
+          protocolMapper: oidc-audience-mapper
+          config:
+            included.client.audience: {{ .Values.keycloak.oisp.mqttBroker.client }}
+            access.token.claim: "true"
+            id.token.claim: "false"
       - id: 2057e003-9e81-44fb-929d-4511ce2c7e33
         clientId: {{ .Values.keycloak.ngsildUpdates.client }}
         publicClient: False

--- a/test/bats/test-scorpio/test-scorpio-mqtt-subscriptions.bats
+++ b/test/bats/test-scorpio/test-scorpio-mqtt-subscriptions.bats
@@ -12,6 +12,13 @@ KEYCLOAK_URL=http://keycloak.local/auth/realms
 MQTT_URL=emqx-listeners:1883
 MQTT_TOPIC_NAME="scorpio-test"
 MQTT_SUB=/tmp/MQTT_SUB
+MQTT_FACTORY_SUB=/tmp/MQTT_FACTORY_SUB
+MQTT_SPB_TOPIC="spBv1.0/${NAMESPACE}/DDATA/testgateway/testdevice"
+MQTT_WRONG_REALM_TOPIC="spBv1.0/wrong-realm/DDATA/testgateway/testdevice"
+MQTT_FACTORY_MSG='{"factory_test":true,"timestamp":1655974018778}'
+DEVICE_CLIENT_ID=device
+DEVICE_ID=testdevice
+GATEWAY_ID=testgateway
 PLASMACUTTER_ID=urn:plasmacutter-test:12345
 SUB_ID=urn:subscription-test:1
 CUTTER=/tmp/CUTTER
@@ -34,6 +41,25 @@ get_password() {
 
 get_token() {
     curl -d "client_id=${CLIENT_ID}" -d "username=${USER}" -d "password=$password" -d 'grant_type=password' "${KEYCLOAK_URL}/${NAMESPACE}/protocol/openid-connect/token" | jq ".access_token" | tr -d '"'
+}
+
+get_vanilla_refresh_and_access_token() {
+    curl -X POST "${KEYCLOAK_URL}/${NAMESPACE}/protocol/openid-connect/token" \
+        -d "client_id=${DEVICE_CLIENT_ID}" \
+        -d "grant_type=password" \
+        -d "username=${USER}" \
+        -d "password=${password}"
+}
+
+get_refreshed_device_token() {
+    curl -X POST "${KEYCLOAK_URL}/${NAMESPACE}/protocol/openid-connect/token" \
+        -d "client_id=${DEVICE_CLIENT_ID}" \
+        -d "grant_type=refresh_token" \
+        -d "refresh_token=$1" \
+        -d "orig_token=$2" \
+        -H "X-DeviceID: ${DEVICE_ID}" \
+        -H "X-GatewayID: ${GATEWAY_ID}" \
+        | jq ".access_token" | tr -d '"'
 }
 
 create_subscription() {
@@ -245,4 +271,90 @@ check_no_delete_notification() {
 
     run check_no_delete_notification ${MQTT_SUB}
     [ "$status" -eq 0 ]
+}
+
+@test "verify factory user can subscribe to arbitrary SparkplugB topic" {
+    $SKIP
+    admin_password=$(get_adminPassword | tr -d '"')
+    admin_username=$(get_adminUsername | tr -d '"')
+    password=$(get_password)
+    token=$(get_token)
+    : > "${MQTT_FACTORY_SUB}"
+    (exec stdbuf -oL mosquitto_sub -L "mqtt://${USER}:${token}@${MQTT_URL}/${MQTT_SPB_TOPIC}" >"${MQTT_FACTORY_SUB}") &
+    sleep 2
+    mosquitto_pub -L "mqtt://${admin_username}:${admin_password}@${MQTT_URL}/${MQTT_SPB_TOPIC}" -m "${MQTT_FACTORY_MSG}"
+    sleep 2
+    killall mosquitto_sub
+
+    run grep -q "factory_test" "${MQTT_FACTORY_SUB}"
+    [ "$status" -eq 0 ]
+}
+
+@test "verify factory user publish to SparkplugB topic is silently dropped" {
+    $SKIP
+    password=$(get_password)
+    token=$(get_token)
+    : > "${MQTT_FACTORY_SUB}"
+    (exec stdbuf -oL mosquitto_sub -L "mqtt://${USER}:${token}@${MQTT_URL}/${MQTT_SPB_TOPIC}" >"${MQTT_FACTORY_SUB}") &
+    sleep 2
+    mosquitto_pub -L "mqtt://${USER}:${token}@${MQTT_URL}/${MQTT_SPB_TOPIC}" -m "${MQTT_FACTORY_MSG}"
+    sleep 2
+    killall mosquitto_sub
+
+    # EMQX deny_action=ignore silently drops the publish; factory subscriber receives nothing
+    [ ! -s "${MQTT_FACTORY_SUB}" ]
+}
+
+@test "verify factory user can subscribe to non-SparkplugB topic" {
+    $SKIP
+    admin_password=$(get_adminPassword | tr -d '"')
+    admin_username=$(get_adminUsername | tr -d '"')
+    password=$(get_password)
+    token=$(get_token)
+    : > "${MQTT_FACTORY_SUB}"
+    (exec stdbuf -oL mosquitto_sub -L "mqtt://${USER}:${token}@${MQTT_URL}/${MQTT_TOPIC_NAME}" >"${MQTT_FACTORY_SUB}") &
+    sleep 2
+    mosquitto_pub -L "mqtt://${admin_username}:${admin_password}@${MQTT_URL}/${MQTT_TOPIC_NAME}" -m "${MQTT_FACTORY_MSG}"
+    sleep 2
+    killall mosquitto_sub
+
+    run grep -q "factory_test" "${MQTT_FACTORY_SUB}"
+    [ "$status" -eq 0 ]
+}
+
+@test "verify factory user cannot subscribe to SparkplugB topic with wrong realm" {
+    $SKIP
+    admin_password=$(get_adminPassword | tr -d '"')
+    admin_username=$(get_adminUsername | tr -d '"')
+    password=$(get_password)
+    token=$(get_token)
+    : > "${MQTT_FACTORY_SUB}"
+    (exec stdbuf -oL mosquitto_sub -L "mqtt://${USER}:${token}@${MQTT_URL}/${MQTT_WRONG_REALM_TOPIC}" >"${MQTT_FACTORY_SUB}") &
+    sleep 2
+    mosquitto_pub -L "mqtt://${admin_username}:${admin_password}@${MQTT_URL}/${MQTT_WRONG_REALM_TOPIC}" -m "${MQTT_FACTORY_MSG}"
+    sleep 2
+    killall mosquitto_sub
+
+    # subscription to wrong-realm SparkplugB is denied; no message received
+    [ ! -s "${MQTT_FACTORY_SUB}" ]
+}
+
+@test "verify device cannot subscribe to non-SparkplugB topic" {
+    $SKIP
+    admin_password=$(get_adminPassword | tr -d '"')
+    admin_username=$(get_adminUsername | tr -d '"')
+    password=$(get_password)
+    device_tokens=$(get_vanilla_refresh_and_access_token)
+    refresh_token=$(echo "$device_tokens" | jq ".refresh_token" | tr -d '"')
+    access_token=$(echo "$device_tokens" | jq ".access_token" | tr -d '"')
+    device_token=$(get_refreshed_device_token "${refresh_token}" "${access_token}")
+    : > "${MQTT_FACTORY_SUB}"
+    (exec stdbuf -oL mosquitto_sub -L "mqtt://${DEVICE_ID}:${device_token}@${MQTT_URL}/${MQTT_TOPIC_NAME}" >"${MQTT_FACTORY_SUB}") &
+    sleep 2
+    mosquitto_pub -L "mqtt://${admin_username}:${admin_password}@${MQTT_URL}/${MQTT_TOPIC_NAME}" -m "${MQTT_FACTORY_MSG}"
+    sleep 2
+    killall mosquitto_sub
+
+    # device subscription to non-SparkplugB topic is denied; no message received
+    [ ! -s "${MQTT_FACTORY_SUB}" ]
 }


### PR DESCRIPTION
Tokens from the scorpio Keycloak client with resource_access.scorpio.roles containing Factory-Admin or Factory-Reader may subscribe to arbitrary SparkplugB topics within their realm. Publish is explicitly denied and silently dropped by EMQX (deny_action=ignore).

Changes:
- authenticate.js: detect factory users via isFactoryUser(), store _factory_reader/{clientid} cache entries with realm for ACL scope check
- acl.js: allow subscribe when cached realm matches SparkplugB account segment; deny publish for all factory users
- emxq.yaml: pass action="${action}" in authorization body so EMQX forwards publish/subscribe to the ACL endpoint
- keycloak-realm.yaml: add mqtt-broker-audience mapper to scorpio client so its tokens satisfy verify-token-audience=true in the bridge adapter
- lib_authServiceTest.js: unit tests for factory user auth and ACL paths
- test-scorpio-mqtt-subscriptions.bats: e2e tests for factory subscribe and silently-dropped factory publish