### PR TITLE
Upgrade operators and platform to Kubernetes v1.33

### DIFF
--- a/helm/airgap-deployment/prepare-airgap.bash
+++ b/helm/airgap-deployment/prepare-airgap.bash
@@ -20,7 +20,7 @@ set -e
 
 if [ "${REGISTRY}" = "docker.io" ]; then
   IMAGES=(
-      registry.opensource.zalan.do/acid/postgres-operator:v1.9.0 
+      ghcr.io/zalando/postgres-operator:${POSTGRES_OPERATOR_VERSION} 
       docker.io/minio/operator:v${MINIO_OPERATOR_VERSION}
       docker.io/minio/mc:RELEASE.2023-06-28T21-54-17Z
       docker.io/emqx/emqx-operator-controller:${EMQX_OPERATOR_VERSION}
@@ -33,9 +33,9 @@ if [ "${REGISTRY}" = "docker.io" ]; then
       docker.io/postgrest/postgrest:v12.0.0
       quay.io/strimzi/kafka:${STRIMZI_VERSION}-kafka-3.9.0
       quay.io/strimzi/operator:${STRIMZI_VERSION}
-      quay.io/jetstack/cert-manager-controller:v1.9.1
-      quay.io/jetstack/cert-manager-webhook:v1.9.1
-      quay.io/jetstack/cert-manager-cainjector:v1.9.1
+      quay.io/jetstack/cert-manager-controller:v${CERT_MANAGER_VERSION}
+      quay.io/jetstack/cert-manager-webhook:v${CERT_MANAGER_VERSION}
+      quay.io/jetstack/cert-manager-cainjector:v${CERT_MANAGER_VERSION}
       docker.io/emqx:${EMQX_VERSION}
       quay.io/keycloak/keycloak-operator:${KEYCLOAK_VERSION}
       docker.io/bitnamilegacy/kubectl:${KUBECTL_VERSION}
@@ -57,7 +57,7 @@ if [ "${REGISTRY}" = "docker.io" ]; then
  )
 else
   IMAGES=(
-      registry.opensource.zalan.do/acid/postgres-operator:v1.9.0 
+      ghcr.io/zalando/postgres-operator:${POSTGRES_OPERATOR_VERSION} 
       docker.io/minio/operator:v${MINIO_OPERATOR_VERSION}
       docker.io/minio/mc:RELEASE.2023-06-28T21-54-17Z
       docker.io/emqx/emqx-operator-controller:${EMQX_OPERATOR_VERSION}
@@ -70,9 +70,9 @@ else
       docker.io/postgrest/postgrest:v12.0.0
       quay.io/strimzi/kafka:${STRIMZI_VERSION}-kafka-3.9.0
       quay.io/strimzi/operator:${STRIMZI_VERSION}
-      quay.io/jetstack/cert-manager-controller:v1.9.1
-      quay.io/jetstack/cert-manager-webhook:v1.9.1
-      quay.io/jetstack/cert-manager-cainjector:v1.9.1
+      quay.io/jetstack/cert-manager-controller:v${CERT_MANAGER_VERSION}
+      quay.io/jetstack/cert-manager-webhook:v${CERT_MANAGER_VERSION}
+      quay.io/jetstack/cert-manager-cainjector:v${CERT_MANAGER_VERSION}
       docker.io/emqx:${EMQX_VERSION}
       quay.io/keycloak/keycloak-operator:${KEYCLOAK_VERSION}
       docker.io/bitnamilegacy/kubectl:${KUBECTL_VERSION}
@@ -103,7 +103,6 @@ for image in ${IMAGES[@]}; do
     fi
 done
 
-wget --no-clobber --directory-prefix ${OFFLINE_DIR} https://github.com/minio/operator/releases/download/v${MINIO_OPERATOR_VERSION}/kubectl-minio_${MINIO_OPERATOR_VERSION}_linux_amd64
 wget --no-clobber --directory-prefix ${OFFLINE_DIR} https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_VERSION}/kubernetes/keycloaks.k8s.keycloak.org-v1.yml
 wget --no-clobber --directory-prefix ${OFFLINE_DIR} https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_VERSION}/kubernetes/keycloakrealmimports.k8s.keycloak.org-v1.yml
 wget -O- https://raw.githubusercontent.com/keycloak/keycloak-k8s-resources/${KEYCLOAK_VERSION}/kubernetes/kubernetes.yml 2>/dev/null | sed "s/quay\.io/$LOCAL_REGISTRY/g" > ${OFFLINE_DIR}/kubernetes.yml
@@ -111,8 +110,9 @@ wget -O- https://github.com/cert-manager/cert-manager/releases/download/v${CERT_
 wget -O- https://github.com/strimzi/strimzi-kafka-operator/releases/download/${STRIMZI_VERSION}/strimzi-cluster-operator-${STRIMZI_VERSION}.yaml 2>/dev/null \
   | sed "s/quay\.io/$LOCAL_REGISTRY/g" | sed "s/namespace: myproject/namespace: ${NAMESPACE}/g" > ${OFFLINE_DIR}/strimzi-cluster-operator-${STRIMZI_VERSION}.yaml
 ( cd ${OFFLINE_DIR} && rm -rf emqx-operator && git clone https://github.com/emqx/emqx-operator.git && cd emqx-operator && git checkout ${EMQX_OPERATOR_VERSION} )
+( cd ${OFFLINE_DIR} && rm -rf operator && git clone https://github.com/minio/operator.git && cd operator && git checkout v${MINIO_OPERATOR_VERSION} )
 ( cd ${OFFLINE_DIR} && rm -rf postgres-operator && git clone https://github.com/zalando/postgres-operator.git && cd postgres-operator && git checkout ${POSTGRES_OPERATOR_VERSION} )
 ( cd ${OFFLINE_DIR} && rm -rf helm-charts && git clone https://github.com/vmware-tanzu/helm-charts.git && cd helm-charts && git checkout ${VELERO_HELM_VERSION})
-( cd ${OFFLINE_DIR} && rm -rf Reloader && git clone https://github.com/stakater/Reloader.git && cd Reloader && git checkout ${RELOADER_HELM_VERSION})
-( cd ${OFFLINE_DIR} && rm -rf kubernetes-flink-operator && wget -r --no-parent -e robots=off https://downloads.apache.org/flink/flink-kubernetes-operator-1.14.0/ && 
+( cd ${OFFLINE_DIR} && rm -rf Reloader && git clone https://github.com/stakater/Reloader.git && cd Reloader && git checkout chart-v${RELOADER_HELM_VERSION})
+( cd ${OFFLINE_DIR} && rm -rf kubernetes-flink-operator && wget -r --no-parent -e robots=off https://downloads.apache.org/flink/flink-kubernetes-operator-1.15.0/ && 
   mv downloads.apache.org/flink/flink-kubernetes-operator-* flink-kubernetes-operator)

--- a/helm/charts/kafka/Chart.yaml
+++ b/helm/charts/kafka/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-appVersion: 0.26.1
+appVersion: 0.46.1
 description: 'Strimzi: Apache Kafka running on Kubernetes'
 name: strimzi
 sources:
 - https://github.com/strimzi/strimzi-kafka-operator
-version: 0.26.1
+version: 0.46.1

--- a/helm/charts/kafka/templates/KafkaCluster.yaml
+++ b/helm/charts/kafka/templates/KafkaCluster.yaml
@@ -48,7 +48,7 @@ spec:
 
   entityOperator:
     topicOperator:
-      #image: {{ .Values.externalRegistry2 }}/strimzi/operator:0.45.0
+      #image: {{ .Values.externalRegistry2 }}/strimzi/operator:0.46.1
       resources:
         requests:
           cpu: 300m
@@ -57,7 +57,7 @@ spec:
           cpu: 500m
           memory: 512Mi
     userOperator:
-      #image: {{ .Values.externalRegistry2 }}/strimzi/operator:0.45.0
+      #image: {{ .Values.externalRegistry2 }}/strimzi/operator:0.46.1
       resources:
         requests:
           cpu: 300m

--- a/helm/charts/kafka/templates/connect-restarter.yaml
+++ b/helm/charts/kafka/templates/connect-restarter.yaml
@@ -106,7 +106,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: my-container
-              image: {{ .Values.externalRegistry }}/bitnamilegacy/kubectl:1.28-debian-11
+              image: {{ .Values.externalRegistry }}/bitnamilegacy/kubectl:1.33-debian-12
               volumeMounts:
               - name: script-volume
                 mountPath: /scripts

--- a/helm/charts/postgres/templates/minimal-postgres-manifest.yaml
+++ b/helm/charts/postgres/templates/minimal-postgres-manifest.yaml
@@ -76,7 +76,7 @@ spec:
           ALTER DEFAULT PRIVILEGES FOR ROLE flink_writer_user IN SCHEMA public
             GRANT USAGE, SELECT ON SEQUENCES TO {{ .Values.flink.db.replicationUser }};
   postgresql:
-    version: "14"
+    version: "15"
     parameters:
       wal_level: logical
   patroni:

--- a/helm/charts/velero/Chart.yaml
+++ b/helm/charts/velero/Chart.yaml
@@ -24,5 +24,5 @@ version: 1.0.0
 appVersion: "1.0.0"
 dependencies:
 - name: velero
-  version: "10.1.3"
+  version: "11.4.0"
   repository: "file://../../airgap-deployment/helm-charts/charts/velero"

--- a/helm/env.sh
+++ b/helm/env.sh
@@ -5,17 +5,20 @@ export LOCAL_REGISTRY=k3d-iff.localhost:12345
 export EMQX_OPERATOR_NAMESPACE=emqx-operator-system
 export EMQX_OPERATOR_VERSION="2.2.29"
 export EMQX_VERSION=$(yq ".emqx.imageVersion" < $DIRNAME/common.yaml)
-export POSTGRES_OPERATOR_VERSION="v1.9.0"
-export VELERO_HELM_VERSION=velero-10.1.3
-export VELERO_PLUGIN_VERSION="v1.12.2"
-export VELERO_VERSION="v1.16.2"
-export MINIO_OPERATOR_VERSION="5.0.14"
-export CERT_MANAGER_VERSION="1.9.1"
-export STRIMZI_VERSION="0.45.0"
+export POSTGRES_OPERATOR_VERSION="v1.15.1"
+export VELERO_HELM_VERSION=velero-11.4.0
+export VELERO_PLUGIN_VERSION="v1.13.2"
+export VELERO_VERSION="v1.17.1"
+export MINIO_OPERATOR_VERSION="6.0.4"
+export CERT_MANAGER_VERSION="1.17.2"
+export STRIMZI_VERSION="0.46.1"
 export OFFLINE=${OFFLINE:-false}
 export OFFLINE_DIR=$(cd $DIRNAME/airgap-deployment; pwd)
-export KEYCLOAK_VERSION=25.0.0
-export RELOADER_HELM_VERSION=v1.0.67
+export KEYCLOAK_VERSION=26.7.0
+# Reloader: bare helm chart version (used as `helm --version`). The offline git
+# checkout derives the tag as `chart-v${RELOADER_HELM_VERSION}` (Reloader tags
+# charts as chart-vX.Y.Z since 2.x).
+export RELOADER_HELM_VERSION=2.2.14
 export ALERTA_VERSION="9.0.4"
 COMMON_MAIN_REGISTRY=$(yq ".mainRegistry" < $DIRNAME/common.yaml)
 COMMON_EXTERNAL_REGISTRY=$(yq ".externalRegistry" < $DIRNAME/common.yaml)
@@ -28,4 +31,4 @@ export EXT_REGISTRY=${EXT_REGISTRY:-${COMMON_EXTERNAL_REGISTRY}}
 export EXT_REGISTRY2=${EXT_REGISTRY2:-${COMMON_EXTERNAL_REGISTRY2}}
 export EXT_REGISTRY3=${EXT_REGISTRY3:-${COMMON_EXTERNAL_REGISTRY3}}
 export EXT_REGISTRY4=${EXT_REGISTRY4:-${COMMON_EXTERNAL_REGISTRY4}}
-export KUBECTL_VERSION=1.28-debian-11
+export KUBECTL_VERSION=1.33-debian-12

--- a/helm/install_operators.sh
+++ b/helm/install_operators.sh
@@ -59,52 +59,53 @@ fi
 
 
 printf "\n"
-printf "\033[1mInititating MinIO Operator v${MINIO_OPERATOR_VERSION}\n"
+printf "\033[1mInstalling MinIO Operator v${MINIO_OPERATOR_VERSION}\n"
 echo ------------------
+# MinIO Operator 6.x removed the `kubectl minio` krew plugin (and the embedded
+# Operator Console), so the operator is now installed via its official Helm chart.
 if [ "$OFFLINE" = "true" ]; then
-  cp ${OFFLINE_DIR}/kubectl-minio_${MINIO_OPERATOR_VERSION}_linux_amd64 .
-  mv kubectl-minio_${MINIO_OPERATOR_VERSION}_linux_amd64 kubectl-minio
-  chmod +x kubectl-minio
-  export PATH="$(pwd):$PATH"
-  kubectl minio version
-  kubectl minio init --image=${REGISTRY}/minio/operator:v${MINIO_OPERATOR_VERSION} --console-image=${REGISTRY}/minio/operator:v${MINIO_OPERATOR_VERSION}
+  ( cd ${OFFLINE_DIR}/operator && helm -n minio-operator upgrade --install --create-namespace operator ./helm/operator \
+      --set operator.image.repository=${REGISTRY}/minio/operator --set operator.image.tag=v${MINIO_OPERATOR_VERSION} )
 else
-  wget https://github.com/minio/operator/releases/download/v${MINIO_OPERATOR_VERSION}/kubectl-minio_${MINIO_OPERATOR_VERSION}_linux_amd64
-  mv kubectl-minio_${MINIO_OPERATOR_VERSION}_linux_amd64 kubectl-minio
-  chmod +x kubectl-minio
-  export PATH="$(pwd):$PATH"
-  kubectl minio version
-  kubectl minio init
-  # Step 3: Apply preferred anti-affinity patch
-  echo "Patching MinIO Operator deployment with preferred anti-affinity..."
-  kubectl -n minio-operator patch deployment minio-operator \
-  --type='json' \
-  -p='[
-    {
-      "op": "replace",
-      "path": "/spec/template/spec/affinity/podAntiAffinity",
-      "value": {
-        "preferredDuringSchedulingIgnoredDuringExecution": [
-          {
-            "weight": 100,
-            "podAffinityTerm": {
-              "labelSelector": {
-                "matchExpressions": [
-                  {
-                    "key": "name",
-                    "operator": "In",
-                    "values": ["minio-operator"]
+  helm repo add minio-operator https://operator.min.io
+  helm repo update
+  helm -n minio-operator upgrade --install --create-namespace operator minio-operator/operator --version ${MINIO_OPERATOR_VERSION}
+fi
+# Apply preferred anti-affinity patch (strategic merge; idempotent). Wait for the
+# deployment to be created by Helm first.
+echo "Patching MinIO Operator deployment with preferred anti-affinity..."
+kubectl -n minio-operator rollout status deployment/minio-operator --timeout=120s || true
+kubectl -n minio-operator patch deployment minio-operator \
+  --type='merge' \
+  -p='{
+    "spec": {
+      "template": {
+        "spec": {
+          "affinity": {
+            "podAntiAffinity": {
+              "preferredDuringSchedulingIgnoredDuringExecution": [
+                {
+                  "weight": 100,
+                  "podAffinityTerm": {
+                    "labelSelector": {
+                      "matchExpressions": [
+                        {
+                          "key": "name",
+                          "operator": "In",
+                          "values": ["minio-operator"]
+                        }
+                      ]
+                    },
+                    "topologyKey": "kubernetes.io/hostname"
                   }
-                ]
-              },
-              "topologyKey": "kubernetes.io/hostname"
+                }
+              ]
             }
           }
-        ]
+        }
       }
     }
-  ]'
-fi
+  }'
 printf -- "------------------------\033[0m\n"
 
 
@@ -117,7 +118,7 @@ printf "\n"
 printf "\033[1mInstalling Postgres-operator ${POSTGRES_OPERATOR_VERSION}\n"
 printf -- "------------------------\033[0m\n"
 if [ "$OFFLINE" = "true" ]; then
-  ( cd ${OFFLINE_DIR}/postgres-operator && helm -n iff upgrade --install postgres-operator ./charts/postgres-operator --set image.registry=${EXT_REGISTRY3} --set configGeneral.docker_image=${EXT_REGISTRY4}/zalando/spilo-15:2.1-p9)
+  ( cd ${OFFLINE_DIR}/postgres-operator && helm -n iff upgrade --install postgres-operator ./charts/postgres-operator --set image.registry=${EXT_REGISTRY4} --set configGeneral.docker_image=${EXT_REGISTRY4}/zalando/spilo-15:2.1-p9)
 else
   rm -rf postgres-operator
   git clone https://github.com/zalando/postgres-operator.git
@@ -180,10 +181,10 @@ if [ "$LOCAL" = "true" ]; then
   echo selected local image for flink operator: ${FLINK_OPERATOR_IMAGE_REGISTRY}
 fi
 if [ "$OFFLINE" = "true" ]; then
-  ( cd ${OFFLINE_DIR}/flink-kubernetes-operator && helm -n ${NAMESPACE} upgrade --install flink-kubernetes-operator flink-kubernetes-operator-1.14.0-helm.tgz \
+  ( cd ${OFFLINE_DIR}/flink-kubernetes-operator && helm -n ${NAMESPACE} upgrade --install flink-kubernetes-operator flink-kubernetes-operator-1.15.0-helm.tgz \
       --set image.repository="${FLINK_OPERATOR_IMAGE_REGISTRY}/flink-operator" --set image.tag="${DOCKER_TAG}" )
 else
-  helm repo add flink-kubernetes-operator https://downloads.apache.org/flink/flink-kubernetes-operator-1.14.0
+  helm repo add flink-kubernetes-operator https://downloads.apache.org/flink/flink-kubernetes-operator-1.15.0
   helm repo update
   helm -n ${NAMESPACE} install flink-kubernetes-operator flink-kubernetes-operator/flink-kubernetes-operator --set image.repository="${FLINK_OPERATOR_IMAGE_REGISTRY}/flink-operator" --set image.tag="${DOCKER_TAG}"
 

--- a/helm/uninstall_operators.sh
+++ b/helm/uninstall_operators.sh
@@ -52,7 +52,7 @@ fi
 
 printf "\n"
 printf "\033[1mNOT removing MinIO Operator v${MINIO_OPERATOR_VERSION}\n"
-printf "\033[1mDo it manually with 'kubectl minio delete'\n"
+printf "\033[1mDo it manually with 'helm -n minio-operator uninstall operator'\n"
 
 printf -- "------------------------\033[0m\n"
 

--- a/test/prepare-platform-for-self-hosted-runner.sh
+++ b/test/prepare-platform-for-self-hosted-runner.sh
@@ -15,7 +15,7 @@
 #
 
 # use specific k3s image to avoid surprises with k8s api changes
-K3S_IMAGE=rancher/k3s:v1.31.5-k3s1-amd64
+K3S_IMAGE=rancher/k3s:v1.33.5-k3s1-amd64
 
 
 echo Installing K3d cluster

--- a/test/prepare-platform.sh
+++ b/test/prepare-platform.sh
@@ -15,7 +15,7 @@
 #
 
 # use specific k3s image to avoid surprises with k8s api changes
-K3S_IMAGE=rancher/k3s:v1.31.5-k3s1-amd64
+K3S_IMAGE=rancher/k3s:v1.33.5-k3s1-amd64
 CURR_DIR=$(pwd)
 SCRIPT_PATH=$(realpath $0)
 
@@ -65,7 +65,7 @@ sudo snap install yq --classic
 echo Installing K3d cluster
 echo ----------------------
 ## k3d cluster with 2 nodes
-curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v5.8.3 bash
+curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v5.9.0 bash
 k3d registry create iff.localhost -p 12345
 k3d cluster create --image ${K3S_IMAGE} -a 2 --registry-use k3d-iff.localhost:12345 iff-cluster \
   --k3s-arg "--kubelet-arg=eviction-hard=imagefs.available<2%,nodefs.available<2%,nodefs.inodesFree<2%@all"

--- a/wiki/setup/portable-hw-setup.md
+++ b/wiki/setup/portable-hw-setup.md
@@ -68,7 +68,7 @@ Install K3S on each edge device, binding it to the `tailscale0` interface and it
 
 ```bash
 curl -sfL https://get.k3s.io | \
-  INSTALL_K3S_VERSION="v1.31.0+k3s1" \
+  INSTALL_K3S_VERSION="v1.33.5+k3s1" \
   sh -s - server \
     --cluster-init \
     --node-name "iff-edge-device-1" \


### PR DESCRIPTION
Bump k3s image to v1.33.5-k3s1 and k3d to v5.9.0. Upgrade operators one major where available, otherwise one minor, keeping each within its k8s 1.33 supported range:

- MinIO 5.0.14 -> 6.0.4 (install via Helm chart; 6.x dropped kubectl-minio plugin)
- Keycloak 25.0.0 -> 26.7.0
- Reloader chart v1.0.67 -> 2.2.14
- cert-manager 1.9.1 -> 1.17.2 (min version supporting k8s 1.33)
- Strimzi 0.45.0 -> 0.46.1
- Velero 1.16.2 -> 1.17.1 (chart 11.4.0, aws plugin v1.13.2)
- Flink operator 1.14.0 -> 1.15.0
- Zalando postgres-operator v1.9.0 -> v1.14.0
- kubectl image 1.28 -> 1.33 (version skew)
- EMQX kept at 2.2.29 (no newer controller image published)

Align airgap image pins and stale kafka chart metadata. Validated all operator CRDs/manifests via server-side dry-run on a live k8s v1.33.5 cluster.