### PR TITLE
fix(py/not-named-self): add @staticmethod to class methods missing self

### DIFF
--- a/FlinkSqlServicesOperator/test/test_beamservicesoperator.py
+++ b/FlinkSqlServicesOperator/test/test_beamservicesoperator.py
@@ -97,10 +97,12 @@ class TestUpdates(aiounittest.AsyncTestCase):
         response = await target.updates(None, patchx, Logger(), body, body["spec"], body["status"])
         self.assertEqual(response, {'deployed': False, 'jobCreated': False})
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def delete_jar(body, jarfile):
         """mock delete jar"""
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def deploy(body, spec, patchx):
         """mock deploy"""
         return "deploy"
@@ -132,12 +134,14 @@ class TestUpdates(aiounittest.AsyncTestCase):
         response = await target.updates(None, patchx, Logger(), body, body["spec"], body["status"])
         self.assertEqual(response, {'deployed': True, 'jarId': 'deploy'})
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def check_readiness(body):
         """mock readiness of 1 slot"""
         return 1
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def create_job(body, spec, update_status):
         """mock create job successful"""
         return "job_id"
@@ -169,7 +173,8 @@ class TestUpdates(aiounittest.AsyncTestCase):
         response = await target.updates(None, patchx, Logger(), body, body["spec"], body["status"])
         self.assertEqual(response, {'jobCreated': True, 'jobId': 'job_id'})
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def check_readiness_0(body):
         """mock no ready task slots"""
         return 0
@@ -200,7 +205,8 @@ class TestUpdates(aiounittest.AsyncTestCase):
         response = await target.updates(None, patchx, Logger(), body, body["spec"], body["status"])
         self.assertEqual(response, None)
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def create_job_none(body, spec, update_status):
         """mock create job unsuccessful"""
         return None
@@ -232,7 +238,8 @@ class TestUpdates(aiounittest.AsyncTestCase):
         response = await target.updates(None, patchx, Logger(), body, body["spec"], body["status"])
         self.assertEqual(response, {'deployed': False, 'jobCreated': False})
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def requestsget(url, timeout=0):
         """mock get jobs"""
         result = Bunch()
@@ -266,7 +273,7 @@ class TestUpdates(aiounittest.AsyncTestCase):
         await target.updates(None, patchx, Logger(), body, body["spec"], body["status"])
         self.assertEqual(patchx["status"].get("state"), "RUNNING")
 
-    # pylint: disable=no-self-use, no-self-argument
+    @staticmethod
     def requestsget_fail(url, timeout=0):
         """mock get jobs fail"""
         result = Bunch()
@@ -300,7 +307,7 @@ class TestUpdates(aiounittest.AsyncTestCase):
         await target.updates(None, patchx, Logger(), body, body["spec"], body["status"])
         self.assertEqual(patchx["status"].get("state"), None)
 
-    # pylint: disable=no-self-argument
+    @staticmethod
     def requestsget_good(url, timeout=0):
         """mock get jobs"""
         result = Bunch()
@@ -312,11 +319,12 @@ class TestUpdates(aiounittest.AsyncTestCase):
             result.json = getjson_put
         return result
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def get_jobname_prefix(body, spec):
         """mock get jobname prefix"""
         return "nam"
-    # pylint: disable=no-self-argument
+    @staticmethod
     def cancel_job(job_id):
         """mock cancel job successful"""
 
@@ -407,7 +415,7 @@ class TestDelete(TestCase):
 
 class TestHelpers(TestCase):
     """Unit test class for helpers"""
-    # pylint: disable=no-self-argument
+    @staticmethod
     def requestget(url, timeout=0):
         """mock get content"""
         assert url == 'url'
@@ -415,7 +423,8 @@ class TestHelpers(TestCase):
         result.content = b'content'
         return result
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def download_file_via_ftp(url, username, password):
         """mock downloaded file with path"""
         return "jarfilepath"
@@ -441,7 +450,8 @@ class TestHelpers(TestCase):
         mock_ftp_constructor.assert_called_with('url', 'username', 'password')
         self.assertRegex(response, r"/tmp/[a-f0-9-]*\.jar")
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def requestpost(url, files, timeout=0):
         """mock successful post of job"""
         response = Bunch()
@@ -477,7 +487,8 @@ class TestHelpers(TestCase):
                 response = target.deploy(body, body["spec"], patchx)
         self.assertEqual(response, "filename")
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def util_format_template(string, tokens, encode):
         """mock format template"""
         return "format"
@@ -515,19 +526,20 @@ class TestHelpers(TestCase):
         }
         response = target.get_jobname_prefix(body, body["spec"])
         self.assertEqual(response, 'entryclass')
-    # pylint: disable=no-self-argument
+    @staticmethod
     # pylint: disable=E1136
     def get_tokens(users):
         """mock get_tokens"""
         THAT.assertDictEqual(users[0], {"user": "user", "password": "password"})
         return {"user1": "token1", "user2": "token2"}
-    # pylint: disable=no-self-argument
+    @staticmethod
     def build_args(args_dict, tokens):
         """mock build_args"""
         THAT.assertDictEqual(args_dict, {"runner": "runner"})
         THAT.assertDictEqual(tokens, {"user1": "token1", "user2": "token2"})
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def request_post_run(url, json, timeout=0):
         """mock post to create job successfully"""
         def json_run():
@@ -567,7 +579,7 @@ class TestHelpers(TestCase):
         response = target.create_job(body, body['spec'], 'jar_id')
         self.assertEqual(response, 'jobid')
 
-    # pylint: disable=no-self-use, no-self-argument
+    @staticmethod
     def request_get_overview(url, timeout=0):
         """mock get overview path of flink"""
         def json_get():

--- a/FlinkSqlServicesOperator/test/test_beamsqlstatementsetoperator.py
+++ b/FlinkSqlServicesOperator/test/test_beamsqlstatementsetoperator.py
@@ -85,12 +85,14 @@ class TestInit(TestCase):
 
 class TestMonitoring(TestCase):
     """Unit test class for monitoring"""
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def create_ddl_from_beamsqltables(beamsqltable, logger):
         """mock successful DDL creation"""
         return "DDL;"
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def submit_statementset_successful(fullname, statementset, logger):
         """mock successful statementset creation"""
         # Keeping normal assert statement as this does not seem to
@@ -102,12 +104,14 @@ class TestMonitoring(TestCase):
                                 'sqlstatementset': ['select;']}
         return "job_id"
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def submit_statementset_failed(fullname, statementset, logger):
         """mock submission failed"""
         raise target.DeploymentFailedException("Mock submission failed")
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def update_status_not_found(body, patchx, logger):
         """mock status not found"""
         patchx.status["state"] = "NOT_FOUND"
@@ -269,12 +273,14 @@ class TestMonitoring(TestCase):
         self.assertEqual(patchx.status["state"], "INITIALIZED")
         self.assertIsNone(patchx.status["job_id"])
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def create_sets(spec, body, namespace, name, logger):
         """mock create sets"""
         return "sets"
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument, too-many-arguments
+    @staticmethod
+    # pylint: disable=unused-argument, too-many-arguments
     def create_tables(beamsqltables, spec, body, namespace, name, logger):
         """mock creation of tables"""
         return "tables"
@@ -316,20 +322,24 @@ class TestMonitoring(TestCase):
 
 class TestDeletion(TestCase):
     """Unit test class for job deletion tests"""
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def update_status_nochange(body, patchx, logger):
         """mock update with no status change"""
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def update_status_change(body, patchx, logger):
         """mock job status change"""
         patchx.status["state"] = "CANCELED"
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def cancel_job(logger, job_id):
         """mock cancel job successful"""
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def cancel_job_error(logger, job_id):
         """mock cancel_job with error"""
         raise kopf.TemporaryError("Could not cancel job")
@@ -487,41 +497,48 @@ JOB_CANCELED = False
 class TestUpdate(TestCase):
     """unit test class to test updates"""
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument, global-statement
+    @staticmethod
+    # pylint: disable=unused-argument, global-statement
     def cancel_job(logger, job_id):
         """mock cancel_job"""
         global JOB_CANCELED
         JOB_CANCELED = True
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def get_job_status(logger, job_id):
         """mock get_job_status running"""
         return {
             "state": "RUNNING"
         }
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def get_job_status_not_running(logger, job_id):
         """mock get job_status unknown"""
         return {
             "state": "UNKNOWN"
         }
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def cancel_job_and_get_state(logger, body, patchx):
         """mock cancel_job_and_get state successful"""
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def cancel_job_and_get_state_fail(logger, body, patchx):
         """mock cancel_job with state fail"""
         raise requests.exceptions.RequestException("Error")
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def stop_job(logger, job_id, savepoint_dir):
         """mock stop_job"""
         return "savepoint_id"
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def get_savepoint_state_successful(logger, job_id, savepoint_id):
         """mock get savepoint_state return successful"""
         return {
@@ -529,7 +546,8 @@ class TestUpdate(TestCase):
             "location": "location"
         }
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def get_savepoint_state_in_progress(logger, job_id, savepoint_id):
         """mock get_savepoint_state is in progress"""
         return {
@@ -537,7 +555,8 @@ class TestUpdate(TestCase):
             "location": "location"
         }
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def get_savepoint_state_not_found(logger, job_id, savepoint_id):
         """mock savepoint_state_not_found"""
         return {
@@ -545,7 +564,8 @@ class TestUpdate(TestCase):
             "location": "location"
         }
 
-    # pylint: disable=no-self-use, unused-argument, no-self-argument
+    @staticmethod
+    # pylint: disable=unused-argument
     def add_message(logger, body, patchx, reason, mtype):
         """mock add_message"""
 
@@ -739,7 +759,7 @@ class TestUpdate(TestCase):
 
 class TestHelpers(TestCase):
     """unit test class for helpers"""
-    # pylint: disable=no-self-use, no-self-argument
+    @staticmethod
     def send_successful(test, json, timeout=0):
         """mock send job successful"""
         def jsonp():
@@ -751,7 +771,7 @@ class TestHelpers(TestCase):
         response.json = jsonp
         return response
 
-    # pylint: disable=no-self-use, no-self-argument
+    @staticmethod
     def send_unsuccessful(test, json, timeout=0):
         """mock send job unsuccessful"""
         def jsonp():
@@ -763,27 +783,27 @@ class TestHelpers(TestCase):
         response.json = jsonp
         return response
 
-    # pylint: disable=no-self-use, no-self-argument
+    @staticmethod
     def get_job_status(logger, jobid):
         """mock get job status"""
         return {
             "state": "ok"
         }
-    # pylint: disable=no-self-use, no-self-argument
+    @staticmethod
     def get_job_status_none(logger, jobid):
         """mock no job_status found"""
         return None
 
-    # pylint: disable=no-self-use, no-self-argument
+    @staticmethod
     def send_exception(test, json, timeout=0):
         """mock send_exception"""
         raise requests.RequestException("Error")
 
-    # pylint: disable=no-self-use, no-self-argument
+    @staticmethod
     def get_job_from_name(logger, jobname):
         """mock get_job_from_name"""
         return "jobid"
-    # pylint: disable=no-self-use, no-self-argument
+    @staticmethod
     def get_no_job_from_name(logger, jobname):
         """mock get_job_from_name"""
         return None

--- a/FlinkSqlServicesOperator/test/test_tables_and_views.py
+++ b/FlinkSqlServicesOperator/test/test_tables_and_views.py
@@ -55,7 +55,8 @@ class TestDdlCreation(TestCase):
     create_kafka_ddl_used = False
     create_upsert_kafka_ddl_used = False
 
-   # pylint: disable=global-statement, no-self-use, no-self-argument
+    @staticmethod
+    # pylint: disable=global-statement
     def create_kafka_ddl(beamsqltable, logger):
         """
         mock for create_kafka_ddl
@@ -82,7 +83,8 @@ class TestDdlCreation(TestCase):
         target.create_ddl_from_beamsqltables(beamsqltable, Logger())
         self.assertEqual(TestDdlCreation.create_kafka_ddl_used, True)
 
-   # pylint: disable=global-statement, no-self-use, no-self-argument
+    @staticmethod
+    # pylint: disable=global-statement
     def create_upsert_kafka_ddl(beamsqltable, logger):
         """
         mock for create_upsert_kafka_ddl
@@ -132,7 +134,7 @@ class TestcreateKafkaDdl(TestCase):
     """
     tests for create_kafka_ddl
     """
-       # pylint: disable=global-statement, no-self-argument
+    # pylint: disable=global-statement
     def test_create_ddl_from_beamsqltable(self):
         """
         test successful kafka_ddl creation

--- a/semantic-model/opcua/lib/nodesetparser.py
+++ b/semantic-model/opcua/lib/nodesetparser.py
@@ -766,6 +766,7 @@ Did you forget to import it?")
                     except:
                         print(f"Warning: Cannot read access_level value {access_level_ex} in node {classiri}")
 
+    @staticmethod
     def is_objecttype_nodeset_node(node):
         return node.tag.endswith('UAObjectType')
 


### PR DESCRIPTION
## Summary

Addresses CodeQL quality rule `py/not-named-self` visible on the repository's `/security/quality` page.

- **`semantic-model/opcua/lib/nodesetparser.py`**: `is_objecttype_nodeset_node` was a class method with no `self` or `cls` parameter, called externally as `NodesetParser.is_objecttype_nodeset_node(node)` — add `@staticmethod`
- **`FlinkSqlServicesOperator/test/`**: 49 mock methods defined at class level intentionally mirror module-level function signatures (used via `@patch`); add `@staticmethod` and remove now-redundant `# pylint: disable=no-self-argument` comments. Callable in Python 3.12 (staticmethod got `__call__` in Python 3.10+)

## Test plan

- [ ] 76 FlinkSqlServicesOperator tests pass (`pytest test/ --ignore=test/test_flinkpythonudfoperator.py`)
- [ ] 217 opcua tests pass (`pytest tests/`)
- [ ] Build CI passes
- [ ] K8s tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)