### PR TITLE
Allow factory users to publish on non-SparkplugB MQTT topics

### DIFF
--- a/KafkaBridge/lib/authService/acl.js
+++ b/KafkaBridge/lib/authService/acl.js
@@ -76,7 +76,7 @@ class Acl {
       this.logger.info('Connection rejected for realm ' + spBAccountId + ' and device ' + spBdevId);
       return res.status(200).json({ result: 'deny' });
     } else {
-      if (action === 'subscribe') {
+      if (action === 'subscribe' || action === 'publish') {
         const factoryRealm = await this.cache.getValue(`_factory_reader/${clientid}`, 'realm');
         if (factoryRealm !== undefined) {
           return res.status(200).json({ result: 'allow' });

--- a/KafkaBridge/lib/authService/authenticate.js
+++ b/KafkaBridge/lib/authService/authenticate.js
@@ -91,7 +91,7 @@ class Authenticate {
     const decodedToken = await this.verifyAndDecodeToken(token);
     this.logger.debug('token decoded: ' + JSON.stringify(decodedToken));
     if (decodedToken === null) {
-      this.logger.info('Could not decode token.');
+      this.logger.warn(`Could not decode token for username ${username} and clientid ${clientid}.`);
       res.status(200).json({ result: 'deny' });
       return;
     }
@@ -140,7 +140,7 @@ class Authenticate {
       .createGrant({ access_token: token })
       .then(grant => grant.access_token.content)
       .catch(err => {
-        this.logger.debug('Token decoding error: ' + err);
+        this.logger.warn(`Token decoding error for token ${maskedToken}: ${err.message || err}`);
         return null;
       });
   }

--- a/KafkaBridge/test/lib_authServiceTest.js
+++ b/KafkaBridge/test/lib_authServiceTest.js
@@ -817,6 +817,41 @@ describe(fileToTest, function () {
     acl.acl(req, res);
   });
 
+  it('Factory user shall be allowed to publish to non-SparkplugB topic', function (done) {
+    const Cache = class {
+      constructor () {}
+      async getValue (key, valueKey) {
+        if (key === '_factory_reader/clientid' && valueKey === 'realm') return 'iff';
+        return undefined;
+      }
+    };
+    ToTest.__set__('Cache', Cache);
+    const config = {
+      mqtt: { adminUsername: 'superuser', adminPassword: 'password' }
+    };
+    const Acl = ToTest.__get__('Acl');
+    const acl = new Acl(config);
+    const req = {
+      query: {
+        username: 'realm_user',
+        clientid: 'clientid',
+        action: 'publish',
+        topic: 'scorpio-test'
+      }
+    };
+    const res = {
+      status: function (status) {
+        assert.equal(status, 200, 'Received wrong status');
+        return this;
+      },
+      json: function (resultObj) {
+        resultObj.should.deep.equal({ result: 'allow' });
+        done();
+      }
+    };
+    acl.acl(req, res);
+  });
+
   it('Non-factory user shall be denied on non-SparkplugB topic', function (done) {
     const Cache = class {
       constructor () {}

--- a/test/bats/test-scorpio/test-scorpio-mqtt-subscriptions.bats
+++ b/test/bats/test-scorpio/test-scorpio-mqtt-subscriptions.bats
@@ -322,6 +322,23 @@ check_no_delete_notification() {
     [ "$status" -eq 0 ]
 }
 
+@test "verify factory user can publish to non-SparkplugB topic" {
+    $SKIP
+    admin_password=$(get_adminPassword | tr -d '"')
+    admin_username=$(get_adminUsername | tr -d '"')
+    password=$(get_password)
+    token=$(get_token)
+    : > "${MQTT_FACTORY_SUB}"
+    (exec stdbuf -oL mosquitto_sub -L "mqtt://${admin_username}:${admin_password}@${MQTT_URL}/${MQTT_TOPIC_NAME}" >"${MQTT_FACTORY_SUB}") &
+    sleep 2
+    mosquitto_pub -L "mqtt://${USER}:${token}@${MQTT_URL}/${MQTT_TOPIC_NAME}" -m "${MQTT_FACTORY_MSG}"
+    sleep 2
+    killall mosquitto_sub 2>/dev/null || true
+
+    run grep -q "factory_test" "${MQTT_FACTORY_SUB}"
+    [ "$status" -eq 0 ]
+}
+
 @test "verify factory user cannot subscribe to SparkplugB topic with wrong realm" {
     $SKIP
     admin_password=$(get_adminPassword | tr -d '"')


### PR DESCRIPTION
## Summary
- Scorpio publishes NGSI-LD MQTT notifications using credentials embedded in the subscription's notification endpoint URI. For factory users, those are their own credentials — but the subscribe-only ACL added in f814d95 denied `publish`, so Scorpio could not deliver notifications on their behalf.
- Extends the MQTT ACL to allow `Factory-Admin`/`Factory-Reader` users to `publish` (in addition to `subscribe`) on non-SparkplugB topics, mirroring their existing subscribe scope. SparkplugB topics remain publish-denied for factory users (unchanged).
- Improves auth-service logging: token-decode failures now log at `warn` with username/clientid and the underlying error, making future debugging easier without needing to flip to debug-level logging.

## Test plan
- [x] `KafkaBridge/test/lib_authServiceTest.js` — added unit test "Factory user shall be allowed to publish to non-SparkplugB topic"; full suite passes (23/23)
- [x] `test/bats/test-scorpio/test-scorpio-mqtt-subscriptions.bats` — added integration test "verify factory user can publish to non-SparkplugB topic"
- [x] Verified manually on local k3d cluster: rebuilt/redeployed `kafka-bridge`, confirmed a `Factory-Admin` user can publish to a non-SparkplugB topic (`ngsi-ld/ngsi-browser/...`) where it previously was denied

🤖 Generated with [Claude Code](https://claude.com/claude-code)