### PR TITLE
fix(KafkaBridge): remove token error message from log to prevent clear-text token exposure

### DIFF
--- a/KafkaBridge/lib/authService/authenticate.js
+++ b/KafkaBridge/lib/authService/authenticate.js
@@ -141,7 +141,7 @@ class Authenticate {
       .createGrant({ access_token: token })
       .then(grant => grant.access_token.content)
       .catch(err => {
-        this.logger.warn(`Token decoding error for token ${maskedToken}: ${err.message || err}`);
+        this.logger.warn(`Token decoding error for token ${maskedToken}`);
         return null;
       });
   }

--- a/KafkaBridge/lib/authService/authenticate.js
+++ b/KafkaBridge/lib/authService/authenticate.js
@@ -141,7 +141,7 @@ class Authenticate {
       .createGrant({ access_token: token })
       .then(grant => grant.access_token.content)
       .catch(err => {
-        this.logger.warn(`Token decoding error for token ${maskedToken}`);
+        this.logger.warn(`Token decoding error for token ${maskedToken}: ${err.name || 'Error'}`);
         return null;
       });
   }


### PR DESCRIPTION
## Summary

Fixes CodeQL alert **`js/clear-text-logging`** in `KafkaBridge/lib/authService/authenticate.js:144`.

- Keycloak's `grantManager.createGrant()` may include the raw JWT in the error `message` when token validation fails
- Logging `err.message || err` in the catch block risked leaking the full token into application logs
- Fix: drop the error message from the log; the masked token prefix (`${maskedToken}`) provides sufficient context for debugging

## Test plan

- [ ] Build workflow CI
- [ ] K8s tests workflow CI

---

**Remaining open issue:** `brace-expansion` HIGH (GHSA-mh99-v99m-4gvg) in nested `minimatch@3.x` and `minimatch@5.x` dependency chains cannot be fixed without breaking those packages (attempted and reverted in baf8691). This is an unfixable transitive dependency issue.