### PR TITLE
fix(py-quality): replace bare except: with except Exception: and exit() with sys.exit()

### DIFF
--- a/semantic-model/opcua/extractType.py
+++ b/semantic-model/opcua/extractType.py
@@ -329,7 +329,7 @@ a loop.")
         try:
             typenode = next(g.subjects(basens['definesType'], typeiri))
             o = typenode
-        except:
+        except Exception:
             pass
         components_found = scan_type(o, classtype)
         if maximal_shacl:
@@ -357,7 +357,7 @@ a loop.")
         has_components = True
         try:
             isAbstract = utils.rdfStringToPythonBool(next(g.objects(classtype, basens['isAbstract'])))
-        except:
+        except Exception:
             isAbstract = False
         if isAbstract:
             return False
@@ -548,7 +548,7 @@ def scan_entity_recursive(node, id, instance, node_id, o, type=None, is_property
     try:
         expanded_type = utils.expand_term(context_graph, instance['type'])
         is_placeholder = shaclg.is_placeholder(expanded_type, attributename)
-    except:
+    except Exception:
         is_placeholder = False
     if is_placeholder:
         if original_attributename is None:
@@ -641,7 +641,7 @@ will flag this.")
                 f'{full_attribute_name}, {str(node)}'
         try:
             is_updating = bool(next(g.objects(o, basens['isUpdating'])))
-        except:
+        except Exception:
             is_updating = False
         if (is_updating or not minimal_shacl) and not is_property:
             bindingsg.create_binding(g, URIRef(node_id), o, attributename)
@@ -708,12 +708,12 @@ if __name__ == '__main__':
     if rootinstancetype is not None and type_all:
         print("Error: root-instance and type-all are mutually exclusive. Please either provide a root-instance or use"
               "type-all to extract all types.")
-        exit(1)
+        sys.exit(1)
 
     if extract_instance_declarations and not type_all:
         print("Error: extract-instance-declarations only works in combination with type-all. Please use type-all to"
               " extract all types and then extract instance declarations.")
-        exit(1)
+        sys.exit(1)
     # create the context_graph
     # Context graph is resolving the context_url and provides just the
     # namespace manager
@@ -725,7 +725,7 @@ if __name__ == '__main__':
         warnings.filterwarnings("ignore", message=message)
     if minimal_shacl and maximal_shacl:
         print("--minimalshacl and --maximalshacl are mutual exclusive")
-        exit(1)
+        sys.exit(1)
     entity_namespace = Namespace(f'{namespace_prefix}entity/') if entity_namespace is None else entity_namespace
     shacl_namespace = Namespace(f'{namespace_prefix}shacl/')
     binding_namespace = Namespace(f'{namespace_prefix}bindings/')
@@ -794,7 +794,7 @@ if __name__ == '__main__':
         if machinery_nodes_and_types is None:
             logger.error("Error: root-instance could not be determined. Neither type given explicitly (via -t) nor a \
 Machinery Folder was found in instance ontology.")
-            exit(1)
+            sys.exit(1)
         rootentity = machinery_nodes_and_types[0][0]
         rootinstancetype = machinery_nodes_and_types[0][1]
         if maximal_shacl:
@@ -807,9 +807,9 @@ Machinery Folder was found in instance ontology.")
     if rootinstancetype is not None:
         try:
             root = next(g.subjects(basens['definesType'], URIRef(rootinstancetype)))
-        except:
+        except Exception:
             print(f"Error: root-instance with type {rootinstancetype} not found. Please review the type parameter.")
-            exit(1)
+            sys.exit(1)
         if instancetypes is None:
             instancetypes = [URIRef(rootinstancetype)]
     for instancetype in instancetypes:
@@ -821,7 +821,7 @@ Machinery Folder was found in instance ontology.")
         minshaclg.serialize(destination=f'min_{shaclname}')
     if shacl_only:
         # If only SHACL shapes are to be created, skip the entity scanning
-        exit(0)
+        sys.exit(0)
     # Then scan the entity with the real values
     rootentities = None
     if extract_instance_declarations:

--- a/semantic-model/opcua/lib/entity.py
+++ b/semantic-model/opcua/lib/entity.py
@@ -209,7 +209,7 @@ class Entity:
             if foundclass is not None:
                 if int(rank) > 0:
                     return [foundclass] * int(array_length)
-        except:
+        except Exception:
             pass
         return foundclass
 

--- a/semantic-model/opcua/lib/jsonld.py
+++ b/semantic-model/opcua/lib/jsonld.py
@@ -339,7 +339,7 @@ class JsonLd:
             # which do not have a datatype
             try:
                 value = json.loads(value)
-            except:
+            except Exception:
                 pass
             if isinstance(value, Literal):
                 value = value.toPython()
@@ -373,10 +373,10 @@ Is there a data mismatch?")
                 try:
                     if datatype == RDF.JSON:
                         json_list = [json.loads(item) for item in json_list]
-                except:
+                except Exception:
                     pass
                 return json_list
-            except:
+            except Exception:
                 print("Warning: BNode which is not an rdf:List cannot be converted into a value")
                 return None
         elif value == RDF.nil:
@@ -386,7 +386,7 @@ Is there a data mismatch?")
         if datatype == RDF.JSON:
             try:
                 value = json.loads(value)
-            except:
+            except Exception:
                 pass
             return value
         if datatype == XSD.dateTime:

--- a/semantic-model/opcua/lib/nodesetparser.py
+++ b/semantic-model/opcua/lib/nodesetparser.py
@@ -21,6 +21,7 @@ import urllib
 import lib.utils as utils
 from lib.utils import RdfUtils, nodeId_to_iri
 import json
+import sys
 
 
 attribute_prefix = utils.ATTRIBUTE_PREFIX
@@ -153,7 +154,7 @@ class NodesetParser:
         try:
             with urllib.request.urlopen(opcua_nodeset) as response:
                 tree = ET.parse(response)
-        except:
+        except Exception:
             tree = ET.parse(opcua_nodeset)
         # calling the root element
         self.root = tree.getroot()
@@ -162,12 +163,12 @@ class NodesetParser:
             models = self.root.find('opcua:Models', self.xml_ns)
             if models is None:
                 print("Error: Namespace cannot be retrieved, please set it explicitly.")
-                exit(1)
+                sys.exit(1)
             model_count = len(models.findall('opcua:Model', self.xml_ns))
             if model_count != 1:
                 print("Error: Target Namespace cannot be retrieved, there is more than one <Model> definition. \
 Please set it explictly.")
-                exit(1)
+                sys.exit(1)
             model = models.find('opcua:Model', self.xml_ns)
             self.ontology_name = URIRef(model.get('ModelUri'))
             self.ontology_name = utils.normalize_namespaceuri(self.ontology_name)
@@ -189,7 +190,7 @@ Please set it explictly.")
             aliases_node = self.root.find('opcua:Aliases', self.xml_ns)
             alias_nodes = aliases_node.findall('opcua:Alias', self.xml_ns)
             self.scan_aliases(alias_nodes)
-        except:
+        except Exception:
             pass
         all_nodeclasses = [
             ('opcua:UADataType', 'DataTypeNodeClass'),
@@ -303,9 +304,9 @@ Please set it explictly.")
                 continue
             try:
                 self.nodeIds[ns][str(nodeId)] = nodeIri
-            except:
+            except Exception:
                 print(f"Warning: Did not find namespace {uri}. Did you import the respective companion specification?")
-                exit(1)
+                sys.exit(1)
         self.urimap = urimap
 
     def get_all_types(self):
@@ -376,10 +377,10 @@ Please set it explictly.")
         namespace_uri = self.opcua_ns[int(index)]
         try:
             prefix = self.known_opcua_ns[namespace_uri]
-        except:
+        except Exception:
             print(f"Warning: Namespace {namespace_uri} not found in imported companion specifications. \
 Did you forget to import it?")
-            exit(1)
+            sys.exit(1)
         namespace = self.rdf_ns[prefix]
         return namespace
 
@@ -394,7 +395,7 @@ Did you forget to import it?")
                 nsid, id = self.parse_nodeid(ref.text)
                 try:
                     subtype = self.nodeIds[nsid][id]
-                except:
+                except Exception:
                     print(f"Warning: Could not find type ns={nsid};i={id}")
                     subtype = None
         return subtype
@@ -406,7 +407,7 @@ Did you forget to import it?")
         index, id = self.parse_nodeid(datatype)
         try:
             typeiri = self.nodeIds[index][id]
-        except:
+        except Exception:
             print(f'Warning: Cannot find nodeId ns={index};i={id}')
             return
         if datatype is not None:
@@ -468,7 +469,7 @@ Did you forget to import it?")
         ns_index = 0
         try:
             ns_part, i_part = nodeid.split(';', 1)
-        except:
+        except Exception:
             ns_part = None
             i_part = nodeid
         if ns_part is not None:
@@ -645,7 +646,7 @@ Did you forget to import it?")
             try:
                 found_component = [ele[2] for ele in self.known_references if (int(ele[0]) == int(reftype_id) and
                                    str(ele[1]) == str(reftype_ns))][0]
-            except:
+            except Exception:
                 found_component = None
             if found_component is not None:
                 componentId = self.resolve_alias(reference.text)
@@ -721,7 +722,7 @@ Did you forget to import it?")
                         content_class = utils.get_contentclass(self.rdf_ns['opcua']['EventNotifierType'],
                                                                bit, self.ig, self.rdf_ns['base'])
                         self.g.add((classiri, self.rdf_ns['base']['hasEventNotifier'], content_class))
-                    except:
+                    except Exception:
                         print(f"Warning: Cannot read all defined event in event_notifier value \
 {event_notifier} in node {classiri}")
 
@@ -737,7 +738,7 @@ Did you forget to import it?")
                             content_class = utils.get_contentclass(self.rdf_ns['opcua']['AccessLevelType'],
                                                                    int(bit), self.g, self.rdf_ns['base'])
                         self.g.add((classiri, self.rdf_ns['base']['hasAccessLevel'], content_class))
-                    except:
+                    except Exception:
                         print(f"Warning: Cannot read access_level value {access_level} in node {classiri}")
         user_access_level = node.get('UserAccessLevel')
         if user_access_level is not None:
@@ -750,7 +751,7 @@ Did you forget to import it?")
                             content_class = utils.get_contentclass(self.rdf_ns['opcua']['AccessLevelType'],
                                                                    int(bit), self.g, self.rdf_ns['base'])
                         self.g.add((classiri, self.rdf_ns['base']['hasUserAccessLevel'], content_class))
-                    except:
+                    except Exception:
                         print(f"Warning: Cannot read access_level value {user_access_level} in node {classiri}")
         access_level_ex = node.get('AccessLevelEx')
         if access_level_ex is not None:
@@ -763,7 +764,7 @@ Did you forget to import it?")
                             content_class = utils.get_contentclass(self.rdf_ns['opcua']['AccessLevelExType'],
                                                                    int(bit), self.g, self.rdf_ns['base'])
                         self.g.add((classiri, self.rdf_ns['base']['hasAccessLevelEx'], content_class))
-                    except:
+                    except Exception:
                         print(f"Warning: Cannot read access_level value {access_level_ex} in node {classiri}")
 
     def is_objecttype_nodeset_node(node):
@@ -806,7 +807,7 @@ Did you forget to import it?")
         if not mandatory_typedef_found and ref_id != baseObjectTypeId and ref_id != referencesId and \
                 ref_id != baseDataTypeId and ref_id != baseVariableType:
             print(f"Error: Objecttype {ref_classiri} has no supertype and is not the base object type.")
-            exit(1)
+            sys.exit(1)
 
     def add_type_name_only(self, node):
         _, browsename = self.getBrowsename(node)
@@ -835,7 +836,7 @@ Did you forget to import it?")
         try:
             references_node = node.find('opcua:References', self.xml_ns)
             references = references_node.findall('opcua:Reference', self.xml_ns)
-        except:
+        except Exception:
             references = []
         if not node.tag.endswith("UAReferenceType"):
             self.g.add((ref_namespace[browsename], RDF.type, OWL.Class))

--- a/semantic-model/opcua/lib/shacl.py
+++ b/semantic-model/opcua/lib/shacl.py
@@ -284,7 +284,7 @@ class Shacl:
         datatype_name = ""
         try:
             _, datatype_name = split_uri(datatype)
-        except:
+        except Exception:
             pass
         array_dim_str = ""
         array_dim = utils.collection_to_list(array_dimensions, self.data_graph)
@@ -556,7 +556,7 @@ or placeholders or both. Will try to guess the right value, but this can go wron
                 if similarity[target_index] < 0.5:
                     confidence = "with low confidence"
                 warn_message += f" Guessed to use {path} for {name} and class {target_class} {confidence}."
-        except:
+        except Exception:
             pass
         if warn_message is not None:
             print_warning('ambiguous path match', warn_message)
@@ -605,7 +605,7 @@ or placeholders or both. Will try to guess the right value, but this can go wron
                 if str(path) == str(propertypath):
                     result = property
                     break
-        except:
+        except Exception:
             pass
         return result
 
@@ -615,7 +615,7 @@ or placeholders or both. Will try to guess the right value, but this can go wron
             return False
         try:
             return bool(next(self.shaclg.objects(property, self.basens['isPlaceHolder'])))
-        except:
+        except Exception:
             return False
 
     def _get_shclass_from_property(self, property):
@@ -625,7 +625,7 @@ or placeholders or both. Will try to guess the right value, but this can go wron
         try:
             subproperty = next(self.shaclg.objects(property, SH.property))
             result = next(self.shaclg.objects(subproperty, SH['class']))
-        except:
+        except Exception:
             pass
         return result
 
@@ -634,7 +634,7 @@ or placeholders or both. Will try to guess the right value, but this can go wron
             subproperty = next(self.shaclg.objects(property, SH.property))
             self.shaclg.remove((subproperty, SH['class'], None))
             self.shaclg.add((subproperty, SH['class'], shclass))
-        except:
+        except Exception:
             pass
 
     def copy_property_from_shacl(self, source_graph, targetclass, propertypath):
@@ -664,10 +664,10 @@ or placeholders or both. Will try to guess the right value, but this can go wron
         try:
             shape = next(self.shaclg.subjects(SH.targetClass, targetclass))
             return shape
-        except:
+        except Exception:
             try:
                 shape = next(source_graph.get_graph().subjects(SH.targetClass, targetclass))
-            except:
+            except Exception:
                 return None
             for s, p, o in source_graph.get_graph().triples((shape, None, None)):
                 if not isinstance(o, BNode):

--- a/semantic-model/opcua/lib/utils.py
+++ b/semantic-model/opcua/lib/utils.py
@@ -774,7 +774,7 @@ class RdfUtils:
                 elif result[1] is not None:
                     type = result[1]
             return (nodeclass, type)
-        except:
+        except Exception:
             print(f"Warning: Could not find nodeclass of class node {node}. This should not happen")
             return None, None
 
@@ -858,7 +858,7 @@ class RdfUtils:
             elif int(modelling_rule) == modelling_nodeid_mandatory_placeholder:
                 is_optional = False
                 use_generic_placeholder = True
-        except:
+        except Exception:
             pass
         if shacl_rule is not None:
             shacl_rule['optional'] = is_optional

--- a/semantic-model/opcua/nodeset-dump.py
+++ b/semantic-model/opcua/nodeset-dump.py
@@ -18,7 +18,7 @@ try:
     ua = asyncua.ua
 except ImportError:
     print("The 'asyncua' library is not installed. Please install it separately to use this tool.")
-    exit(1)
+    sys.exit(1)
 
 sys.setrecursionlimit(1500)  # Increase the recursion limit to avoid maximum recursion depth error
 
@@ -125,7 +125,7 @@ async def main():
 
         if args.namespaces is None:
             print(f"Please provide a namespace, e.g. one of {namespace_uris}.")
-            exit(1)
+            sys.exit(1)
         for index, uri in enumerate(namespace_uris):
             # Only resolve requested namespaces and add "dummy" nodes for the other NSs
             nsidx = await client.get_namespace_index(uri)
@@ -158,7 +158,7 @@ async def main():
                 # Check if the node is a Variable type
                 if args.values and node_class == ua.NodeClass.Variable:
                     await node.read_value()
-            except:
+            except Exception:
                 exported_nodes.remove(node)
                 print(f"Removing node {node.nodeid} since it cannot export values.")
                 # remove the node since this will create exceptions later

--- a/semantic-model/opcua/validate.py
+++ b/semantic-model/opcua/validate.py
@@ -68,7 +68,7 @@ data-file name (.jsonld, .ttl).")
             args.data_format = 'ttl'
         else:
             print(f"Error: No default data-format given and cannot infer it from filename {args.data}")
-            exit(1)
+            sys.exit(1)
     data_graph.parse(args.data, format=args.data_format)
     # Load SHACL shapes (Shapes Graph)
     shapes_graph = Graph(store='Oxigraph')
@@ -103,7 +103,7 @@ data-file name (.jsonld, .ttl).")
 
     else:
         print("No valid mode selected.")
-        sys.exit(1)
+        sys.sys.exit(1)
 
     if args.merge_entity is True:
         os.environ["PYSHACL_USE_FULL_MIXIN"] = "true"
@@ -153,7 +153,7 @@ data-file name (.jsonld, .ttl).")
             else:
                 print(f'Focus Node (Entity which triggered the validation error): {entity_id}. More details \
 cannot be determined. Check Source Shape for detailed path.')
-    sys.exit(1)
+    sys.sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/semantic-model/shacl2flink/create_ngsild_models.py
+++ b/semantic-model/shacl2flink/create_ngsild_models.py
@@ -142,7 +142,7 @@ def get_entity_id_and_parentId(node, name, target_datasetId, g):
             uptriples = next(g.triples((None, None, entityId)))
             entityId = uptriples[0]
             id = f'\\{uptriples[1]}\\{datasetId}{id}'
-        except:
+        except Exception:
             entityId = None
             break
     if id != '':

--- a/semantic-model/shacl2flink/create_sql_checks_from_shacl.py
+++ b/semantic-model/shacl2flink/create_sql_checks_from_shacl.py
@@ -57,10 +57,10 @@ def main(shaclfile, knowledgefile, context, maps_namespace, output_folder='outpu
             with open(commonyamlfile, "r") as file:
                 yaml_dict = commonyaml.load(file)
                 context = yaml_dict['ontology']['baseUri'] + 'context.jsonld'
-        except:
+        except Exception:
             print("Could neither derive context file implicitly, nor by commandline. Check if common.yaml \
 is accessible.")
-            exit(1)
+            sys.exit(1)
     try:
         context_graph = rdflib.Graph()
         context_graph.parse(context, format="json-ld")
@@ -69,10 +69,10 @@ is accessible.")
     except Exception as e:
         print(f"Could not derive prefixes from context file. Check if contextfile {context} is valid and \
 accessible: {e}")
-        exit(1)
+        sys.exit(1)
     if 'base' not in prefixes.keys():
         print(f"No prefix 'base:' is found in your given context {context}. This is needed!")
-        exit(1)
+        sys.exit(1)
     utils.create_output_folder(output_folder)
 
     yaml = ruamel.yaml.YAML()

--- a/semantic-model/shacl2flink/lib/sparql_to_sql.py
+++ b/semantic-model/shacl2flink/lib/sparql_to_sql.py
@@ -124,7 +124,7 @@ def translate_sparql(shaclfile, knowledgefile, sparql_query, target_class, lg):
     parsed_query = None
     try:
         parsed_query = translateQuery(parseQuery(sparql_query))
-    except:
+    except Exception:
         raise utils.SparqlValidationFailed('Failed to parse: ' + sparql_query)
     ctx = translate_query(parsed_query, target_class, sparql_query)
     return ctx['target_sql'], ctx['sql_tables']
@@ -281,7 +281,7 @@ def translate_aggregate_join(ctx, elem):
     vars = utils.get_aggregate_vars(ctx)
     try:
         elem['target_sql'] = bgp_translation_utils.replace_attributes_table_expression(elem.p['target_sql'], vars)
-    except:
+    except Exception:
         raise utils.SparqlValidationFailed('Group by aggregation defined but no aggregated variables found.')
     elem['where'] = elem.p['where']
 
@@ -535,7 +535,7 @@ def wrap_sql_projection(ctx, node):
         try:
             column = bounds[utils.create_varname(var)]
             expression += f'{column} AS `{utils.create_varname(var)}` '
-        except:
+        except Exception:
             # variable could not be bound, bind it with NULL
             expression += f'NULL AS `{utils.create_varname(var)}`'
 

--- a/semantic-model/shacl2flink/lib/utils.py
+++ b/semantic-model/shacl2flink/lib/utils.py
@@ -98,7 +98,7 @@ def get_common_data():
         with open(os.path.join(os.path.dirname(__file__), commonyamlfile), "r") as file:
             yaml_dict = commonyaml.load(file)
         return yaml_dict
-    except:
+    except Exception:
         raise Exception("Could not read common.yaml file.")
 
 


### PR DESCRIPTION
## Summary

Addresses two CodeQL quality rules from the GitHub `/security/quality` page:

- **`py/catch-base-exception`**: 40 bare `except:` clauses replaced with `except Exception:` across 11 files. Bare `except:` also catches `SystemExit` and `KeyboardInterrupt`, which is almost never intended.
- **`py/use-of-exit-or-quit`**: 21 `exit()` / `quit()` calls replaced with `sys.exit()` across 5 files. `exit()` and `quit()` are interactive built-ins not suitable for scripts; `sys.exit()` is the correct way to terminate a script.

`import sys` was added to 3 files that didn't already have it.

All 217 opcua tests pass. All 12 modified files pass Python syntax check (`python3 -m py_compile`).

## Files changed

- `semantic-model/opcua/extractType.py`
- `semantic-model/opcua/lib/entity.py`
- `semantic-model/opcua/lib/jsonld.py`
- `semantic-model/opcua/lib/nodesetparser.py`
- `semantic-model/opcua/lib/shacl.py`
- `semantic-model/opcua/lib/utils.py`
- `semantic-model/opcua/nodeset-dump.py`
- `semantic-model/opcua/validate.py`
- `semantic-model/shacl2flink/create_ngsild_models.py`
- `semantic-model/shacl2flink/create_sql_checks_from_shacl.py`
- `semantic-model/shacl2flink/lib/sparql_to_sql.py`
- `semantic-model/shacl2flink/lib/utils.py`

## Test plan

- [x] `python3 -m py_compile` on all 12 files — OK
- [x] `pytest tests/` in `semantic-model/opcua` — 217 passed
- [ ] Build workflow CI
- [ ] K8s tests workflow CI