### PR TITLE
Fix DEXPI KeyError in nodesetparser and add DEXPI nodeset to make

### DIFF
--- a/semantic-model/opcua/lib/nodesetparser.py
+++ b/semantic-model/opcua/lib/nodesetparser.py
@@ -218,15 +218,12 @@ Please set it explictly.")
         # Create Type Hierarchy
         for tag_name, _ in type_nodeclasses:
             uanodes = self.root.findall(tag_name, self.xml_ns)
-            firstpass = True
+            # Pre-register all type names so forward references don't raise KeyError in add_type.
             for uanode in uanodes:
-                try:
-                    self.add_type(uanode)
-                except:
-                    firstpass = False
-            if not firstpass:
-                for uanode in uanodes:
-                    self.add_type(uanode)
+                self.add_type_name_only(uanode)
+            # Now add full type definitions; all type names are pre-registered so forward references resolve.
+            for uanode in uanodes:
+                self.add_type(uanode)
         # Type objects and varialbes
         for tag_name, _ in typed_nodeclasses:
             uanodes = self.root.findall(tag_name, self.xml_ns)
@@ -804,21 +801,28 @@ Did you forget to import it?")
                         self.g.add((typeiri, RDFS.subClassOf, br_namespace[browsename]))
                     else:
                         self.g.add((typeiri, RDFS.subPropertyOf, br_namespace[browsename]))
-                isAbstract = node.get('IsAbstract')
-                if isAbstract is not None:
-                    self.g.add((br_namespace[browsename], self.rdf_ns['base']['isAbstract'], Literal(isAbstract)))
-                self.typeIds[ref_index][ref_id] = br_namespace[browsename]
-                self.g.add((ref_classiri, self.rdf_ns['base']['definesType'], br_namespace[browsename]))
-        if ref_id == baseObjectTypeId or ref_id == referencesId or ref_id == baseDataTypeId or\
-                ref_id == baseVariableType:
-            isAbstract = node.get('IsAbstract')
-            if isAbstract is not None:
-                self.g.add((br_namespace[browsename], self.rdf_ns['base']['isAbstract'], Literal(isAbstract)))
-            self.typeIds[ref_index][ref_id] = br_namespace[browsename]
-            self.g.add((ref_classiri, self.rdf_ns['base']['definesType'], br_namespace[browsename]))
-        elif not mandatory_typedef_found:
+        if not mandatory_typedef_found and ref_id != baseObjectTypeId and ref_id != referencesId and \
+                ref_id != baseDataTypeId and ref_id != baseVariableType:
             print(f"Error: Objecttype {ref_classiri} has no supertype and is not the base object type.")
             exit(1)
+
+    def add_type_name_only(self, node):
+        _, browsename = self.getBrowsename(node)
+        nodeid = node.get('NodeId')
+        ref_index, ref_id, idtype = self.parse_nodeid(nodeid)
+        ref_namespace = self.get_rdf_ns_from_ua_index(ref_index)
+        ref_classiri = nodeId_to_iri(ref_namespace, self.rdf_ns['base'], ref_id, idtype)
+        isAbstract = node.get('IsAbstract')
+        br_namespace = ref_namespace
+        if isAbstract is not None:
+            self.g.add((br_namespace[browsename], self.rdf_ns['base']['isAbstract'], Literal(isAbstract)))
+        self.typeIds[ref_index][ref_id] = br_namespace[browsename]
+        self.g.add((ref_classiri, self.rdf_ns['base']['definesType'], br_namespace[browsename]))
+        if not node.tag.endswith("UAReferenceType"):
+            self.g.add((ref_namespace[browsename], RDF.type, OWL.Class))
+        else:
+            self.known_references.append((Literal(ref_id), ref_namespace, Literal(browsename)))
+            self.g.add((ref_namespace[browsename], RDF.type, OWL.ObjectProperty))
 
     def add_type(self, node):
         _, browsename = self.getBrowsename(node)

--- a/semantic-model/opcua/tests/test_libnodesetparser.py
+++ b/semantic-model/opcua/tests/test_libnodesetparser.py
@@ -130,6 +130,7 @@ class TestNodesetParser(unittest.TestCase):
     @patch('lib.nodesetparser.urllib.request.urlopen')
     @patch('lib.nodesetparser.NodesetParser.add_uadatatype')
     @patch('lib.nodesetparser.NodesetParser.add_typedef')
+    @patch('lib.nodesetparser.NodesetParser.add_type_name_only')
     @patch('lib.nodesetparser.NodesetParser.add_type')
     @patch('lib.nodesetparser.NodesetParser.add_uanode')
     @patch('lib.nodesetparser.NodesetParser.scan_aliases')
@@ -138,7 +139,7 @@ class TestNodesetParser(unittest.TestCase):
     @patch('lib.nodesetparser.NodesetParser.create_prefixes')
     @patch('lib.nodesetparser.NodesetParser.add_datatype_dependent')
     def test_parse(self, mock_add_datatype_dependent, mock_create_prefixes, mock_init_nodeids, mock_create_header, mock_scan_aliases,
-                   mock_add_uanode, mock_add_type, mock_add_typedef, mock_add_uadatatype,
+                   mock_add_uanode, mock_add_type, mock_add_type_name_only, mock_add_typedef, mock_add_uadatatype,
                    mock_urlopen, mock_et_parse):
         
         # Mock the XML parsing
@@ -190,9 +191,10 @@ class TestNodesetParser(unittest.TestCase):
         expected_calls = len(mock_uadatatype_nodes) + len(mock_uaobject_nodes) + len(mock_uavariable_nodes) + len(mock_uamethod_nodes)
         self.assertEqual(mock_add_uanode.call_count, expected_calls)
 
-        # Verify that add_type was called for each type node class in type_nodeclasses
+        # Verify that add_type and add_type_name_only were called for each type node class in type_nodeclasses
         expected_type_calls = len(mock_uadatatype_nodes)
         self.assertEqual(mock_add_type.call_count, expected_type_calls)
+        self.assertEqual(mock_add_type_name_only.call_count, expected_type_calls)
 
         # Verify that add_typedef was called for typed node classes
         expected_typed_calls = len(mock_uavariable_nodes) + len(mock_uaobject_nodes)
@@ -910,14 +912,10 @@ class TestNodesetParser(unittest.TestCase):
         # Call the method to be tested
         self.parser.get_typedefinition_from_references([ref_node], ref_classiri, node)
 
-        # Assert that the correct triples were added to the graph
-        expected_triples = [
-            (URIRef('http://example.com/ns1#TestBrowseName'), RDFS.subPropertyOf, URIRef('http://example.com/type/500')),
-            (URIRef('http://example.com/ns1#TestBrowseName'), self.parser.rdf_ns['base']['isAbstract'], Literal('true')),
-            (ref_classiri, self.parser.rdf_ns['base']['definesType'], URIRef('http://example.com/ns1#TestBrowseName'))
-        ]
-        for triple in expected_triples:
-            mock_add.assert_any_call(triple)
+        # isAbstract and definesType are now handled by add_type_name_only, not here.
+        mock_add.assert_any_call(
+            (URIRef('http://example.com/ns1#TestBrowseName'), RDFS.subPropertyOf, URIRef('http://example.com/type/500'))
+        )
 
     @patch.object(Graph, 'add')
     def test_add_type(self, mock_add):

--- a/semantic-model/opcua/translate_default_nodesets.make
+++ b/semantic-model/opcua/translate_default_nodesets.make
@@ -46,6 +46,7 @@ MACHINETOOL_EXAMPLE_NODESET := https://raw.githubusercontent.com/OPCFoundation/U
 LASERSYSTEMS_EXAMPLE_NODESET := https://raw.githubusercontent.com/OPCFoundation/UA-Nodeset/$(NODESET_VERSION)/LaserSystems/LaserSystem-Example.NodeSet2.xml
 PACKML_NODESET            := https://raw.githubusercontent.com/OPCFoundation/UA-Nodeset/$(NODESET_VERSION)/PackML/Opc.Ua.PackML.NodeSet2.xml
 TMC_NODESET               := https://raw.githubusercontent.com/OPCFoundation/UA-Nodeset/$(NODESET_VERSION)/TMC/Opc.Ua.TMC.NodeSet2.xml
+DEXPI_NODESET             := https://raw.githubusercontent.com/OPCFoundation/UA-Nodeset/$(NODESET_VERSION)/DEXPI/Opc.Ua.DEXPI.NodeSet2.xml
 
 # -----------------------------------------------------------------------------
 # Base Ontology URL and Remote Mode
@@ -177,10 +178,16 @@ TMC_ONTOLOGY      = tmc.ttl
 TMC_DEPENDENCIES  = $(BASE_ONTOLOGY) $(CORE_ONTOLOGY) $(DI_ONTOLOGY) $(PACKML_ONTOLOGY)
 TMC_OPTS          = -p tmc
 
+# DEXPI target
+DEXPI_NODESET_URL   = $(DEXPI_NODESET)
+DEXPI_ONTOLOGY      = dexpi.ttl
+DEXPI_DEPENDENCIES  = $(BASE_ONTOLOGY) $(CORE_ONTOLOGY)
+DEXPI_OPTS          = -p dexpi
+
 # -----------------------------------------------------------------------------
 # List of all target files to be built.
 # -----------------------------------------------------------------------------
-TARGET_NAMES = CORE DI IA MACHINERY PUMPS PUMPEXAMPLE MACHINETOOL LASERSYSTEMS LASERSYSTEMSEXAMPLE MACHINETOOLEXAMPLE MACHINERYEXAMPLE DICTIONARY_IRDI PADIM MACHINERY_PROCESSVALUES MACHINERY_JOBS PACKML MACHINERY_RESULT ISA95_JOBCONTROL TMC
+TARGET_NAMES = CORE DI IA MACHINERY PUMPS PUMPEXAMPLE MACHINETOOL LASERSYSTEMS LASERSYSTEMSEXAMPLE MACHINETOOLEXAMPLE MACHINERYEXAMPLE DICTIONARY_IRDI PADIM MACHINERY_PROCESSVALUES MACHINERY_JOBS PACKML MACHINERY_RESULT ISA95_JOBCONTROL TMC DEXPI
 
 ALL_TARGETS = $(foreach t, $(TARGET_NAMES), $($(t)_ONTOLOGY))
 


### PR DESCRIPTION
## Summary

- **Fix forward-reference KeyError for DEXPI (and similar) nodesets**: replaces the fragile single-pass try/except in `nodesetparser.py`'s type-hierarchy construction with a clean two-pass approach. A new `add_type_name_only` method pre-registers all type IDs in the first pass; the existing `add_type` then resolves supertype references in the second pass without any KeyError, even when a supertype appears later in the nodeset XML than the subtype.
- **Add DEXPI companion specification to `translate_default_nodesets.make`**: the DEXPI nodeset (`Opc.Ua.DEXPI.NodeSet2.xml`) is now built as part of `make -f translate_default_nodesets.make`, which is already invoked by `make test` in `semantic-model/opcua/`.

Closes #837

## Test plan

- [ ] Run `cd semantic-model/opcua && make test` — pytest coverage must stay ≥ 80 %, all bash sub-tests must pass, and `translate_default_nodesets.make` (including the new `dexpi.ttl` target) must complete without error.
- [ ] Confirm `dexpi.ttl` is generated successfully alongside the other ontology TTL files.
- [ ] Confirm the existing nodeset2owl tests still pass (no regression from the two-pass change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)