### PR TITLE
Watch addition to kafka restart role, resources quota increase for Entity Operator

### DIFF
--- a/helm/charts/kafka/templates/KafkaCluster.yaml
+++ b/helm/charts/kafka/templates/KafkaCluster.yaml
@@ -51,20 +51,20 @@ spec:
       #image: {{ .Values.externalRegistry2 }}/strimzi/operator:0.45.0
       resources:
         requests:
-          cpu: 150m
-          memory: 128Mi
-        limits:
           cpu: 300m
           memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
     userOperator:
       #image: {{ .Values.externalRegistry2 }}/strimzi/operator:0.45.0
       resources:
         requests:
-          cpu: 150m
-          memory: 128Mi
-        limits:
           cpu: 300m
           memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
 ---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaNodePool

--- a/helm/charts/kafka/templates/connect-restarter.yaml
+++ b/helm/charts/kafka/templates/connect-restarter.yaml
@@ -11,7 +11,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["pods"]
-  verbs: ["delete", "list", "get"]
+  verbs: ["delete", "list", "get", "watch"]
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
1. Kafka restart needed "watch" verb in it's role, in order to cleanup completed jobs. If not, it was assuming job was not complete and was scheduling another job causing cluster conjestion.
2. Cluster entity operator was crashing often due to OOM Killed. Increasing the resource solved the problem.