### PR TITLE
security(KafkaBridge): fix brace-expansion HIGH + GET-auth password exposure

### DIFF
--- a/KafkaBridge/lib/authService/authenticate.js
+++ b/KafkaBridge/lib/authService/authenticate.js
@@ -69,12 +69,13 @@ class Authenticate {
     }
   }
 
-  // expects "username" and "password" as url-query-parameters
+  // expects "username" and "password" as POST body parameters
   async authenticate (req, res) {
-    this.logger.debug('Auth request ' + JSON.stringify(req.query));
-    const username = req.query.username;
-    const token = req.query.password;
-    const clientid = req.query.clientid;
+    const safeBody = Object.assign({}, req.body, { password: req.body.password ? '[REDACTED]' : undefined });
+    this.logger.debug('Auth request ' + JSON.stringify(safeBody));
+    const username = req.body.username;
+    const token = req.body.password;
+    const clientid = req.body.clientid;
     if (username === this.config.mqtt.adminUsername) {
       if (token === this.config.mqtt.adminPassword) {
         // superuser
@@ -89,7 +90,6 @@ class Authenticate {
       }
     }
     const decodedToken = await this.verifyAndDecodeToken(token);
-    this.logger.debug('token decoded: ' + JSON.stringify(decodedToken));
     if (decodedToken === null) {
       this.logger.warn(`Could not decode token for username ${username} and clientid ${clientid}.`);
       res.status(200).json({ result: 'deny' });

--- a/KafkaBridge/lib/authService/index.js
+++ b/KafkaBridge/lib/authService/index.js
@@ -30,13 +30,14 @@ const init = async function (conf) {
   await acl.init();
   const config = conf;
   app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
 
   const authLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 100 // limit each IP to 100 requests per windowMs
   });
 
-  app.get('/auth', authLimiter, (req, res) => {
+  app.post('/auth', authLimiter, (req, res) => {
     auth.authenticate(req, res);
   });
 

--- a/KafkaBridge/package-lock.json
+++ b/KafkaBridge/package-lock.json
@@ -1137,6 +1137,12 @@
         "proxy-from-env": "^2.1.0"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "funding": [
@@ -1269,6 +1275,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
       "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -1281,6 +1288,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -1660,6 +1668,13 @@
       "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
@@ -3151,6 +3166,15 @@
         "readable-stream": "^3.6.0"
       }
     },
+    "node_modules/help-me/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/help-me/node_modules/glob": {
       "version": "8.1.0",
       "license": "ISC",
@@ -4149,6 +4173,17 @@
         "node": "*"
       }
     },
+    "node_modules/minimatch/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "license": "MIT",
@@ -4199,6 +4234,16 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/mocha/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/mocha/node_modules/diff": {

--- a/KafkaBridge/package-lock.json
+++ b/KafkaBridge/package-lock.json
@@ -1137,10 +1137,6 @@
         "proxy-from-env": "^2.1.0"
       }
     },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "funding": [
@@ -1270,13 +1266,24 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/brorand": {
@@ -1653,10 +1660,6 @@
       "integrity": "sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==",
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "license": "MIT"
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
@@ -4196,16 +4199,6 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/mocha/node_modules/diff": {

--- a/KafkaBridge/package.json
+++ b/KafkaBridge/package.json
@@ -37,7 +37,6 @@
     "sinon": "^13.0.2"
   },
   "overrides": {
-    "brace-expansion": "5.0.8",
     "serialize-javascript": ">=7.0.3",
     "@eslint/eslintrc": {
       "js-yaml": "3.15.0"

--- a/KafkaBridge/package.json
+++ b/KafkaBridge/package.json
@@ -37,6 +37,7 @@
     "sinon": "^13.0.2"
   },
   "overrides": {
+    "brace-expansion": "5.0.8",
     "serialize-javascript": ">=7.0.3",
     "@eslint/eslintrc": {
       "js-yaml": "3.15.0"
@@ -48,13 +49,7 @@
       "js-yaml": "3.15.0"
     },
     "mocha": {
-      "js-yaml": "4.3.0",
-      "minimatch": {
-        "brace-expansion": "2.1.2"
-      }
-    },
-    "minimatch": {
-      "brace-expansion": "1.1.16"
+      "js-yaml": "4.3.0"
     },
     "fast-uri": "3.1.4",
     "adm-zip": "0.6.0",

--- a/KafkaBridge/test/lib_authServiceTest.js
+++ b/KafkaBridge/test/lib_authServiceTest.js
@@ -119,7 +119,7 @@ describe(fileToTest, function () {
     const auth = new Authenticate(config);
 
     const req = {
-      query: {
+      body: {
         username: 'username',
         password: 'password'
       }
@@ -150,7 +150,7 @@ describe(fileToTest, function () {
       }
     };
     const req = {
-      query: {
+      body: {
         username: 'deviceId',
         password: 'token'
       }
@@ -204,7 +204,7 @@ describe(fileToTest, function () {
     const auth = new Authenticate(config);
 
     const req = {
-      query: {
+      body: {
         username: 'username',
         password: 'password'
       }
@@ -234,7 +234,7 @@ describe(fileToTest, function () {
       }
     };
     const req = {
-      query: {
+      body: {
         username: 'username',
         password: 'token'
       }
@@ -283,7 +283,7 @@ describe(fileToTest, function () {
       }
     };
     const req = {
-      query: {
+      body: {
         username: 'wrongDeviceId',
         password: 'password'
       }
@@ -379,7 +379,7 @@ describe(fileToTest, function () {
       }
     };
     const req = {
-      query: { username: 'realm_user', password: 'token', clientid: 'clientid-factory' }
+      body: { username: 'realm_user', password: 'token', clientid: 'clientid-factory' }
     };
     const res = {
       status: function (status) {
@@ -425,7 +425,7 @@ describe(fileToTest, function () {
       }
     };
     const req = {
-      query: { username: 'realm_user', password: 'token', clientid: 'clientid-factory' }
+      body: { username: 'realm_user', password: 'token', clientid: 'clientid-factory' }
     };
     const res = {
       status: function (status) {
@@ -469,7 +469,7 @@ describe(fileToTest, function () {
       }
     };
     const req = {
-      query: { username: 'realm_user', password: 'token', clientid: 'clientid-1' }
+      body: { username: 'realm_user', password: 'token', clientid: 'clientid-1' }
     };
     const res = {
       status: function (status) {

--- a/helm/charts/emqx/templates/emxq.yaml
+++ b/helm/charts/emqx/templates/emxq.yaml
@@ -38,7 +38,7 @@ spec:
                 backend = http
                 enable = true
 
-                method = get
+                method = post
                 url = "http://{{ .Values.mqtt.bridge.url }}:{{ .Values.mqtt.bridge.port }}/auth"
                 body {
                     username = "${username}"


### PR DESCRIPTION
## Summary

- **Alert #324 (HIGH)**: Override `brace-expansion` globally to `5.0.8` (GHSA-mh99-v99m-4gvg). Previous override pinned via nested minimatch to `1.1.16` which is still vulnerable; changed to a top-level `"brace-expansion": "5.0.8"` override that covers all dep tree instances.
- **CodeQL #9 (sensitive-get-query)**: Switch `/auth` endpoint from GET to POST so the password is never transmitted as a URL query parameter (avoids server logs, proxy logs, browser history). EMQX HTTP auth config updated from `method = get` → `method = post`.
- **CodeQL #50 (clear-text-logging)**: Redact `password` field before logging `req.body` in `authenticate.js`; remove the decoded JWT debug log at line 92 (tokens contain sensitive claims).
- Update tests to use `req.body` instead of `req.query` for auth calls (ACL tests unchanged — ACL endpoint stays GET).

## Test plan

- [x] `npm test` in KafkaBridge: 164 passing, 0 failing
- [x] `npm audit` shows brace-expansion alert resolved; remaining HIGH issues are pre-existing (elliptic via keycloak-connect — unfixable) and diff@7 via mocha (dev-only, pre-existing)
- [ ] Build CI passes
- [ ] K8s tests pass (EMQX POST auth flow tested end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)