### PR TITLE
chore: upgrade actions/checkout to v4 and Node.js EOL versions to 22

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Build the Docker images
       run: docker compose build
     # Use conda-incubator to install Miniconda

--- a/.github/workflows/k8s-tests.yaml
+++ b/.github/workflows/k8s-tests.yaml
@@ -21,7 +21,7 @@ jobs:
     needs: clean-docker
     runs-on: private
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Prepare K3d cluster
       run: |
         if [ -z "${SELF_HOSTED_RUNNER}" ]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       DOCKER_PREFIX: ${{ secrets.DOCKER_PREFIX }}
       BUILDONLY: true
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Prepare K3d cluster
         run: |
           cd ./test && bash ./prepare-platform.sh

--- a/FlinkSqlGateway/Dockerfile
+++ b/FlinkSqlGateway/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.8 as plint
 ADD submitjob/ submitjob
 RUN pip3 install flake8 && flake8 submitjob/job.py
 
-FROM node:20 as nodelint
+FROM node:22 as nodelint
 ADD gateway.js gateway.js
 ADD package.json package.json
 ADD lib/ lib
@@ -16,7 +16,7 @@ FROM flink:1.19.1
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash
 ENV NVM_DIR="$HOME/.nvm"
 RUN NVM_DIR="$HOME/.nvm" && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-RUN . $HOME/.nvm/nvm.sh && nvm install 20 && node --version
+RUN . $HOME/.nvm/nvm.sh && nvm install 22 && node --version
 RUN mkdir -p /opt/gateway
 ENV SIMPLE_FLINK_SQL_GATEWAY_ROOT=/opt/flink
 ENV NODE_ENV=production

--- a/NgsildAgent/Dockerfile
+++ b/NgsildAgent/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM node:21
+FROM node:22
 
 ADD . /app
 


### PR DESCRIPTION
## Summary

- **GitHub Actions**: `actions/checkout@v2` → `@v4` in `build.yaml`, `k8s-tests.yaml`, and `release.yaml` — v2 is deprecated and unsupported
- **NgsildAgent**: `FROM node:21` → `FROM node:22` — Node 21 reached EOL in April 2024; Node 22 is the current LTS
- **FlinkSqlGateway**: `FROM node:20` → `FROM node:22` in the lint stage; `nvm install 20` → `nvm install 22` in the production stage — Node 20 LTS reaches EOL in April 2026

These are drop-in replacements with no API changes. Improves reliability (no EOL security patches), reduces GitHub Actions deprecation warnings, and satisfies the maintainability/code-quality metrics in the security dashboard.

## Test plan
- [ ] Build workflow passes (docker compose build still works)
- [ ] K8s tests pass
- [ ] NgsildAgent Docker build succeeds with node:22
- [ ] FlinkSqlGateway Docker build succeeds with node:22 in both lint and runtime stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)