### PR TITLE
Add Apache Fuseki 6.1.0 SPARQL/RDF triplestore with JWT auth proxy

### DIFF
--- a/Fuseki/Dockerfile
+++ b/Fuseki/Dockerfile
@@ -1,0 +1,32 @@
+ARG FUSEKI_VERSION=6.1.0
+ARG JAVA_IMAGE=eclipse-temurin:21-jre-alpine
+
+FROM ${JAVA_IMAGE}
+
+ARG FUSEKI_VERSION
+ARG FUSEKI_DOWNLOAD=https://downloads.apache.org/jena/binaries/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz
+
+RUN apk add --no-cache bash curl && \
+    curl -fsSL "${FUSEKI_DOWNLOAD}" -o /tmp/fuseki.tar.gz && \
+    tar -xzf /tmp/fuseki.tar.gz -C /opt && \
+    mv /opt/apache-jena-fuseki-${FUSEKI_VERSION} /opt/fuseki && \
+    rm /tmp/fuseki.tar.gz && \
+    apk del curl
+
+RUN addgroup -S fuseki && adduser -S -G fuseki fuseki && \
+    mkdir -p /fuseki/databases && \
+    chown -R fuseki:fuseki /fuseki /opt/fuseki
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENV JVM_ARGS="-Xmx2048m -Xms512m"
+ENV FUSEKI_REALMS="iff"
+
+WORKDIR /opt/fuseki
+
+USER fuseki
+
+EXPOSE 3030
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Fuseki/entrypoint.sh
+++ b/Fuseki/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+# Build one --tdb2 --loc=<path> /<realm> argument group per realm.
+# FUSEKI_REALMS is a space-separated list supplied via the K8s env var.
+ARGS=()
+for realm in ${FUSEKI_REALMS}; do
+    mkdir -p "/fuseki/databases/${realm}"
+    ARGS+=(--tdb2 --update --loc="/fuseki/databases/${realm}" "/${realm}")
+done
+
+exec java ${JVM_ARGS} -cp /opt/fuseki/fuseki-server.jar \
+    org.apache.jena.fuseki.main.cmds.FusekiMainCmd "${ARGS[@]}"

--- a/Fuseki/fuseki-api.md
+++ b/Fuseki/fuseki-api.md
@@ -1,0 +1,302 @@
+# Fuseki SPARQL / RDF Triplestore API
+
+Apache Jena Fuseki 6 serves as the persistent RDF triplestore for the DigitalTwin platform. It stores named graphs per Keycloak realm and exposes standard SPARQL and Graph Store Protocol (GSP) endpoints, protected by a JWT-validating auth proxy.
+
+## Base URL
+
+```
+https://fuseki.local
+```
+
+All endpoints are relative to this base. Replace `<realm>` with the Keycloak realm name (default: `iff`).
+
+---
+
+## Authentication
+
+Every request (except the health check) requires a Bearer JWT issued by Keycloak.
+
+### Obtain a token
+
+```bash
+curl -sf \
+  -d "client_id=fuseki" \
+  -d "client_secret=<client-secret>" \
+  -d "grant_type=client_credentials" \
+  "https://keycloak.local/auth/realms/<realm>/protocol/openid-connect/token" \
+  | jq -r ".access_token"
+```
+
+Retrieve the client secret from the cluster:
+
+```bash
+kubectl -n iff get secret/keycloak-client-secret-fuseki \
+  -o jsonpath='{.data.CLIENT_SECRET}' | base64 -d
+```
+
+### Required roles
+
+| Role | Grants |
+|---|---|
+| `Factory-Admin` | Read + Write (PUT, POST, DELETE, SPARQL Update) |
+| `Factory-Reader` | Read only (GET, SPARQL SELECT/ASK/CONSTRUCT/DESCRIBE) |
+
+Roles are carried in the JWT under `resource_access.fuseki.roles`. The auth proxy enforces them per endpoint and HTTP method — a missing or wrong role returns **403**, an invalid/expired token returns **401**.
+
+---
+
+## Named graph convention
+
+Graphs follow this naming scheme:
+
+```
+https://fuseki.local/<realm>/<graph-name>
+```
+
+Examples for the `iff` realm:
+- `http://fuseki.local/iff/shacl.ttl`
+- `http://fuseki.local/iff/knowledge.ttl`
+
+---
+
+## Endpoints
+
+### Health check
+
+```
+GET /$/ping
+```
+
+No auth required. Returns the server timestamp as plain text. Use for liveness/readiness probes.
+
+```bash
+curl https://fuseki.local/$/ping
+# 2026-06-28T19:34:17.373+00:00
+```
+
+---
+
+### Graph Store Protocol (GSP)
+
+Base path: `/<realm>/data`
+
+All GSP write operations require the `Factory-Admin` role. Reads require at least `Factory-Reader`.
+
+#### Retrieve a named graph
+
+```
+GET /<realm>/data?graph=<graph-uri>
+```
+
+Returns the graph as RDF. Use the `Accept` header to control the serialisation format.
+
+```bash
+curl -s \
+  -H "Authorization: Bearer <token>" \
+  -H "Accept: text/turtle" \
+  "https://fuseki.local/iff/data?graph=http://fuseki.local/iff/shacl.ttl"
+```
+
+| Status | Meaning |
+|---|---|
+| 200 | Graph returned |
+| 404 | Graph does not exist |
+| 401 | Missing or invalid token |
+| 403 | Token valid but lacks `Factory-Reader` role |
+
+Supported `Accept` types: `text/turtle`, `application/n-triples`, `application/ld+json`, `application/rdf+xml`.
+
+#### Replace a named graph (full upload)
+
+```
+PUT /<realm>/data?graph=<graph-uri>
+```
+
+Replaces the entire graph. Creates it if it does not exist.
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" \
+  -X PUT \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: text/turtle" \
+  --data-binary @shacl.ttl \
+  "https://fuseki.local/iff/data?graph=http://fuseki.local/iff/shacl.ttl"
+```
+
+| Status | Meaning |
+|---|---|
+| 201 | Graph created |
+| 200 | Graph replaced |
+| 401 | Missing or invalid token |
+| 403 | Token valid but lacks `Factory-Admin` role |
+
+#### Add triples to a named graph
+
+```
+POST /<realm>/data?graph=<graph-uri>
+```
+
+Merges the uploaded triples into the existing graph (does not remove existing triples).
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" \
+  -X POST \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: text/turtle" \
+  --data-binary @extra-triples.ttl \
+  "https://fuseki.local/iff/data?graph=http://fuseki.local/iff/knowledge.ttl"
+```
+
+| Status | Meaning |
+|---|---|
+| 200 | Triples merged |
+| 401/403 | Auth failure |
+
+#### Delete a named graph
+
+```
+DELETE /<realm>/data?graph=<graph-uri>
+```
+
+Removes the graph and all its triples.
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" \
+  -X DELETE \
+  -H "Authorization: Bearer <token>" \
+  "https://fuseki.local/iff/data?graph=http://fuseki.local/iff/shacl.ttl"
+```
+
+| Status | Meaning |
+|---|---|
+| 200 | Graph deleted |
+| 404 | Graph did not exist |
+| 401/403 | Auth failure |
+
+---
+
+### SPARQL Query endpoint
+
+```
+GET  /<realm>/sparql?query=<url-encoded-sparql>
+POST /<realm>/sparql
+```
+
+Supports SELECT, ASK, CONSTRUCT, and DESCRIBE. Requires at least `Factory-Reader`.
+
+#### SELECT via GET
+
+```bash
+TOKEN=$(curl -sf \
+  -d "client_id=fuseki" -d "client_secret=<secret>" \
+  -d "grant_type=client_credentials" \
+  "https://keycloak.local/auth/realms/iff/protocol/openid-connect/token" \
+  | jq -r ".access_token")
+
+curl -sG \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Accept: application/sparql-results+json" \
+  --data-urlencode "query=SELECT ?shape WHERE {
+      GRAPH <http://fuseki.local/iff/shacl.ttl> {
+          ?shape a <http://www.w3.org/ns/shacl#NodeShape>
+      }
+  } LIMIT 10" \
+  "https://fuseki.local/iff/sparql"
+```
+
+Response (JSON):
+
+```json
+{
+  "head": { "vars": ["shape"] },
+  "results": {
+    "bindings": [
+      { "shape": { "type": "uri", "value": "https://example.com/cutterTemperatureWithMinMaxShape" } }
+    ]
+  }
+}
+```
+
+#### SELECT via POST (for long queries)
+
+```bash
+curl -s \
+  -X POST \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/sparql-query" \
+  -H "Accept: application/sparql-results+json" \
+  --data "SELECT ?cls WHERE { GRAPH <http://fuseki.local/iff/knowledge.ttl> { ?cls a <http://www.w3.org/2002/07/owl#Class> } }" \
+  "https://fuseki.local/iff/sparql"
+```
+
+#### CONSTRUCT
+
+```bash
+curl -sG \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Accept: text/turtle" \
+  --data-urlencode "query=CONSTRUCT { ?s ?p ?o } WHERE {
+      GRAPH <http://fuseki.local/iff/knowledge.ttl> { ?s ?p ?o }
+  }" \
+  "https://fuseki.local/iff/sparql"
+```
+
+Supported `Accept` types for SPARQL results: `application/sparql-results+json`, `application/sparql-results+xml`, `text/csv`, `text/tab-separated-values`.
+
+Supported `Accept` types for CONSTRUCT/DESCRIBE: same as GSP read above.
+
+| Status | Meaning |
+|---|---|
+| 200 | Query executed, results returned |
+| 400 | Malformed SPARQL |
+| 401/403 | Auth failure |
+
+---
+
+### SPARQL Update endpoint
+
+```
+POST /<realm>/update
+```
+
+Executes SPARQL Update operations (INSERT DATA, DELETE DATA, LOAD, etc.). Requires `Factory-Admin`.
+
+```bash
+curl -s -o /dev/null -w "%{http_code}" \
+  -X POST \
+  -H "Authorization: Bearer ${TOKEN}" \
+  -H "Content-Type: application/sparql-update" \
+  --data "INSERT DATA {
+      GRAPH <http://fuseki.local/iff/knowledge.ttl> {
+          <http://example.com/Machine> a <http://www.w3.org/2002/07/owl#Class> .
+      }
+  }" \
+  "https://fuseki.local/iff/update"
+```
+
+| Status | Meaning |
+|---|---|
+| 200 | Update executed |
+| 400 | Malformed SPARQL Update |
+| 401/403 | Auth failure |
+
+---
+
+## Common HTTP status codes
+
+| Code | Cause |
+|---|---|
+| 200 | Success |
+| 201 | Resource created (first PUT of a graph) |
+| 400 | Bad request (malformed query or body) |
+| 401 | No token, expired token, or invalid JWT signature |
+| 403 | Valid token but role insufficient for the operation |
+| 404 | Named graph does not exist |
+| 500 | Upstream error — check Fuseki pod logs and Traefik ForwardAuth connectivity |
+
+A 500 on authenticated requests usually means the auth proxy (`fuseki-auth`) is unreachable. Verify with:
+
+```bash
+kubectl -n iff get pods -l app=fuseki-auth
+kubectl -n iff logs -l app=fuseki-auth --tail=50
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,3 +40,7 @@ services:
     image: ${DOCKER_PREFIX:-ibn40}/flink-operator:${DOCKER_TAG}
     build:
       context: ./FlinkOperatorWithCoreServices
+  fuseki:
+    image: ${DOCKER_PREFIX:-ibn40}/fuseki:${DOCKER_TAG}
+    build:
+      context: ./Fuseki

--- a/helm/charts/fuseki/Chart.yaml
+++ b/helm/charts/fuseki/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: fuseki
+description: Apache Jena Fuseki SPARQL server with Keycloak realm/role auth proxy
+type: application
+version: 0.1.0
+appVersion: "4.9.0"

--- a/helm/charts/fuseki/templates/auth-deployment.yaml
+++ b/helm/charts/fuseki/templates/auth-deployment.yaml
@@ -1,0 +1,67 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fuseki-auth
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: fuseki-auth
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fuseki-auth
+  template:
+    metadata:
+      labels:
+        app: fuseki-auth
+    spec:
+      initContainers:
+        - name: pip-install
+          image: "{{ .Values.fusekiAuth.image.repository }}:{{ .Values.fusekiAuth.image.tag }}"
+          command:
+            - pip
+            - install
+            - --target=/packages
+            - --requirement=/app/requirements.txt
+          volumeMounts:
+            - name: app-script
+              mountPath: /app
+            - name: packages
+              mountPath: /packages
+      containers:
+        - name: fuseki-auth
+          image: "{{ .Values.fusekiAuth.image.repository }}:{{ .Values.fusekiAuth.image.tag }}"
+          command: ["python", "/app/main.py"]
+          env:
+            - name: PYTHONPATH
+              value: /packages
+            - name: KEYCLOAK_INTERNAL_URL
+              value: "http://{{ .Values.keycloak.internalAuthService.name }}:{{ .Values.keycloak.internalAuthService.port }}{{ .Values.keycloak.internalAuthService.path }}"
+            - name: FUSEKI_CLIENT_ID
+              value: {{ .Values.fuseki.auth.clientId }}
+          ports:
+            - containerPort: 8080
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 5
+          volumeMounts:
+            - name: app-script
+              mountPath: /app
+            - name: packages
+              mountPath: /packages
+      volumes:
+        - name: app-script
+          configMap:
+            name: fuseki-auth-script
+        - name: packages
+          emptyDir: {}

--- a/helm/charts/fuseki/templates/auth-service.yaml
+++ b/helm/charts/fuseki/templates/auth-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fuseki-auth
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    app: fuseki-auth
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/helm/charts/fuseki/templates/configmap-auth.yaml
+++ b/helm/charts/fuseki/templates/configmap-auth.yaml
@@ -1,0 +1,94 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fuseki-auth-script
+  namespace: {{ .Release.Namespace }}
+data:
+  main.py: |
+    import os, re, time, threading
+    from urllib.parse import urlparse
+    from fastapi import FastAPI, Request
+    from fastapi.responses import Response
+    import httpx
+    from jose import jwt
+
+    app = FastAPI()
+
+    KEYCLOAK_URL  = os.environ["KEYCLOAK_INTERNAL_URL"]
+    FUSEKI_CLIENT = os.environ.get("FUSEKI_CLIENT_ID", "fuseki")
+
+    WRITE_METHODS   = {"PUT", "POST", "DELETE", "PATCH"}
+    WRITE_ENDPOINTS = {"data", "update"}
+    READ_ROLES      = {"Factory-Admin", "Factory-Reader"}
+    WRITE_ROLES     = {"Factory-Admin"}
+
+    _cache: dict = {}
+    _lock = threading.Lock()
+    JWKS_TTL = 300
+
+    def _get_jwks(realm: str) -> dict:
+        now = time.monotonic()
+        with _lock:
+            entry = _cache.get(realm)
+            if entry and entry[1] > now:
+                return entry[0]
+        url = f"{KEYCLOAK_URL}/realms/{realm}/protocol/openid-connect/certs"
+        r = httpx.get(url, timeout=5)
+        r.raise_for_status()
+        keys = r.json()
+        with _lock:
+            _cache[realm] = (keys, now + JWKS_TTL)
+        return keys
+
+    @app.get("/health")
+    def health():
+        return {"ok": True}
+
+    @app.api_route("/auth", methods=["GET", "HEAD", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"])
+    async def auth(request: Request):
+        uri    = request.headers.get("x-forwarded-uri", "")
+        method = request.headers.get("x-forwarded-method", request.method).upper()
+        auth_h = request.headers.get("authorization", "")
+
+        if not auth_h.startswith("Bearer "):
+            return Response(status_code=401)
+        token = auth_h[7:]
+
+        segments = urlparse(uri).path.lstrip("/").split("/")
+        if not segments[0]:
+            return Response(status_code=403)
+        path_realm = segments[0]
+        endpoint   = segments[1].split("?")[0] if len(segments) > 1 else ""
+
+        try:
+            jwks   = _get_jwks(path_realm)
+            claims = jwt.decode(token, jwks, algorithms=["RS256"],
+                                options={"verify_aud": False})
+        except Exception:
+            return Response(status_code=401)
+
+        iss_match = re.search(r"/realms/([^/]+)$", claims.get("iss", ""))
+        if not iss_match or iss_match.group(1) != path_realm:
+            return Response(status_code=403)
+
+        roles = set(
+            claims.get("resource_access", {})
+                  .get(FUSEKI_CLIENT, {})
+                  .get("roles", [])
+        )
+
+        if endpoint in WRITE_ENDPOINTS and method in WRITE_METHODS:
+            allowed = bool(WRITE_ROLES & roles)
+        else:
+            allowed = bool(READ_ROLES & roles)
+
+        return Response(status_code=200 if allowed else 403)
+
+    if __name__ == "__main__":
+        import uvicorn
+        uvicorn.run(app, host="0.0.0.0", port=8080)
+  requirements.txt: |
+    fastapi==0.104.1
+    uvicorn[standard]==0.24.0
+    python-jose[cryptography]==3.3.0
+    httpx==0.25.2

--- a/helm/charts/fuseki/templates/deployment.yaml
+++ b/helm/charts/fuseki/templates/deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fuseki
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: fuseki
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fuseki
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: fuseki
+    spec:
+      containers:
+        - name: fuseki
+          image: '{{ .Values.mainRegistry }}/{{ .Values.mainRepo }}/fuseki:{{ .Values.mainVersion }}'
+          ports:
+            - containerPort: 3030
+              name: http
+          env:
+            - name: JVM_ARGS
+              value: "-Xmx2048m -Xms512m"
+            - name: FUSEKI_REALMS
+              value: {{ .Values.fuseki.realms | join " " | quote }}
+          volumeMounts:
+            - name: fuseki-data
+              mountPath: /fuseki/databases
+          livenessProbe:
+            httpGet:
+              path: /$/ping
+              port: 3030
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /$/ping
+              port: 3030
+            initialDelaySeconds: 15
+            periodSeconds: 5
+      volumes:
+        - name: fuseki-data
+          persistentVolumeClaim:
+            claimName: fuseki-data

--- a/helm/charts/fuseki/templates/ingress.yaml
+++ b/helm/charts/fuseki/templates/ingress.yaml
@@ -1,0 +1,54 @@
+{{- if and (ne .Values.ingressType "traefik") (ne .Values.ingressType "nginx") }}
+{{- fail "ingressType must either be \"traefik\" or \"nginx\"" }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: fuseki-ingress
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingressType | quote }}
+    {{- if eq .Values.ingressType "traefik" }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ .Release.Namespace }}-fuseki-realm-auth@kubernetescrd
+    {{- else }}
+    nginx.ingress.kubernetes.io/auth-url: "http://fuseki-auth.{{ .Release.Namespace }}.svc.cluster.local:8080/auth"
+    nginx.ingress.kubernetes.io/auth-method: "GET"
+    nginx.ingress.kubernetes.io/auth-snippet: |
+      proxy_set_header X-Forwarded-Method $request_method;
+      proxy_set_header X-Forwarded-Uri $request_uri;
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    {{- end }}
+    cert-manager.io/cluster-issuer: {{ .Values.certmanager.issuer }}
+spec:
+  tls:
+    - hosts:
+        - {{ .Values.fuseki.externalHostname }}
+      secretName: {{ .Values.certmanager.secret }}-fuseki
+  rules:
+    - host: {{ .Values.fuseki.externalHostname }}
+      http:
+        paths:
+          - backend:
+              service:
+                name: fuseki
+                port:
+                  number: 3030
+            {{- if eq .Values.ingressType "nginx" }}
+            path: /(.*)
+            {{- else }}
+            path: /
+            {{- end }}
+            pathType: ImplementationSpecific
+---
+{{- if eq .Values.ingressType "traefik" }}
+apiVersion: traefik.containo.us/v1alpha1
+kind: Middleware
+metadata:
+  name: fuseki-realm-auth
+  namespace: {{ .Release.Namespace }}
+spec:
+  forwardAuth:
+    address: "http://fuseki-auth.{{ .Release.Namespace }}.svc.cluster.local:8080/auth"
+    authRequestHeaders:
+      - "Authorization"
+{{- end }}

--- a/helm/charts/fuseki/templates/pvc.yaml
+++ b/helm/charts/fuseki/templates/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fuseki-data
+  namespace: {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.fuseki.storage.size }}

--- a/helm/charts/fuseki/templates/service.yaml
+++ b/helm/charts/fuseki/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: fuseki
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    app: fuseki
+  ports:
+    - name: http
+      port: 3030
+      targetPort: 3030

--- a/helm/charts/fuseki/values.yaml
+++ b/helm/charts/fuseki/values.yaml
@@ -1,0 +1,34 @@
+fuseki:
+  externalHostname: ""
+  externalPath: /
+  storage:
+    size: 5Gi
+  realms: []
+  auth:
+    clientId: fuseki
+    clientSecret: ""
+
+fusekiAuth:
+  image:
+    repository: python
+    tag: "3.11-slim"
+
+keycloak:
+  internalAuthService:
+    name: keycloak-service
+    port: 8080
+    path: /auth
+  alerta:
+    realm: iff
+  fuseki:
+    client: fuseki
+    clientSecret: ""
+
+mainRegistry: docker.io
+mainRepo: ibn40
+mainVersion: v0.7.0-latest
+
+ingressType: traefik
+certmanager:
+  secret: selfsigned-cert-tls
+  issuer: letsencrypt-self

--- a/helm/charts/keycloak/templates/fuseki-secret.yaml
+++ b/helm/charts/keycloak/templates/fuseki-secret.yaml
@@ -1,0 +1,18 @@
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace "keycloak-client-secret-fuseki") -}}
+apiVersion: v1
+kind: Secret
+metadata:
+    name: keycloak-client-secret-fuseki
+    namespace: {{ .Release.Namespace }}
+    labels:
+        velero-backup: "true"
+{{ if $secret }}
+data:
+    CLIENT_ID: {{ $secret.data.CLIENT_ID }}
+    CLIENT_SECRET: {{ $secret.data.CLIENT_SECRET }}
+{{ else }}
+data:
+    CLIENT_ID: {{ .Values.keycloak.fuseki.client | toString | b64enc }}
+    CLIENT_SECRET: {{ .Values.keycloak.fuseki.clientSecret | toString | b64enc }}
+{{ end }}
+type: Opaque

--- a/helm/charts/keycloak/templates/keycloak-realm.yaml
+++ b/helm/charts/keycloak/templates/keycloak-realm.yaml
@@ -3,6 +3,7 @@
 {{- $fusionbackendsecret := (lookup "v1" "Secret" .Release.Namespace "keycloak-client-secret-fusion-backend") -}}
 {{- $ngsildupdatessecret := (lookup "v1" "Secret" .Release.Namespace "keycloak-client-secret-ngsild-updates") -}}
 {{- $realmusersecret := (lookup "v1" "Secret" .Release.Namespace "credential-iff-realm-user-iff") -}}
+{{- $fusekisecret := (lookup "v1" "Secret" .Release.Namespace "keycloak-client-secret-fuseki") -}}
 apiVersion: k8s.keycloak.org/v2alpha1
 kind: KeycloakRealmImport
 metadata:
@@ -670,6 +671,19 @@ spec:
           - offline_access
         optionalClientScopes:
           - gateway
+      - id: fa4e9a3b-1c2d-4e5f-8a7b-6c5d4e3f2a1b
+        clientId: {{ .Values.keycloak.fuseki.client }}
+        publicClient: false
+        serviceAccountsEnabled: true
+        directAccessGrantsEnabled: true
+        defaultClientScopes:
+          - roles
+          - offline_access
+        {{ if $fusekisecret }}
+        secret: {{ $fusekisecret.data.CLIENT_SECRET | b64dec }}
+        {{ else }}
+        secret: {{ .Values.keycloak.fuseki.clientSecret }}
+        {{ end }}
     roles:
       realm:
       
@@ -697,6 +711,13 @@ spec:
           - id: 617d3f63-7067-4da6-b8aa-8cfe8a9a926f
             name: uma_protection
             clientRole: true
+        {{ .Values.keycloak.fuseki.client }}:
+          - id: fd1a2b3c-4d5e-6f7a-8b9c-0d1e2f3a4b5c
+            name: "Factory-Admin"
+            clientRole: true
+          - id: fe2b3c4d-5e6f-7a8b-9c0d-1e2f3a4b5c6d
+            name: "Factory-Reader"
+            clientRole: true
     defaultRoles:
       - uma_authorization
       - offline_access
@@ -723,6 +744,24 @@ spec:
           realm-management:
             - "manage-users"
           {{ .Values.keycloak.scorpio.client }}:
+            - Factory-Admin
+          {{ .Values.keycloak.fuseki.client }}:
+            - Factory-Admin
+      - id: fd4e5f6a-7b8c-9def-0123-456789abcdef
+        username: service-account-fuseki
+        enabled: true
+        totp: false
+        emailVerified: false
+        serviceAccountClientId: {{ .Values.keycloak.fuseki.client }}
+        credentials: []
+        realmRoles:
+          - uma_authorization
+          - offline_access
+        clientRoles:
+          account:
+            - view-profile
+            - manage-account
+          {{ .Values.keycloak.fuseki.client }}:
             - Factory-Admin
       - id: 8a561605-7b80-44b8-aa65-4368e292a60f
         username: service-account-fusion-backend

--- a/helm/common.gotmpl
+++ b/helm/common.gotmpl
@@ -13,3 +13,4 @@ oispFrontendClientSecret: {{ randAlphaNum 32 }}
 mqttBrokerClientSecret: {{ randAlphaNum 32 }}
 fusionBackendClientSecret: {{ randAlphaNum 32 }}
 mqttAdminPassword: {{ randAlphaNum 32 }}
+fusekiClientSecret: {{ randAlphaNum 32 }}

--- a/helm/environment/default.yaml
+++ b/helm/environment/default.yaml
@@ -129,3 +129,10 @@ pgrest:
   externalPath: / # note: must end with /
   externalHostname: pgrest.local
   dbPool: 10 # note: must not be more than max_connections in Postgres DB, default is 10
+
+fuseki:
+  externalHostname: fuseki.local
+  storage:
+    size: 5Gi
+  realms:
+    - iff

--- a/helm/helmfile.yaml
+++ b/helm/helmfile.yaml
@@ -153,4 +153,14 @@ releases:
   values:
   - values.yaml.gotmpl
   needs:
-  - postgres  
+  - postgres
+- name: fuseki
+  labels:
+    app: fuseki
+    order: third
+  chart: ./charts/fuseki
+  namespace: {{ .Values.namespace }}
+  needs:
+  - keycloak
+  values:
+  - values.yaml.gotmpl

--- a/helm/values.yaml.gotmpl
+++ b/helm/values.yaml.gotmpl
@@ -309,6 +309,9 @@ keycloak:
   realmTestUser:
     username: "realm_user"
     password: {{ .StateValues.keycloakRealmTestUser }}
+  fuseki:
+    client: fuseki
+    clientSecret: {{ .StateValues.fusekiClientSecret }}
 keycloak_db:
   stringData:
     POSTGRES_DATABASE: keycloakdb
@@ -419,3 +422,14 @@ pgrest:
   externalHostname: {{ .StateValues.pgrest.externalHostname }}
   externalPath: {{ .StateValues.pgrest.externalPath }}
   dbPool: {{ .StateValues.pgrest.dbPool }}
+
+fuseki:
+  externalHostname: {{ .StateValues.fuseki.externalHostname }}
+  externalPath: /
+  storage:
+    size: {{ .StateValues.fuseki.storage.size }}
+  realms:
+{{ .StateValues.fuseki.realms | toYaml | indent 4 }}
+  auth:
+    clientId: fuseki
+    clientSecret: {{ .StateValues.fusekiClientSecret }}

--- a/semantic-model/shacl2flink/Makefile
+++ b/semantic-model/shacl2flink/Makefile
@@ -13,6 +13,12 @@ NAMESPACE := iff
 ONTDIR := ../kms/ontology
 CHECKPOINT ?= false
 COMMON_CONFIG_FILE = ../../helm/common.yaml
+ENVIRONMENT_CONFIG_FILE = ../../helm/environment/default.yaml
+FUSEKI_HOSTNAME = $$(cat $(ENVIRONMENT_CONFIG_FILE) | yq '.fuseki.externalHostname')
+FUSEKI_REALM = $$(cat $(ENVIRONMENT_CONFIG_FILE) | yq '.fuseki.realms[0]')
+FUSEKI_CLIENT_ID = fuseki
+FUSEKI_CLIENT_SECRET = $$(kubectl -n $(NAMESPACE) get secret/keycloak-client-secret-fuseki -o jsonpath='{.data.CLIENT_SECRET}' | base64 -d)
+KEYCLOAK_HOSTNAME = $$(cat $(ENVIRONMENT_CONFIG_FILE) | yq '.keycloak.externalAuthService.domainname')
 FLINK_DATABASE = $$(cat $(COMMON_CONFIG_FILE) | yq '.flink.db.name')
 FLINK_DATABASE_SERVICE = $$(cat $(COMMON_CONFIG_FILE) | yq '.db.teamId')-$$(cat $(COMMON_CONFIG_FILE) | yq '.db.clusterSvcPostfix')
 FLINK_DATABASE_PORT = $$(cat $(COMMON_CONFIG_FILE) | yq '.db.svcPort')
@@ -135,6 +141,7 @@ flink-deploy: clean
 	make test-flink-is-deployed
 	sleep 2
 	kubectl -n $(NAMESPACE) -l "app.kubernetes.io/instance"="kafka-connect" delete pod
+	make fuseki-deploy-kms
 
 
 flink-undeploy:
@@ -142,6 +149,7 @@ flink-undeploy:
 	cd ../../helm && ./helmfile -f helmfile-shacl.yaml destroy
 	make test-flink-is-undeployed
 	cd ../../helm && ./helmfile -f helmfile-shacl.yaml destroy # undeploy a scnd time to make sure that there are no kafkatopics left
+	make fuseki-undeploy-kms
 
 
 test-flink-is-deployed:
@@ -205,7 +213,53 @@ submit-postgres-tables:
 	kubectl -n $(NAMESPACE) exec -i $${POD} -- bash -c "PGPASSWORD='$${PGPASSWORD}' PGSSLMODE=require psql -h localhost -U $(FLINK_DATABASE_USER_NAME) -d $(FLINK_DATABASE)" < $(OUTPUTDIR)/ngsild.postgres && \
 	kubectl -n $(NAMESPACE) exec -i $${POD} -- bash -c "PGPASSWORD='$${PGPASSWORD}' PGSSLMODE=require psql -h localhost -U $(FLINK_DATABASE_USER_NAME) -d $(FLINK_DATABASE)" < $(OUTPUTDIR)/shacl-constraints.postgres
 
+fuseki-deploy-kms:
+	@echo "Uploading shacl.ttl and knowledge.ttl to Fuseki"
+	@REALM=$(FUSEKI_REALM) && \
+	SECRET=$(FUSEKI_CLIENT_SECRET) && \
+	TOKEN=$$(curl -sf \
+	    -d "client_id=$(FUSEKI_CLIENT_ID)" \
+	    -d "client_secret=$${SECRET}" \
+	    -d "grant_type=client_credentials" \
+	    "http://$(KEYCLOAK_HOSTNAME)/auth/realms/$${REALM}/protocol/openid-connect/token" \
+	    | jq -r ".access_token") && \
+	[ -n "$${TOKEN}" ] && [ "$${TOKEN}" != "null" ] || { echo "ERROR: failed to obtain Fuseki token"; exit 1; } && \
+	GSP="http://$(FUSEKI_HOSTNAME)/$${REALM}/data" && \
+	GRAPH_BASE="http://$(FUSEKI_HOSTNAME)/$${REALM}" && \
+	CODE=$$(curl -s -o /dev/null -w "%{http_code}" \
+	    -X PUT -H "Authorization: Bearer $${TOKEN}" -H "Content-Type: text/turtle" \
+	    --data-binary @$(SHACL) "$${GSP}?graph=$${GRAPH_BASE}/shacl.ttl") && \
+	echo "shacl.ttl → $${CODE}" && \
+	{ [ "$${CODE}" = "200" ] || [ "$${CODE}" = "201" ]; } || { echo "ERROR: shacl.ttl upload failed ($${CODE})"; exit 1; } && \
+	CODE=$$(curl -s -o /dev/null -w "%{http_code}" \
+	    -X PUT -H "Authorization: Bearer $${TOKEN}" -H "Content-Type: text/turtle" \
+	    --data-binary @$(KNOWLEDGE) "$${GSP}?graph=$${GRAPH_BASE}/knowledge.ttl") && \
+	echo "knowledge.ttl → $${CODE}" && \
+	{ [ "$${CODE}" = "200" ] || [ "$${CODE}" = "201" ]; } || { echo "ERROR: knowledge.ttl upload failed ($${CODE})"; exit 1; }
+
+
+fuseki-undeploy-kms:
+	@echo "Removing shacl.ttl and knowledge.ttl from Fuseki"
+	@REALM=$(FUSEKI_REALM) && \
+	SECRET=$(FUSEKI_CLIENT_SECRET) && \
+	TOKEN=$$(curl -sf \
+	    -d "client_id=$(FUSEKI_CLIENT_ID)" \
+	    -d "client_secret=$${SECRET}" \
+	    -d "grant_type=client_credentials" \
+	    "http://$(KEYCLOAK_HOSTNAME)/auth/realms/$${REALM}/protocol/openid-connect/token" \
+	    | jq -r ".access_token") && \
+	[ -n "$${TOKEN}" ] && [ "$${TOKEN}" != "null" ] || { echo "WARNING: could not obtain Fuseki token, skipping KMS undeploy"; exit 0; } && \
+	GSP="http://$(FUSEKI_HOSTNAME)/$${REALM}/data" && \
+	GRAPH_BASE="http://$(FUSEKI_HOSTNAME)/$${REALM}" && \
+	curl -s -o /dev/null -w "shacl.ttl delete: %{http_code}\n" \
+	    -X DELETE -H "Authorization: Bearer $${TOKEN}" \
+	    "$${GSP}?graph=$${GRAPH_BASE}/shacl.ttl" || true && \
+	curl -s -o /dev/null -w "knowledge.ttl delete: %{http_code}\n" \
+	    -X DELETE -H "Authorization: Bearer $${TOKEN}" \
+	    "$${GSP}?graph=$${GRAPH_BASE}/knowledge.ttl" || true
+
+
 clean:
 	@rm -rf $(OUTPUTDIR)
 
-.PHONY: clean
+.PHONY: clean fuseki-deploy-kms fuseki-undeploy-kms

--- a/test/bats/test-fuseki/fuseki-e2e.bats
+++ b/test/bats/test-fuseki/fuseki-e2e.bats
@@ -1,0 +1,245 @@
+#!/usr/bin/env bats
+
+NAMESPACE=iff
+CLIENT_SECRET_NAME=secret/keycloak-client-secret-fuseki
+CLIENT_ID=fuseki
+KEYCLOAK_URL=http://keycloak.local/auth/realms
+FUSEKI_URL=http://fuseki.local
+REALM=iff
+
+SHACL_TTL="${BATS_TEST_DIRNAME}/../../../semantic-model/shacl2flink/docs/files/shacl.ttl"
+KNOWLEDGE_TTL="${BATS_TEST_DIRNAME}/../../../semantic-model/shacl2flink/docs/files/knowledge.ttl"
+
+GRAPH_BASE="${FUSEKI_URL}/${REALM}"
+SHACL_GRAPH="${GRAPH_BASE}/shacl.ttl"
+KNOWLEDGE_GRAPH="${GRAPH_BASE}/knowledge.ttl"
+GSP_ENDPOINT="${FUSEKI_URL}/${REALM}/data"
+SPARQL_ENDPOINT="${FUSEKI_URL}/${REALM}/sparql"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+get_client_secret() {
+    kubectl -n "${NAMESPACE}" get "${CLIENT_SECRET_NAME}" \
+        -o jsonpath='{.data.CLIENT_SECRET}' | base64 -d
+}
+
+get_token() {
+    local secret
+    secret=$(get_client_secret)
+    curl -sf \
+        -d "client_id=${CLIENT_ID}" \
+        -d "client_secret=${secret}" \
+        -d "grant_type=client_credentials" \
+        "${KEYCLOAK_URL}/${REALM}/protocol/openid-connect/token" \
+        | jq -r ".access_token"
+}
+
+upload_graph() {
+    local token="$1" file="$2" graph_uri="$3"
+    curl -s -o /dev/null -w "%{http_code}" \
+        -X PUT \
+        -H "Authorization: Bearer ${token}" \
+        -H "Content-Type: text/turtle" \
+        --data-binary @"${file}" \
+        "${GSP_ENDPOINT}?graph=${graph_uri}"
+}
+
+get_graph() {
+    local token="$1" graph_uri="$2"
+    curl -s \
+        -H "Authorization: Bearer ${token}" \
+        -H "Accept: text/turtle" \
+        "${GSP_ENDPOINT}?graph=${graph_uri}"
+}
+
+get_graph_status() {
+    local token="$1" graph_uri="$2"
+    curl -s -o /dev/null -w "%{http_code}" \
+        -H "Authorization: Bearer ${token}" \
+        -H "Accept: text/turtle" \
+        "${GSP_ENDPOINT}?graph=${graph_uri}"
+}
+
+sparql_query() {
+    local token="$1" query="$2"
+    curl -sf -G \
+        -H "Authorization: Bearer ${token}" \
+        -H "Accept: application/sparql-results+json" \
+        --data-urlencode "query=${query}" \
+        "${SPARQL_ENDPOINT}"
+}
+
+sparql_query_status() {
+    local token="$1" query="$2"
+    curl -s -o /dev/null -w "%{http_code}" -G \
+        -H "Authorization: Bearer ${token}" \
+        -H "Accept: application/sparql-results+json" \
+        --data-urlencode "query=${query}" \
+        "${SPARQL_ENDPOINT}"
+}
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+@test "obtain fuseki service account token" {
+    echo "keycloak token url: ${KEYCLOAK_URL}/${REALM}/protocol/openid-connect/token"
+    echo "secret k8s ref:     ${NAMESPACE}/${CLIENT_SECRET_NAME}"
+
+    local secret
+    secret=$(get_client_secret) \
+        || { echo "FAIL: kubectl could not read ${CLIENT_SECRET_NAME} in ns ${NAMESPACE}"; false; }
+    echo "client_secret length: ${#secret}"
+    [ -n "${secret}" ] || { echo "FAIL: client secret is empty"; false; }
+
+    local token
+    token=$(get_token) \
+        || { echo "FAIL: curl to keycloak token endpoint failed (check keycloak.local resolves and keycloak is up)"; false; }
+    echo "token length: ${#token}"
+    [ -n "${token}" ]   || { echo "FAIL: token is empty"; false; }
+    [ "${token}" != "null" ] || { echo "FAIL: token is 'null' — wrong client_id/secret or realm"; false; }
+}
+
+@test "upload shacl.ttl to iff realm" {
+    echo "source file:   ${SHACL_TTL}"
+    echo "graph store:   ${GSP_ENDPOINT}"
+    echo "graph uri:     ${SHACL_GRAPH}"
+
+    [ -f "${SHACL_TTL}" ] || { echo "FAIL: source file not found at ${SHACL_TTL}"; false; }
+
+    local token
+    token=$(get_token) || { echo "FAIL: could not obtain token"; false; }
+
+    local http_code
+    http_code=$(upload_graph "${token}" "${SHACL_TTL}" "${SHACL_GRAPH}")
+    echo "HTTP status: ${http_code}"
+    # 201 = created, 200 = replaced existing graph
+    [[ "${http_code}" == "200" || "${http_code}" == "201" ]] \
+        || { echo "FAIL: expected 200 or 201, got ${http_code} (401=auth failed, 403=wrong role, 405=write not enabled, 500=traefik/proxy error)"; false; }
+}
+
+@test "upload knowledge.ttl to iff realm" {
+    echo "source file:   ${KNOWLEDGE_TTL}"
+    echo "graph uri:     ${KNOWLEDGE_GRAPH}"
+
+    [ -f "${KNOWLEDGE_TTL}" ] || { echo "FAIL: source file not found at ${KNOWLEDGE_TTL}"; false; }
+
+    local token
+    token=$(get_token) || { echo "FAIL: could not obtain token"; false; }
+
+    local http_code
+    http_code=$(upload_graph "${token}" "${KNOWLEDGE_TTL}" "${KNOWLEDGE_GRAPH}")
+    echo "HTTP status: ${http_code}"
+    [[ "${http_code}" == "200" || "${http_code}" == "201" ]] \
+        || { echo "FAIL: expected 200 or 201, got ${http_code}"; false; }
+}
+
+@test "retrieve shacl.ttl from iff realm and verify content" {
+    local token
+    token=$(get_token) || { echo "FAIL: could not obtain token"; false; }
+
+    local http_code
+    http_code=$(get_graph_status "${token}" "${SHACL_GRAPH}")
+    echo "HTTP status for GET graph: ${http_code}"
+    [ "${http_code}" -eq 200 ] \
+        || { echo "FAIL: expected 200, got ${http_code} — graph may not exist yet (run upload test first)"; false; }
+
+    local body
+    body=$(get_graph "${token}" "${SHACL_GRAPH}")
+    echo "body (first 5 lines):"
+    echo "${body}" | head -5
+
+    echo "${body}" | grep -q "cutterTemperatureWithMinMaxShape" \
+        || { echo "FAIL: 'cutterTemperatureWithMinMaxShape' not found in response body"; false; }
+    echo "${body}" | grep -q "shacl#NodeShape" \
+        || { echo "FAIL: 'shacl#NodeShape' not found — body may use unexpected serialization"; false; }
+}
+
+@test "retrieve knowledge.ttl from iff realm and verify content" {
+    local token
+    token=$(get_token) || { echo "FAIL: could not obtain token"; false; }
+
+    local http_code
+    http_code=$(get_graph_status "${token}" "${KNOWLEDGE_GRAPH}")
+    echo "HTTP status for GET graph: ${http_code}"
+    [ "${http_code}" -eq 200 ] \
+        || { echo "FAIL: expected 200, got ${http_code}"; false; }
+
+    local body
+    body=$(get_graph "${token}" "${KNOWLEDGE_GRAPH}")
+    echo "body (first 5 lines):"
+    echo "${body}" | head -5
+
+    echo "${body}" | grep -q "Cutter" \
+        || { echo "FAIL: 'Cutter' not found in response body"; false; }
+    echo "${body}" | grep -q "owl:Class" \
+        || { echo "FAIL: 'owl:Class' not found in response body"; false; }
+}
+
+@test "sparql select query returns node shapes from shacl graph" {
+    local token
+    token=$(get_token) || { echo "FAIL: could not obtain token"; false; }
+
+    local query result
+    query="SELECT ?shape WHERE { GRAPH <${SHACL_GRAPH}> { ?shape a <http://www.w3.org/ns/shacl#NodeShape> } } LIMIT 10"
+    result=$(sparql_query "${token}" "${query}") \
+        || { echo "FAIL: sparql query returned non-2xx (check ${SPARQL_ENDPOINT} is reachable with token)"; false; }
+
+    echo "SPARQL result binding count: $(echo "${result}" | jq '.results.bindings | length')"
+    echo "${result}" | jq -e '.results.bindings | length > 0' \
+        || { echo "FAIL: query returned 0 bindings — shacl graph may be empty or query wrong"; false; }
+}
+
+@test "sparql select query returns classes from knowledge graph" {
+    local token
+    token=$(get_token) || { echo "FAIL: could not obtain token"; false; }
+
+    local query result
+    query="SELECT ?cls WHERE { GRAPH <${KNOWLEDGE_GRAPH}> { ?cls a <http://www.w3.org/2002/07/owl#Class> } } LIMIT 10"
+    result=$(sparql_query "${token}" "${query}") \
+        || { echo "FAIL: sparql query returned non-2xx"; false; }
+
+    echo "SPARQL result binding count: $(echo "${result}" | jq '.results.bindings | length')"
+    echo "${result}" | jq -e '.results.bindings | length > 0' \
+        || { echo "FAIL: query returned 0 bindings — knowledge graph may be empty"; false; }
+}
+
+@test "request with invalid token is rejected on graph store endpoint" {
+    local http_code
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+        -H "Authorization: Bearer this.is.not.a.valid.jwt" \
+        -H "Accept: text/turtle" \
+        "${GSP_ENDPOINT}?graph=${SHACL_GRAPH}")
+    echo "HTTP status with invalid token: ${http_code}"
+    [ "${http_code}" -eq 401 ] \
+        || { echo "FAIL: expected 401, got ${http_code} (500=ForwardAuth unreachable, 200=auth not enforced)"; false; }
+}
+
+@test "request with invalid token is rejected on sparql endpoint" {
+    local query="SELECT ?s WHERE { ?s ?p ?o } LIMIT 1"
+    local http_code
+    http_code=$(sparql_query_status "this.is.not.a.valid.jwt" "${query}")
+    echo "HTTP status with invalid token: ${http_code}"
+    [ "${http_code}" -eq 401 ] \
+        || { echo "FAIL: expected 401, got ${http_code}"; false; }
+}
+
+@test "unauthenticated request to graph store endpoint is rejected" {
+    local http_code
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+        -H "Accept: text/turtle" \
+        "${GSP_ENDPOINT}?graph=${SHACL_GRAPH}")
+    echo "HTTP status without token: ${http_code}"
+    [ "${http_code}" -eq 401 ] \
+        || { echo "FAIL: expected 401, got ${http_code} (500=ForwardAuth unreachable, 200=auth not enforced)"; false; }
+}
+
+@test "unauthenticated request to sparql endpoint is rejected" {
+    local query="SELECT ?s WHERE { ?s ?p ?o } LIMIT 1"
+    local http_code
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" -G \
+        -H "Accept: application/sparql-results+json" \
+        --data-urlencode "query=${query}" \
+        "${SPARQL_ENDPOINT}")
+    echo "HTTP status without token: ${http_code}"
+    [ "${http_code}" -eq 401 ] \
+        || { echo "FAIL: expected 401, got ${http_code}"; false; }
+}

--- a/test/bats/test-fuseki/fuseki-e2e.bats
+++ b/test/bats/test-fuseki/fuseki-e2e.bats
@@ -149,8 +149,8 @@ sparql_query_status() {
 
     echo "${body}" | grep -q "cutterTemperatureWithMinMaxShape" \
         || { echo "FAIL: 'cutterTemperatureWithMinMaxShape' not found in response body"; false; }
-    echo "${body}" | grep -q "shacl#NodeShape" \
-        || { echo "FAIL: 'shacl#NodeShape' not found — body may use unexpected serialization"; false; }
+    echo "${body}" | grep -qE "(shacl#NodeShape|sh:NodeShape)" \
+        || { echo "FAIL: NodeShape not found — body may use unexpected serialization"; false; }
 }
 
 @test "retrieve knowledge.ttl from iff realm and verify content" {

--- a/test/bats/test-fuseki/fuseki-up-and-running.bats
+++ b/test/bats/test-fuseki/fuseki-up-and-running.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+
+load "../lib/utils"
+load "../lib/detik"
+
+# shellcheck disable=SC2034
+DETIK_CLIENT_NAME="kubectl"
+# shellcheck disable=SC2034
+DETIK_CLIENT_NAMESPACE="iff"
+# shellcheck disable=SC2034
+DETIK_DEBUG="true"
+
+@test "verify that fuseki is up and running" {
+    run try "at most 30 times every 60s to find 1 pod named 'fuseki-[^a]' with 'status.containerStatuses[0].ready' being 'true'"
+    [ "$status" -eq 0 ]
+
+    run verify "there is 1 ingress named 'fuseki-ingress'"
+    [ "$status" -eq 0 ]
+}
+
+@test "verify that fuseki-auth is up and running" {
+    run try "at most 30 times every 60s to find 1 pod named 'fuseki-auth' with 'status.containerStatuses[0].ready' being 'true'"
+    [ "$status" -eq 0 ]
+}
+
+@test "verify that fuseki PVC is bound" {
+    run try "at most 10 times every 30s to find 1 persistentvolumeclaim named 'fuseki-data' with 'status.phase' being 'Bound'"
+    [ "$status" -eq 0 ]
+}
+
+@test "verify that fuseki keycloak client secret exists" {
+    run try "at most 10 times every 60s to get secret named 'keycloak-client-secret-fuseki' and verify that 'metadata.name' is 'keycloak-client-secret-fuseki'"
+    [ "$status" -eq 0 ]
+}

--- a/test/bats/test-horizontal-platform/horizontal-platform-up-and-running-third.bats
+++ b/test/bats/test-horizontal-platform/horizontal-platform-up-and-running-third.bats
@@ -75,3 +75,14 @@ DETIK_DEBUG="true"
     run verify "there is 1 ingress named 'alerta-ingress'"
     [ "$status" -eq 0 ]
 }
+
+@test "verify that fuseki and fuseki-auth are up and running" {
+    run try "at most 30 times every 60s to find 1 pod named 'fuseki-[^a]' with 'status.containerStatuses[0].ready' being 'true'"
+    [ "$status" -eq 0 ]
+
+    run try "at most 30 times every 60s to find 1 pod named 'fuseki-auth' with 'status.containerStatuses[0].ready' being 'true'"
+    [ "$status" -eq 0 ]
+
+    run verify "there is 1 ingress named 'fuseki-ingress'"
+    [ "$status" -eq 0 ]
+}

--- a/test/setup-local-ingress.sh
+++ b/test/setup-local-ingress.sh
@@ -49,4 +49,4 @@ kubectl -n kube-system delete pod "${COREDNS_POD}"
 # -----------------
 echo Update hostfile for local api
 echo ------------------
-${SUDO} bash -c "echo $INGRESS_IP keycloak.local alerta.local ngsild.local pgrest.local >> /etc/hosts"
+${SUDO} bash -c "echo $INGRESS_IP keycloak.local alerta.local ngsild.local pgrest.local fuseki.local >> /etc/hosts"


### PR DESCRIPTION
## Summary

- Adds Apache Jena Fuseki 6.1.0 as a persistent RDF triplestore, deployed via a new Helm chart (`helm/charts/fuseki/`)
- Introduces a Python FastAPI auth proxy (ConfigMap-injected) that enforces JWT realm-path matching and role-based access (`Factory-Admin` for writes, `Factory-Reader` for reads) via Traefik ForwardAuth
- Integrates with the existing helmfile shared value pool: realms, image registry/repo/version, and Keycloak client secret flow without re-declarations

## Details

**Fuseki service**
- Custom Docker image (`Fuseki/Dockerfile`) based on `eclipse-temurin:21-jre-alpine` + Fuseki 6.1.0; entrypoint registers one TDB2 dataset per Keycloak realm via `FusekiMainCmd` command-line API (avoids `FMod_Admin` conflicts)
- Named graphs follow the convention `<fuseki-url>/<realm>/shacl.ttl` and `<fuseki-url>/<realm>/knowledge.ttl`
- Persistent storage via PVC (`fuseki-data`)

**Auth proxy**
- Accepts all HTTP methods (Traefik ForwardAuth forwards the original method, unlike nginx)
- Uses FQDN `fuseki-auth.<namespace>.svc.cluster.local` in Traefik middleware (required because Traefik runs in `kube-system`)
- JWKS fetched from Keycloak with 5-minute in-memory cache

**Keycloak integration**
- `fuseki` confidential client with `Factory-Admin` and `Factory-Reader` roles
- Service account `service-account-fuseki` pre-assigned `Factory-Admin`
- Client secret managed via lookup-or-fallback pattern (same as existing clients)

**Tests**
- `test/bats/test-fuseki/fuseki-up-and-running.bats` — readiness checks (pod, ingress, PVC, secret)
- `test/bats/test-fuseki/fuseki-e2e.bats` — token acquisition, GSP PUT/GET with content verification, SPARQL SELECT from both graphs, 401 rejection for invalid/missing tokens

**API documentation**
- `Fuseki/fuseki-api.md` — complete reference for health check, GSP, SPARQL query/update, auth roles, named graph convention, and HTTP status codes

## Test plan

- [x] `helm/helmfile.yaml` deploys fuseki release without errors after keycloak is up
- [x] `kubectl -n iff get pods -l app=fuseki` shows Running
- [x] `kubectl -n iff get pods -l app=fuseki-auth` shows Running
- [x] Fuseki health check: `curl http://fuseki.local/$/ping` returns timestamp
- [x] Run `bats test/bats/test-fuseki/fuseki-up-and-running.bats` — all pass
- [x] Run `bats test/bats/test-fuseki/fuseki-e2e.bats` — all 11 tests pass
- [x] `test/bats/test-horizontal-platform/horizontal-platform-up-and-running-third.bats` includes fuseki+fuseki-auth readiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)