### PR TITLE
feat(keycloak): add ifric-company-id and ifric-factory-id claims to scorpio client

### DIFF
--- a/helm/airgap-deployment/prepare-airgap.bash
+++ b/helm/airgap-deployment/prepare-airgap.bash
@@ -54,6 +54,7 @@ if [ "${REGISTRY}" = "docker.io" ]; then
       docker.io/ibn40/keycloak:${DOCKER_TAG}
       docker.io/ibn40/flink-sql-gateway:${DOCKER_TAG}
       docker.io/ibn40/debezium-postgresql-connector:${DOCKER_TAG}
+      docker.io/curlimages/curl:8.11.1
  )
 else
   IMAGES=(
@@ -85,6 +86,7 @@ else
       docker.io/rancher/klipper-lb:v0.4.9
       docker.io/rancher/mirrored-library-traefik:2.11.18
       docker.io/rancher/mirrored-library-busybox:1.36.1
+      docker.io/curlimages/curl:8.11.1
   )
 fi
 for image in ${IMAGES[@]}; do 

--- a/helm/charts/keycloak/templates/keycloak-realm.yaml
+++ b/helm/charts/keycloak/templates/keycloak-realm.yaml
@@ -587,6 +587,32 @@ spec:
             included.client.audience: {{ .Values.keycloak.oisp.mqttBroker.client }}
             access.token.claim: "true"
             id.token.claim: "false"
+        {{- if .Values.keycloak.ifric.companyId }}
+        - name: ifric_company_id
+          protocol: openid-connect
+          protocolMapper: oidc-hardcoded-claim-mapper
+          config:
+            claim.value: {{ .Values.keycloak.ifric.companyId | quote }}
+            userinfo.token.claim: "true"
+            id.token.claim: "true"
+            access.token.claim: "true"
+            claim.name: ifric_company_id
+            jsonType.label: String
+            access.tokenResponse.claim: "false"
+        {{- end }}
+        {{- if .Values.keycloak.ifric.factoryId }}
+        - name: ifric_factory_id
+          protocol: openid-connect
+          protocolMapper: oidc-hardcoded-claim-mapper
+          config:
+            claim.value: {{ .Values.keycloak.ifric.factoryId | quote }}
+            userinfo.token.claim: "true"
+            id.token.claim: "true"
+            access.token.claim: "true"
+            claim.name: ifric_factory_id
+            jsonType.label: String
+            access.tokenResponse.claim: "false"
+        {{- end }}
       - id: 2057e003-9e81-44fb-929d-4511ce2c7e33
         clientId: {{ .Values.keycloak.ngsildUpdates.client }}
         publicClient: False

--- a/helm/charts/keycloak/templates/keycloak-scorpio-mappers-job.yaml
+++ b/helm/charts/keycloak/templates/keycloak-scorpio-mappers-job.yaml
@@ -1,0 +1,112 @@
+{{- if or .Values.keycloak.ifric.companyId .Values.keycloak.ifric.factoryId }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: keycloak-scorpio-mappers
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: update-mappers
+        image: {{ .Values.externalRegistry }}/curlimages/curl:8.11.1
+        command: ["/bin/sh", "-c"]
+        args:
+        - |
+          set -e
+
+          KEYCLOAK_URL="http://{{ .Values.keycloak.internalAuthService.name }}:{{ .Values.keycloak.internalAuthService.port }}{{ .Values.keycloak.internalAuthService.path }}"
+          REALM="{{ .Values.keycloak.scorpio.realm }}"
+          CLIENT_ID="{{ .Values.keycloak.scorpio.client }}"
+
+          # Wait for Keycloak to be ready
+          until curl -sf "${KEYCLOAK_URL}/realms/master" > /dev/null 2>&1; do
+            echo "Waiting for Keycloak at ${KEYCLOAK_URL} ..."
+            sleep 10
+          done
+          echo "Keycloak is ready"
+
+          # Obtain admin access token from master realm
+          TOKEN_RESPONSE=$(curl -sf -X POST \
+            "${KEYCLOAK_URL}/realms/master/protocol/openid-connect/token" \
+            --data-urlencode "grant_type=password" \
+            --data-urlencode "client_id=admin-cli" \
+            --data-urlencode "username=${ADMIN_USER}" \
+            --data-urlencode "password=${ADMIN_PASSWORD}")
+
+          TOKEN=$(echo "$TOKEN_RESPONSE" | grep -oE '"access_token":"[^"]*"' | cut -d'"' -f4)
+          [ -z "$TOKEN" ] && echo "ERROR: Failed to get admin token" && exit 1
+
+          # Look up the scorpio client UUID
+          CLIENTS=$(curl -sf \
+            -H "Authorization: Bearer ${TOKEN}" \
+            "${KEYCLOAK_URL}/admin/realms/${REALM}/clients?clientId=${CLIENT_ID}")
+
+          CLIENT_UUID=$(echo "$CLIENTS" | grep -oE '"id":"[^"]*"' | head -1 | cut -d'"' -f4)
+          [ -z "$CLIENT_UUID" ] && echo "ERROR: Client '${CLIENT_ID}' not found in realm '${REALM}'" && exit 1
+          echo "Client ${CLIENT_ID}: UUID=${CLIENT_UUID}"
+
+          # Fetch all existing protocol mappers for the client
+          MAPPERS=$(curl -sf \
+            -H "Authorization: Bearer ${TOKEN}" \
+            "${KEYCLOAK_URL}/admin/realms/${REALM}/clients/${CLIENT_UUID}/protocol-mappers/models")
+
+          # Upsert a hardcoded-claim mapper.
+          # Keycloak always serialises "id" immediately before "name" in each mapper object,
+          # which lets us correlate the two fields with a single grep pattern.
+          upsert_mapper() {
+            local name="$1"
+            local value="$2"
+
+            local existing_id
+            existing_id=$(echo "$MAPPERS" | \
+              grep -oE '"id":"[^"]*","name":"'"${name}"'"' | \
+              grep -oE '"id":"[^"]*"' | cut -d'"' -f4)
+
+            local payload
+            if [ -n "$existing_id" ]; then
+              payload="{\"id\":\"${existing_id}\",\"name\":\"${name}\",\"protocol\":\"openid-connect\",\"protocolMapper\":\"oidc-hardcoded-claim-mapper\",\"config\":{\"claim.value\":\"${value}\",\"userinfo.token.claim\":\"true\",\"id.token.claim\":\"true\",\"access.token.claim\":\"true\",\"claim.name\":\"${name}\",\"jsonType.label\":\"String\",\"access.tokenResponse.claim\":\"false\"}}"
+              echo "Updating mapper '${name}' (${existing_id})"
+              curl -sf -X PUT \
+                -H "Authorization: Bearer ${TOKEN}" \
+                -H "Content-Type: application/json" \
+                "${KEYCLOAK_URL}/admin/realms/${REALM}/clients/${CLIENT_UUID}/protocol-mappers/models/${existing_id}" \
+                -d "${payload}"
+            else
+              payload="{\"name\":\"${name}\",\"protocol\":\"openid-connect\",\"protocolMapper\":\"oidc-hardcoded-claim-mapper\",\"config\":{\"claim.value\":\"${value}\",\"userinfo.token.claim\":\"true\",\"id.token.claim\":\"true\",\"access.token.claim\":\"true\",\"claim.name\":\"${name}\",\"jsonType.label\":\"String\",\"access.tokenResponse.claim\":\"false\"}}"
+              echo "Creating mapper '${name}'"
+              curl -sf -X POST \
+                -H "Authorization: Bearer ${TOKEN}" \
+                -H "Content-Type: application/json" \
+                "${KEYCLOAK_URL}/admin/realms/${REALM}/clients/${CLIENT_UUID}/protocol-mappers/models" \
+                -d "${payload}"
+            fi
+            echo "Done: ${name}=${value}"
+          }
+
+          [ -n "$IFRIC_COMPANY_ID" ] && upsert_mapper "ifric_company_id" "$IFRIC_COMPANY_ID"
+          [ -n "$IFRIC_FACTORY_ID" ] && upsert_mapper "ifric_factory_id" "$IFRIC_FACTORY_ID"
+
+          echo "Protocol mappers updated successfully"
+        env:
+        - name: ADMIN_USER
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-initial-admin
+              key: username
+        - name: ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: keycloak-initial-admin
+              key: password
+        - name: IFRIC_COMPANY_ID
+          value: {{ .Values.keycloak.ifric.companyId | quote }}
+        - name: IFRIC_FACTORY_ID
+          value: {{ .Values.keycloak.ifric.factoryId | quote }}
+{{- end }}

--- a/helm/environment/default.yaml
+++ b/helm/environment/default.yaml
@@ -5,10 +5,13 @@ alerta:
   externalHostname: alerta.local
 keycloak:
   adminName: admin
-  externalAuthService:   # put here the *external* keycloak name, i.e. through ingress 
+  externalAuthService:   # put here the *external* keycloak name, i.e. through ingress
     protocol: "http:"
     domainname: keycloak.local
     path: /auth/ # keycloak internal, do not change
+  ifric:
+    companyId: "urn:ifric:ifx-eur-com-own-42ced491-b35d-41f7-9949-fcbb5fa4dcd9"
+    factoryId: "urn:ifric:ifx-eur-loc-fac-bd063b72-8748-461f-888d-3ea75058f205"
 
 db:
   pvSize: 1Gi

--- a/helm/environment/oep.yaml
+++ b/helm/environment/oep.yaml
@@ -5,11 +5,14 @@ alerta:
   externalHostname: oep-testing.industry-fusion.com
 keycloak:
   adminName: admin
-  externalAuthService:   # put here the *external* keycloak name, i.e. through ingress 
+  externalAuthService:   # put here the *external* keycloak name, i.e. through ingress
     protocol: "http:"   # use https in production, use http if use self signed certificate or ignoring certificate validation
     domainname: oep-testing.industry-fusion.com
     path: /auth/ # keycloak internal do not change
     # pathPrefix: /keycloak-iff/ # for ingress, must end with /
+  ifric:
+    companyId: ""
+    factoryId: ""
 
 db:
   pvSize: 1Gi

--- a/helm/environment/production.yaml
+++ b/helm/environment/production.yaml
@@ -5,11 +5,14 @@ alerta:
   externalHostname: testing.industry-fusion.com
 keycloak:
   adminName: admin
-  externalAuthService:   # put here the *external* keycloak name, i.e. through ingress 
+  externalAuthService:   # put here the *external* keycloak name, i.e. through ingress
     protocol: "https:"
     domainname: testing.industry-fusion.com
     path: /auth/ # keycloak internal do not change
     # pathPrefix: /keycloak-iff/ # for ingress, must end with /
+  ifric:
+    companyId: ""
+    factoryId: ""
 
 db:
   pvSize: 1Gi

--- a/helm/values.yaml.gotmpl
+++ b/helm/values.yaml.gotmpl
@@ -301,6 +301,9 @@ keycloak:
   scorpio:
     realm: iff
     client: scorpio
+  ifric:
+    companyId: {{ .StateValues.keycloak.ifric.companyId | default "" | quote }}
+    factoryId: {{ .StateValues.keycloak.ifric.factoryId | default "" | quote }}
   ngsildUpdates:
     clientSecret: {{ .StateValues.ngsildUpdatesClientSecret }}
     realm: iff

--- a/test/bats/test-keycloak/test-keycloak-ifric-claims.bats
+++ b/test/bats/test-keycloak/test-keycloak-ifric-claims.bats
@@ -1,0 +1,211 @@
+#!/usr/bin/env bats
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# shellcheck disable=SC2005
+
+NAMESPACE=iff
+USER_SECRET=secret/credential-iff-realm-user-iff
+USER=realm_user
+CLIENT_ID=scorpio
+KEYCLOAK_URL=http://keycloak.local/auth
+
+# Known test values — distinct from any real deployment values
+TEST_COMPANY_ID="urn:ifric:ifx-eur-com-own-test-00000000-1111-1111-1111-111111111111"
+TEST_FACTORY_ID="urn:ifric:ifx-eur-loc-fac-test-00000000-2222-2222-2222-222222222222"
+TEST_COMPANY_ID_UPDATED="urn:ifric:ifx-eur-com-own-test-00000000-1111-1111-1111-111111111112"
+TEST_FACTORY_ID_UPDATED="urn:ifric:ifx-eur-loc-fac-test-00000000-2222-2222-2222-222222222223"
+
+# State persisted across setup → @test → teardown
+_admin_token=""
+_client_uuid=""
+_orig_company_id=""
+_orig_factory_id=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+get_realm_user_password() {
+    kubectl -n "${NAMESPACE}" get "${USER_SECRET}" -o jsonpath='{.data.password}' | base64 -d
+}
+
+get_admin_token() {
+    local admin_user admin_password
+    admin_user=$(kubectl -n "${NAMESPACE}" get secret/keycloak-initial-admin \
+        -o jsonpath='{.data.username}' | base64 -d)
+    admin_password=$(kubectl -n "${NAMESPACE}" get secret/keycloak-initial-admin \
+        -o jsonpath='{.data.password}' | base64 -d)
+    curl -sf -X POST "${KEYCLOAK_URL}/realms/master/protocol/openid-connect/token" \
+        -d "grant_type=password" \
+        -d "client_id=admin-cli" \
+        -d "username=${admin_user}" \
+        -d "password=${admin_password}" \
+        | jq -r '.access_token'
+}
+
+get_scorpio_token() {
+    local password
+    password=$(get_realm_user_password)
+    curl -sf -d "client_id=${CLIENT_ID}" \
+        -d "username=${USER}" \
+        -d "password=${password}" \
+        -d "grant_type=password" \
+        "${KEYCLOAK_URL}/realms/${NAMESPACE}/protocol/openid-connect/token" \
+        | jq -r '.access_token'
+}
+
+get_client_uuid() {
+    local admin_token="$1"
+    curl -sf \
+        -H "Authorization: Bearer ${admin_token}" \
+        "${KEYCLOAK_URL}/admin/realms/${NAMESPACE}/clients?clientId=${CLIENT_ID}" \
+        | jq -r '.[0].id'
+}
+
+get_all_mappers() {
+    local admin_token="$1" client_uuid="$2"
+    curl -sf \
+        -H "Authorization: Bearer ${admin_token}" \
+        "${KEYCLOAK_URL}/admin/realms/${NAMESPACE}/clients/${client_uuid}/protocol-mappers/models"
+}
+
+# Upsert a hardcoded-claim mapper: PUT if the mapper already exists, POST otherwise.
+upsert_mapper() {
+    local admin_token="$1" client_uuid="$2" name="$3" value="$4"
+    local mappers existing_id payload
+
+    mappers=$(get_all_mappers "${admin_token}" "${client_uuid}")
+    existing_id=$(echo "${mappers}" \
+        | jq -r ".[] | select(.name == \"${name}\") | .id // \"\"")
+
+    payload=$(jq -n \
+        --arg name  "${name}" \
+        --arg value "${value}" \
+        '{name: $name,
+          protocol: "openid-connect",
+          protocolMapper: "oidc-hardcoded-claim-mapper",
+          config: {
+            "claim.value":            $value,
+            "userinfo.token.claim":   "true",
+            "id.token.claim":         "true",
+            "access.token.claim":     "true",
+            "claim.name":             $name,
+            "jsonType.label":         "String",
+            "access.tokenResponse.claim": "false"
+          }}')
+
+    if [ -n "${existing_id}" ] && [ "${existing_id}" != "null" ]; then
+        payload=$(echo "${payload}" | jq --arg id "${existing_id}" '. + {id: $id}')
+        curl -sf -X PUT \
+            -H "Authorization: Bearer ${admin_token}" \
+            -H "Content-Type: application/json" \
+            "${KEYCLOAK_URL}/admin/realms/${NAMESPACE}/clients/${client_uuid}/protocol-mappers/models/${existing_id}" \
+            -d "${payload}"
+    else
+        curl -sf -X POST \
+            -H "Authorization: Bearer ${admin_token}" \
+            -H "Content-Type: application/json" \
+            "${KEYCLOAK_URL}/admin/realms/${NAMESPACE}/clients/${client_uuid}/protocol-mappers/models" \
+            -d "${payload}"
+    fi
+}
+
+# Delete a mapper by name; no-op if it does not exist.
+delete_mapper_by_name() {
+    local admin_token="$1" client_uuid="$2" name="$3"
+    local mappers mapper_id
+
+    mappers=$(get_all_mappers "${admin_token}" "${client_uuid}")
+    mapper_id=$(echo "${mappers}" \
+        | jq -r ".[] | select(.name == \"${name}\") | .id // \"\"")
+
+    if [ -n "${mapper_id}" ] && [ "${mapper_id}" != "null" ]; then
+        curl -sf -X DELETE \
+            -H "Authorization: Bearer ${admin_token}" \
+            "${KEYCLOAK_URL}/admin/realms/${NAMESPACE}/clients/${client_uuid}/protocol-mappers/models/${mapper_id}"
+    fi
+}
+
+# Decode a claim from the JWT payload (base64url → JSON).
+get_jwt_claim() {
+    local token="$1" claim="$2"
+    local payload pad
+    payload=$(echo "${token}" | cut -d'.' -f2 | tr '_-' '/+')
+    pad=$(( (4 - ${#payload} % 4) % 4 ))
+    while [ "${pad}" -gt 0 ]; do
+        payload="${payload}="
+        pad=$(( pad - 1 ))
+    done
+    echo "${payload}" | base64 -d 2>/dev/null | jq -r ".\"${claim}\""
+}
+
+# ---------------------------------------------------------------------------
+# Setup: snapshot originals, install known test values before every test.
+# Teardown: restore originals (runs even when a test fails).
+# ---------------------------------------------------------------------------
+
+setup() {
+    local mappers
+    _admin_token=$(get_admin_token)
+    _client_uuid=$(get_client_uuid "${_admin_token}")
+
+    mappers=$(get_all_mappers "${_admin_token}" "${_client_uuid}")
+    _orig_company_id=$(echo "${mappers}" \
+        | jq -r '.[] | select(.name == "ifric_company_id") | .config["claim.value"] // ""')
+    _orig_factory_id=$(echo "${mappers}" \
+        | jq -r '.[] | select(.name == "ifric_factory_id") | .config["claim.value"] // ""')
+
+    upsert_mapper "${_admin_token}" "${_client_uuid}" "ifric_company_id" "${TEST_COMPANY_ID}"
+    upsert_mapper "${_admin_token}" "${_client_uuid}" "ifric_factory_id" "${TEST_FACTORY_ID}"
+}
+
+teardown() {
+    if [ -n "${_orig_company_id}" ]; then
+        upsert_mapper "${_admin_token}" "${_client_uuid}" "ifric_company_id" "${_orig_company_id}"
+    else
+        delete_mapper_by_name "${_admin_token}" "${_client_uuid}" "ifric_company_id"
+    fi
+    if [ -n "${_orig_factory_id}" ]; then
+        upsert_mapper "${_admin_token}" "${_client_uuid}" "ifric_factory_id" "${_orig_factory_id}"
+    else
+        delete_mapper_by_name "${_admin_token}" "${_client_uuid}" "ifric_factory_id"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@test "scorpio token contains ifric_company_id claim" {
+    local token
+    token=$(get_scorpio_token)
+    [ "$(get_jwt_claim "${token}" "ifric_company_id")" = "${TEST_COMPANY_ID}" ]
+}
+
+@test "scorpio token contains ifric_factory_id claim" {
+    local token
+    token=$(get_scorpio_token)
+    [ "$(get_jwt_claim "${token}" "ifric_factory_id")" = "${TEST_FACTORY_ID}" ]
+}
+
+@test "ifric claims reflect updated mapper values" {
+    upsert_mapper "${_admin_token}" "${_client_uuid}" "ifric_company_id" "${TEST_COMPANY_ID_UPDATED}"
+    upsert_mapper "${_admin_token}" "${_client_uuid}" "ifric_factory_id" "${TEST_FACTORY_ID_UPDATED}"
+
+    local token
+    token=$(get_scorpio_token)
+    [ "$(get_jwt_claim "${token}" "ifric_company_id")" = "${TEST_COMPANY_ID_UPDATED}" ]
+    [ "$(get_jwt_claim "${token}" "ifric_factory_id")" = "${TEST_FACTORY_ID_UPDATED}" ]
+}


### PR DESCRIPTION
## Summary

Adds two optional hardcoded claims to the Scorpio client in the IFF Keycloak realm:
- **`ifric-company-id`** — identifies the company in the IFRIC ecosystem
- **`ifric-factory-id`** — identifies the factory in the IFRIC ecosystem

Both claims are added to the access token, ID token, and userinfo endpoint.

## Configuration

Set the values per deployment in the environment file (e.g. `helm/environment/production.yaml`):

```yaml
keycloak:
  scorpio:
    ifricCompanyId: "my-company-uuid"
    ifricFactoryId: "my-factory-uuid"
```

When left as empty strings (the default), the mappers are omitted entirely from the realm — no empty claims are injected.

## Files changed

- `helm/charts/keycloak/templates/keycloak-realm.yaml` — two conditional `oidc-hardcoded-claim-mapper` entries in the scorpio client
- `helm/values.yaml.gotmpl` — passes `ifricCompanyId`/`ifricFactoryId` from state values into the chart
- `helm/environment/default.yaml` — adds `keycloak.scorpio.ifricCompanyId/ifricFactoryId: ""` default
- `helm/environment/production.yaml` — same default
- `helm/environment/oep.yaml` — same default

## Test plan

- [ ] Build workflow CI
- [ ] K8s tests workflow CI