### PR TITLE
fix: serialize-javascript >=7.0.5 (HIGH/MEDIUM) in NgsildAgent + @hono/node-server 2.0.11 (MEDIUM) in datamodel/tools

### DIFF
--- a/NgsildAgent/package-lock.json
+++ b/NgsildAgent/package-lock.json
@@ -2649,16 +2649,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -2812,13 +2802,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
+      "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/shebang-command": {

--- a/NgsildAgent/package.json
+++ b/NgsildAgent/package.json
@@ -23,7 +23,8 @@
     "winston": "^3.7.2"
   },
   "overrides": {
-    "node-gyp": "^12.1.0"
+    "node-gyp": "^12.1.0",
+    "serialize-javascript": ">=7.0.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.11.0",

--- a/semantic-model/datamodel/tools/package-lock.json
+++ b/semantic-model/datamodel/tools/package-lock.json
@@ -3200,9 +3200,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.5.tgz",
-      "integrity": "sha512-yQFvDmyDo3y6rEOJZDUYPJ49DIKTPpIk4kGvm40xx4Ejne0Pu9a1+exxPN+C1UppWK/WGZX9F++/Xs231tE86g==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+      "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/semantic-model/datamodel/tools/package.json
+++ b/semantic-model/datamodel/tools/package.json
@@ -70,6 +70,6 @@
     "@comunica/core": {
       "immutable": "4.3.9"
     },
-    "@hono/node-server": "2.0.5"
+    "@hono/node-server": "2.0.11"
   }
 }


### PR DESCRIPTION
## Summary

Fixes two open Dependabot security alerts:

### NgsildAgent — serialize-javascript (HIGH #332, MEDIUM #333)
- Added `"serialize-javascript": ">=7.0.5"` to npm overrides
- serialize-javascript is a transitive devDep via mocha; upgraded 6.0.2 → 7.0.7
- Fixes GHSA: RCE via RegExp.flags accessor (#332, HIGH) and CPU-exhaustion DoS (#333, MEDIUM)

### semantic-model/datamodel/tools — @hono/node-server (MEDIUM #335)
- Bumped `@hono/node-server` override from `2.0.5` → `2.0.11`
- Previous fix targeted <2.0.5; new CVE covers 2.0.0–2.0.9; first patched: 2.0.10
- Fixes GHSA: unauthenticated memory-leak DoS in Node.js adapter (#335, MEDIUM)

## Test plan
- [ ] `npm audit --production --audit-level high` passes in both NgsildAgent and datamodel/tools (0 vulnerabilities)
- [ ] All existing tests pass
- [ ] Build workflow passes
- [ ] K8s tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)