### PR TITLE
security: add minimum permissions declarations to all CI workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/docker-clean.yaml
+++ b/.github/workflows/docker-clean.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: none
+
 jobs:
   clean-docker:
     runs-on: [self-hosted]  # <-- use your runner's labels

--- a/.github/workflows/k8s-tests.yaml
+++ b/.github/workflows/k8s-tests.yaml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   SELF_HOSTED_RUNNER: true
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,6 +2,10 @@ name: Nigthly
 on:
   schedule:
     - cron: '0 0 * * *'
+
+permissions:
+  contents: read
+
 jobs:
   cleanup:
     runs-on: private

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: read
+
 jobs:
   push-release-images:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary

- Resolves CodeQL `actions/missing-workflow-permissions` alerts #26, #27, #29, #31, #32, #42, #43, #48, #49
- Adds `permissions: contents: read` to `build.yaml`, `k8s-tests.yaml`, `nightly.yaml`, and `release.yaml`
- Adds `permissions: contents: none` to `docker-clean.yaml` (no git checkout, only runs `docker system prune`)

Following the principle of least privilege: the `GITHUB_TOKEN` is restricted to the minimum needed for each workflow to function.

## Test plan

- [x] No functional changes — workflow steps are identical
- [ ] Build CI passes on `build.yaml`
- [ ] K8s tests pass on `k8s-tests.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)