### PR TITLE
Stop the Kafka/MQTT bridges failing silently

### DIFF
--- a/KafkaBridge/alerta/app.js
+++ b/KafkaBridge/alerta/app.js
@@ -18,10 +18,10 @@
 const GROUPID = 'alertakafkabridge';
 const CLIENTID = 'alertakafkaclient';
 const { Kafka } = require('kafkajs');
-const fs = require('fs');
 const config = require('../config/config.json');
 const Alerta = require('../lib/alerta.js');
 const Logger = require('../lib/logger.js');
+const KafkaHealth = require('../lib/kafkaHealth.js');
 
 const alerta = new Alerta(config);
 const logger = new Logger(config);
@@ -61,6 +61,7 @@ const pauseresume = function (consumer, topic) {
 };
 
 const startListener = async function () {
+  const health = new KafkaHealth(consumer, logger);
   await consumer.connect();
   await consumer.subscribe({ topic: config.alerta.topic, fromBeginning: false });
 
@@ -119,8 +120,12 @@ const startListener = async function () {
       try {
         console.log(`process.on ${type}`);
         console.error(e);
+        health.shutdown();
         await consumer.disconnect();
-        process.exit(0);
+        // Non-zero: this path is only reached on an unhandled error, and
+        // exiting 0 made a crash-looping bridge indistinguishable from a clean
+        // stop in kubectl and in any exit-code based alerting.
+        process.exit(1);
       } catch (_) {
         process.exit(1);
       }
@@ -129,14 +134,14 @@ const startListener = async function () {
   signalTraps.map(type =>
     process.once(type, async () => {
       try {
+        health.shutdown();
         await consumer.disconnect();
       } finally {
         process.kill(process.pid, type);
       }
     }));
   try {
-    fs.writeFileSync('/tmp/ready', 'ready');
-    fs.writeFileSync('/tmp/healthy', 'healthy');
+    health.start();
   } catch (err) {
     logger.error(err);
   }

--- a/KafkaBridge/config/config.json
+++ b/KafkaBridge/config/config.json
@@ -91,7 +91,8 @@
 			"maxRetryTime": 5000,
 			"retries": 10,
 			"linger": 50,
-			"partitioner": "defaultPartitioner"
+			"partitioner": "defaultPartitioner",
+			"maxBufferedMessages": 50000
 		  }
     },
 	"cache": {

--- a/KafkaBridge/config/config.json
+++ b/KafkaBridge/config/config.json
@@ -92,7 +92,9 @@
 			"retries": 10,
 			"linger": 50,
 			"partitioner": "defaultPartitioner",
-			"maxBufferedMessages": 50000
+			"maxBufferedMessages": 50000,
+			"awaitDelivery": true,
+			"maxDeliveryStallMs": 300000
 		  }
     },
 	"cache": {

--- a/KafkaBridge/debeziumBridge/app.js
+++ b/KafkaBridge/debeziumBridge/app.js
@@ -17,11 +17,11 @@
 
 const GROUPID = 'debeziumBridgeGroup';
 const CLIENTID = 'ngsildkafkaclient';
-const fs = require('fs');
 const { Kafka } = require('kafkajs');
 const config = require('../config/config.json');
 const DebeziumBridge = require('../lib/debeziumBridge.js');
 const Logger = require('../lib/logger.js');
+const KafkaHealth = require('../lib/kafkaHealth.js');
 const runningAsMain = require.main === module;
 
 const debeziumBridge = new DebeziumBridge(config);
@@ -36,6 +36,7 @@ const consumer = kafka.consumer({ groupId: GROUPID, allowAutoTopicCreation: fals
 const producer = kafka.producer();
 
 const startListener = async function () {
+  const health = new KafkaHealth(consumer, logger);
   await consumer.connect();
   await consumer.subscribe({ topic: config.debeziumBridge.topic, fromBeginning: false });
   await producer.connect();
@@ -58,7 +59,13 @@ const startListener = async function () {
         logger.error('could not process message: ' + e.stack);
       }
     }
-  }).catch(e => logger.error(`[StateUpdater/consumer] ${e.message}`, e));
+  }).catch(e => {
+    // Rethrow: a consumer.run() that rejects leaves the bridge with no message
+    // loop at all, and swallowing it here let startup continue on to declare
+    // the pod ready.
+    logger.error(`[StateUpdater/consumer] ${e.message}`, e);
+    throw e;
+  });
 
   const errorTypes = ['unhandledRejection', 'uncaughtException'];
   const signalTraps = ['SIGTERM', 'SIGINT', 'SIGUSR2'];
@@ -68,8 +75,12 @@ const startListener = async function () {
       try {
         console.log(`process.on ${type}`);
         console.error(e);
+        health.shutdown();
         await consumer.disconnect();
-        process.exit(0);
+        // Non-zero: this path is only reached on an unhandled error, and
+        // exiting 0 made a crash-looping bridge indistinguishable from a clean
+        // stop in kubectl and in any exit-code based alerting.
+        process.exit(1);
       } catch (_) {
         process.exit(1);
       }
@@ -78,14 +89,14 @@ const startListener = async function () {
   signalTraps.map(type =>
     process.once(type, async () => {
       try {
+        health.shutdown();
         await consumer.disconnect();
       } finally {
         process.kill(process.pid, type);
       }
     }));
   try {
-    fs.writeFileSync('/tmp/ready', 'ready');
-    fs.writeFileSync('/tmp/healthy', 'healthy');
+    health.start();
   } catch (err) {
     logger.error(err);
   }

--- a/KafkaBridge/lib/authService/index.js
+++ b/KafkaBridge/lib/authService/index.js
@@ -48,8 +48,16 @@ const init = async function (conf) {
     res.sendStatus(200);
   });
 
-  app.listen(config.mqtt.authServicePort, () => {
-    console.log(`Auth/ACL Service started and listening on port ${config.mqtt.authServicePort}`);
+  // Resolve on 'listening', not on the call: the caller declares readiness off
+  // the back of this promise, and a pod that is Ready before its socket accepts
+  // sends EMQX's auth callbacks to a closed port. A failed bind (port taken)
+  // rejects here instead of surfacing as an unhandled 'error' event.
+  return new Promise((resolve, reject) => {
+    const server = app.listen(config.mqtt.authServicePort, () => {
+      console.log(`Auth/ACL Service started and listening on port ${config.mqtt.authServicePort}`);
+      resolve(server);
+    });
+    server.once('error', reject);
   });
 };
 module.exports.init = init;

--- a/KafkaBridge/lib/healthState.js
+++ b/KafkaBridge/lib/healthState.js
@@ -52,6 +52,24 @@ module.exports = function HealthState (logger, options) {
       cleanups.push(fn);
     },
 
+    /**
+     * Declare the bridge able to serve traffic on its Service, without claiming
+     * its input works yet.
+     *
+     * Only the MQTT bridge needs this, and it needs it because its readiness
+     * gates something its own input depends on: the mqtt-bridge Service carries
+     * EMQX's authn/authz callbacks, and a Service skips endpoints that are not
+     * Ready. Withholding /tmp/ready until the subscription exists therefore
+     * deadlocks -- the subscription cannot be authorised until EMQX can reach
+     * the auth API, and it cannot reach it until the pod is Ready.
+     *
+     * A bridge whose readiness gates nothing it depends on should call up()
+     * instead and keep the two signals together.
+     */
+    serving: function () {
+      fs.writeFileSync(readyFile, 'ready');
+    },
+
     /** Declare the bridge up. Only call once the input is genuinely working. */
     up: function () {
       fs.writeFileSync(readyFile, 'ready');

--- a/KafkaBridge/lib/healthState.js
+++ b/KafkaBridge/lib/healthState.js
@@ -89,10 +89,6 @@ module.exports = function HealthState (logger, options) {
     shutdown: function () {
       shuttingDown = true;
       runCleanups();
-    },
-
-    isShuttingDown: function () {
-      return shuttingDown;
     }
   };
 };

--- a/KafkaBridge/lib/healthState.js
+++ b/KafkaBridge/lib/healthState.js
@@ -1,0 +1,98 @@
+/**
+* Copyright (c) 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+'use strict';
+
+const fs = require('fs');
+
+const READY_FILE = '/tmp/ready';
+const HEALTHY_FILE = '/tmp/healthy';
+
+/**
+ * The liveness/readiness files every bridge exposes, plus the one way they are
+ * allowed to fail.
+ *
+ * Shared so a Kafka bridge and the MQTT bridge report a broken input the same
+ * way: remove /tmp/healthy and exit non-zero. Which conditions count as broken
+ * is up to the caller -- see kafkaHealth.js and mqttHealth.js.
+ *
+ * @param {object} logger - winston-style logger
+ * @param {object} options - readyFile, healthyFile, exit (optional, for tests)
+ */
+module.exports = function HealthState (logger, options) {
+  const opts = options || {};
+  const readyFile = opts.readyFile || READY_FILE;
+  const healthyFile = opts.healthyFile || HEALTHY_FILE;
+  const exit = opts.exit || function (code) { process.exit(code); };
+
+  let shuttingDown = false;
+  const cleanups = [];
+
+  const runCleanups = function () {
+    while (cleanups.length > 0) {
+      cleanups.pop()();
+    }
+  };
+
+  return {
+    /** Register a timer to stop when the bridge fails or shuts down. */
+    addCleanup: function (fn) {
+      cleanups.push(fn);
+    },
+
+    /** Declare the bridge up. Only call once the input is genuinely working. */
+    up: function () {
+      fs.writeFileSync(readyFile, 'ready');
+      fs.writeFileSync(healthyFile, 'healthy');
+    },
+
+    /**
+     * Report a broken input. Idempotent, because one failure usually arrives as
+     * a cascade of events, and because a bridge that is already on its way down
+     * should not log the same thing five times.
+     */
+    fail: function (reason) {
+      if (shuttingDown) {
+        return;
+      }
+      shuttingDown = true;
+      logger.error(`Bridge unhealthy: ${reason}. Exiting to force a restart.`);
+      runCleanups();
+      try {
+        fs.unlinkSync(healthyFile);
+      } catch (err) {
+        // Failing before ever becoming healthy is the normal startup-failure
+        // path, so a missing file here is expected, not another problem.
+        if (err.code !== 'ENOENT') {
+          logger.error(`Could not remove ${healthyFile}: ${err}`);
+        }
+      }
+      exit(1);
+    },
+
+    /**
+     * Mark an intentional shutdown, so the disconnect events a graceful stop
+     * produces are not reported as a failure.
+     */
+    shutdown: function () {
+      shuttingDown = true;
+      runCleanups();
+    },
+
+    isShuttingDown: function () {
+      return shuttingDown;
+    }
+  };
+};

--- a/KafkaBridge/lib/kafkaHealth.js
+++ b/KafkaBridge/lib/kafkaHealth.js
@@ -1,0 +1,150 @@
+/**
+* Copyright (c) 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+'use strict';
+
+const fs = require('fs');
+
+const READY_FILE = '/tmp/ready';
+const HEALTHY_FILE = '/tmp/healthy';
+
+/**
+ * Ties a bridge's liveness file to its Kafka consumer actually consuming.
+ *
+ * The bridges' liveness probe is `cat /tmp/healthy`. That file used to be
+ * written once at startup and never touched again, so a consumer that died
+ * afterwards left a permanently Ready pod that forwarded nothing. Observed on
+ * alerta-bridge: its consumer group went to Empty/0 members while the separate
+ * heartbeat producer kept logging success every second, so both the logs and
+ * the probes looked fine and SHACL alerts stopped reaching Alerta.
+ *
+ * Two independent detectors, because kafkajs only reports some of the ways a
+ * consumer can stop:
+ *   - CRASH/STOP/DISCONNECT events, which kafkajs does emit and nobody listened
+ *     for;
+ *   - a watchdog over the consumer's own loop, for stalls it does not report at
+ *     all (a lost `resume` timer, a rebalance that never completes).
+ *
+ * Both end the process with a non-zero exit so the pod restarts, and remove
+ * /tmp/healthy first so the liveness probe also fails if the exit is somehow
+ * swallowed. Keeping the staleness logic here rather than in the probe command
+ * means the existing `cat /tmp/healthy` charts need no change.
+ *
+ * @param {object} consumer - a kafkajs consumer
+ * @param {object} logger - winston-style logger
+ * @param {object} options - staleAfterMs, checkIntervalMs, readyFile,
+ *                           healthyFile, exit (all optional, for tests)
+ */
+module.exports = function KafkaHealth (consumer, logger, options) {
+  const opts = options || {};
+  // Idle bridges are normal, so the window has to clear the quietest signal
+  // the consumer emits by itself. kafkajs fetches on a loop even with no
+  // traffic (maxWaitTimeInMs defaults to 5s), so 90s is ~18 missed cycles.
+  const staleAfterMs = opts.staleAfterMs || 90000;
+  const checkIntervalMs = opts.checkIntervalMs || 10000;
+  const readyFile = opts.readyFile || READY_FILE;
+  const healthyFile = opts.healthyFile || HEALTHY_FILE;
+  const exit = opts.exit || function (code) { process.exit(code); };
+
+  let lastAlive = Date.now();
+  let watchdog = null;
+  let shuttingDown = false;
+
+  const markAlive = function () {
+    lastAlive = Date.now();
+  };
+
+  const unhealthy = function (reason) {
+    if (shuttingDown) {
+      return;
+    }
+    shuttingDown = true;
+    logger.error(`Kafka consumer unhealthy: ${reason}. Exiting to force a restart.`);
+    if (watchdog !== null) {
+      clearInterval(watchdog);
+      watchdog = null;
+    }
+    try {
+      fs.unlinkSync(healthyFile);
+    } catch (err) {
+      logger.error(`Could not remove ${healthyFile}: ${err}`);
+    }
+    exit(1);
+  };
+
+  // Every sign of life from the consumer's own loop. FETCH and HEARTBEAT keep
+  // ticking on an idle topic, so a bridge that legitimately sees no messages is
+  // not mistaken for a dead one.
+  [
+    consumer.events.HEARTBEAT,
+    consumer.events.FETCH,
+    consumer.events.END_BATCH_PROCESS,
+    consumer.events.COMMIT_OFFSETS,
+    consumer.events.GROUP_JOIN
+  ].forEach(function (event) {
+    consumer.on(event, markAlive);
+  });
+
+  consumer.on(consumer.events.CRASH, function (e) {
+    const payload = (e && e.payload) || {};
+    if (payload.restart) {
+      // kafkajs recovers by itself here. Say so, but do not kill the process --
+      // if the restart does not actually bring the loop back, the watchdog below
+      // notices within staleAfterMs.
+      logger.error(`Kafka consumer crashed, kafkajs will restart it: ${payload.error}`);
+      return;
+    }
+    unhealthy(`consumer crashed and will not restart: ${payload.error}`);
+  });
+
+  consumer.on(consumer.events.STOP, function () {
+    unhealthy('consumer stopped');
+  });
+
+  consumer.on(consumer.events.DISCONNECT, function () {
+    unhealthy('consumer disconnected');
+  });
+
+  return {
+    /**
+     * Declare the bridge up and start the watchdog. Call once the consumer is
+     * running, i.e. where the bridges used to write the two files.
+     */
+    start: function () {
+      fs.writeFileSync(readyFile, 'ready');
+      fs.writeFileSync(healthyFile, 'healthy');
+      markAlive();
+      watchdog = setInterval(function () {
+        const age = Date.now() - lastAlive;
+        if (age > staleAfterMs) {
+          unhealthy(`no consumer activity for ${Math.round(age / 1000)}s`);
+        }
+      }, checkIntervalMs);
+      return this;
+    },
+
+    /**
+     * Mark an intentional shutdown, so the STOP/DISCONNECT that a graceful
+     * `consumer.disconnect()` emits is not reported as a failure.
+     */
+    shutdown: function () {
+      shuttingDown = true;
+      if (watchdog !== null) {
+        clearInterval(watchdog);
+        watchdog = null;
+      }
+    }
+  };
+};

--- a/KafkaBridge/lib/kafkaHealth.js
+++ b/KafkaBridge/lib/kafkaHealth.js
@@ -15,10 +15,7 @@
 */
 'use strict';
 
-const fs = require('fs');
-
-const READY_FILE = '/tmp/ready';
-const HEALTHY_FILE = '/tmp/healthy';
+const HealthState = require('./healthState.js');
 
 /**
  * Ties a bridge's liveness file to its Kafka consumer actually consuming.
@@ -37,10 +34,8 @@ const HEALTHY_FILE = '/tmp/healthy';
  *   - a watchdog over the consumer's own loop, for stalls it does not report at
  *     all (a lost `resume` timer, a rebalance that never completes).
  *
- * Both end the process with a non-zero exit so the pod restarts, and remove
- * /tmp/healthy first so the liveness probe also fails if the exit is somehow
- * swallowed. Keeping the staleness logic here rather than in the probe command
- * means the existing `cat /tmp/healthy` charts need no change.
+ * Keeping the staleness logic here rather than in the probe command means the
+ * existing `cat /tmp/healthy` charts need no change.
  *
  * @param {object} consumer - a kafkajs consumer
  * @param {object} logger - winston-style logger
@@ -54,34 +49,12 @@ module.exports = function KafkaHealth (consumer, logger, options) {
   // traffic (maxWaitTimeInMs defaults to 5s), so 90s is ~18 missed cycles.
   const staleAfterMs = opts.staleAfterMs || 90000;
   const checkIntervalMs = opts.checkIntervalMs || 10000;
-  const readyFile = opts.readyFile || READY_FILE;
-  const healthyFile = opts.healthyFile || HEALTHY_FILE;
-  const exit = opts.exit || function (code) { process.exit(code); };
+  const state = new HealthState(logger, opts);
 
   let lastAlive = Date.now();
-  let watchdog = null;
-  let shuttingDown = false;
 
   const markAlive = function () {
     lastAlive = Date.now();
-  };
-
-  const unhealthy = function (reason) {
-    if (shuttingDown) {
-      return;
-    }
-    shuttingDown = true;
-    logger.error(`Kafka consumer unhealthy: ${reason}. Exiting to force a restart.`);
-    if (watchdog !== null) {
-      clearInterval(watchdog);
-      watchdog = null;
-    }
-    try {
-      fs.unlinkSync(healthyFile);
-    } catch (err) {
-      logger.error(`Could not remove ${healthyFile}: ${err}`);
-    }
-    exit(1);
   };
 
   // Every sign of life from the consumer's own loop. FETCH and HEARTBEAT keep
@@ -106,15 +79,15 @@ module.exports = function KafkaHealth (consumer, logger, options) {
       logger.error(`Kafka consumer crashed, kafkajs will restart it: ${payload.error}`);
       return;
     }
-    unhealthy(`consumer crashed and will not restart: ${payload.error}`);
+    state.fail(`Kafka consumer crashed and will not restart: ${payload.error}`);
   });
 
   consumer.on(consumer.events.STOP, function () {
-    unhealthy('consumer stopped');
+    state.fail('Kafka consumer stopped');
   });
 
   consumer.on(consumer.events.DISCONNECT, function () {
-    unhealthy('consumer disconnected');
+    state.fail('Kafka consumer disconnected');
   });
 
   return {
@@ -123,28 +96,22 @@ module.exports = function KafkaHealth (consumer, logger, options) {
      * running, i.e. where the bridges used to write the two files.
      */
     start: function () {
-      fs.writeFileSync(readyFile, 'ready');
-      fs.writeFileSync(healthyFile, 'healthy');
+      state.up();
       markAlive();
-      watchdog = setInterval(function () {
+      const watchdog = setInterval(function () {
         const age = Date.now() - lastAlive;
         if (age > staleAfterMs) {
-          unhealthy(`no consumer activity for ${Math.round(age / 1000)}s`);
+          state.fail(`no Kafka consumer activity for ${Math.round(age / 1000)}s`);
         }
       }, checkIntervalMs);
+      state.addCleanup(function () {
+        clearInterval(watchdog);
+      });
       return this;
     },
 
-    /**
-     * Mark an intentional shutdown, so the STOP/DISCONNECT that a graceful
-     * `consumer.disconnect()` emits is not reported as a failure.
-     */
     shutdown: function () {
-      shuttingDown = true;
-      if (watchdog !== null) {
-        clearInterval(watchdog);
-        watchdog = null;
-      }
+      state.shutdown();
     }
   };
 };

--- a/KafkaBridge/lib/mqttHealth.js
+++ b/KafkaBridge/lib/mqttHealth.js
@@ -105,9 +105,13 @@ module.exports = function MqttHealth (broker, logger, options) {
       return this;
     },
 
-    /** The subscription could not be established at all. */
-    fail: function (reason) {
-      state.fail(`MQTT subscription failed: ${reason}`);
+    /**
+     * Anything that means the bridge can no longer do its job -- the
+     * subscription never came up, or the Kafka side can no longer guarantee
+     * delivery. Reported the same way as a dead broker connection.
+     */
+    fatal: function (reason) {
+      state.fail(reason);
     },
 
     shutdown: function () {

--- a/KafkaBridge/lib/mqttHealth.js
+++ b/KafkaBridge/lib/mqttHealth.js
@@ -75,8 +75,29 @@ module.exports = function MqttHealth (broker, logger, options) {
     },
 
     /**
+     * The auth/ACL API is listening, so the pod can join its Service.
+     *
+     * This has to happen before the subscription rather than with it: EMQX
+     * resolves every authn/authz callback through the mqtt-bridge Service, and
+     * a Service drops endpoints that are not Ready. Gating /tmp/ready on the
+     * subscription made the bridge wait for an authorisation that could only
+     * arrive once it was already Ready, so the pod never came up and EMQX
+     * rejected every client -- the bridge's own subscription included.
+     *
+     * Readiness therefore answers "can I serve this Service?" and liveness
+     * answers "is my input working?", which is what the two probes are for.
+     * Never subscribing is still a failure; it is now caught by the startup
+     * deadline below, which removes /tmp/healthy and exits.
+     */
+    serving: function () {
+      state.serving();
+      logger.info('MQTT bridge is serving auth/ACL requests.');
+      return this;
+    },
+
+    /**
      * The subscription is granted and messages can flow. This -- not the call
-     * to bind() -- is what makes the bridge ready.
+     * to bind() -- is what makes the bridge healthy.
      */
     ready: function () {
       if (subscribed) {

--- a/KafkaBridge/lib/mqttHealth.js
+++ b/KafkaBridge/lib/mqttHealth.js
@@ -1,0 +1,117 @@
+/**
+* Copyright (c) 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+'use strict';
+
+const HealthState = require('./healthState.js');
+
+/**
+ * Ties the MQTT bridge's liveness file to its subscription actually existing.
+ *
+ * Same failure shape as the Kafka bridges, reached by a different route. The
+ * MQTT bridge used to write /tmp/ready and /tmp/healthy immediately after
+ * calling bind(), but bind() only *starts* connecting: the broker connection is
+ * retried for up to retries*1500ms in the background and its failure was
+ * reported through a callback nobody passed. So the pod went Ready within
+ * milliseconds whether or not it ever subscribed, and a bridge that never
+ * connected forwarded nothing while looking perfectly healthy.
+ *
+ * Two detectors:
+ *   - a startup deadline, so never coming up is a failure rather than a wait;
+ *   - a connection watchdog, since mqtt.js reconnects silently on its own and a
+ *     permanently refused reconnect (expired credentials, revoked ACL) is
+ *     otherwise indistinguishable from an idle broker.
+ *
+ * The watchdog polls rather than listening for 'close', because a disconnect
+ * that mqtt.js immediately repairs is normal and must not restart the pod.
+ * Only being down continuously for longer than graceMs counts.
+ *
+ * @param {object} broker - lib/mqtt_connector Broker (needs connected())
+ * @param {object} logger - winston-style logger
+ * @param {object} options - startupTimeoutMs, graceMs, checkIntervalMs,
+ *                           readyFile, healthyFile, exit (optional, for tests)
+ */
+module.exports = function MqttHealth (broker, logger, options) {
+  const opts = options || {};
+  // Must outlast Broker.connect's own retry budget (max_retries * 1500ms,
+  // 45s by default), otherwise this fires while the connector is still
+  // legitimately retrying.
+  const startupTimeoutMs = opts.startupTimeoutMs || 120000;
+  // mqtt.js reconnects every second by default; 60s is a long outage, not a blip.
+  const graceMs = opts.graceMs || 60000;
+  const checkIntervalMs = opts.checkIntervalMs || 10000;
+  const state = new HealthState(logger, opts);
+
+  let subscribed = false;
+  let lastConnected = Date.now();
+
+  return {
+    /**
+     * Start the startup deadline. Call before binding, so a bind that never
+     * completes is caught.
+     */
+    start: function () {
+      const deadline = setTimeout(function () {
+        if (!subscribed) {
+          state.fail(`MQTT subscription not established within ${Math.round(startupTimeoutMs / 1000)}s`);
+        }
+      }, startupTimeoutMs);
+      state.addCleanup(function () {
+        clearTimeout(deadline);
+      });
+      return this;
+    },
+
+    /**
+     * The subscription is granted and messages can flow. This -- not the call
+     * to bind() -- is what makes the bridge ready.
+     */
+    ready: function () {
+      if (subscribed) {
+        return this;
+      }
+      subscribed = true;
+      lastConnected = Date.now();
+      state.up();
+      logger.info('MQTT bridge is ready: subscription established.');
+
+      const watchdog = setInterval(function () {
+        if (broker.connected()) {
+          lastConnected = Date.now();
+          return;
+        }
+        const down = Date.now() - lastConnected;
+        if (down > graceMs) {
+          state.fail(`MQTT broker connection down for ${Math.round(down / 1000)}s`);
+        } else {
+          logger.warn(`MQTT broker connection is down, waiting for mqtt.js to reconnect (${Math.round(down / 1000)}s)`);
+        }
+      }, checkIntervalMs);
+      state.addCleanup(function () {
+        clearInterval(watchdog);
+      });
+      return this;
+    },
+
+    /** The subscription could not be established at all. */
+    fail: function (reason) {
+      state.fail(`MQTT subscription failed: ${reason}`);
+    },
+
+    shutdown: function () {
+      state.shutdown();
+    }
+  };
+};

--- a/KafkaBridge/lib/mqtt_connector.js
+++ b/KafkaBridge/lib/mqtt_connector.js
@@ -70,17 +70,47 @@ function Broker (conf, logger) {
   };
   me.setCredential();
 
+  /**
+   * Dispatch incoming messages from handleMessage rather than from the
+   * 'message' event.
+   *
+   * mqtt.js sends the PUBACK only once handleMessage calls back (see
+   * handlers/publish.js), so this is the hook that lets the bridge hold the
+   * acknowledgement until the message is safely forwarded. Not acknowledging
+   * also stops the packet queue, which is the backpressure: the broker keeps
+   * the message and stops handing us more.
+   *
+   * The dispatch has to live here and not in an 'message' listener, because
+   * mqtt.js emits 'message' *and* calls handleMessage for the same packet --
+   * doing both would forward every message twice.
+   */
   me.listen = function () {
-    me.client.on('message', function (topic, message) {
+    me.client.handleMessage = function (packet, callback) {
+      let message;
       try {
-        message = JSON.parse(message);
+        message = JSON.parse(packet.payload);
       } catch (e) {
         me.logger.error('Invalid Message: %s', e);
-        return;
+        // Acknowledge anyway: a payload that does not parse will not parse on
+        // redelivery either, and refusing it would wedge the queue for good.
+        return callback();
       }
-      me.logger.info('STATUS: %s', topic, message);
-      me.onMessage(topic, message);
-    });
+      me.logger.info('STATUS: %s', packet.topic, message);
+      let handled;
+      try {
+        handled = me.onMessage(packet.topic, message);
+      } catch (e) {
+        me.logger.error('Could not handle message on ' + packet.topic + ': ' + e);
+        return callback();
+      }
+      Promise.resolve(handled).then(function () {
+        callback();
+      }, function (err) {
+        // Deliberately unacknowledged, so the broker still owns the message.
+        me.logger.error('Not acknowledging message on ' + packet.topic + ': ' + err);
+        callback(err);
+      });
+    };
   };
   me.connect = function (done) {
     let retries = 0;
@@ -165,9 +195,15 @@ function Broker (conf, logger) {
       return !tryPattern(obj.t, topic);
     });
   };
+  /**
+   * @returns a promise settling when every matching handler has finished with
+   *          the message. Handlers that return nothing settle immediately, so
+   *          this stays compatible with synchronous ones.
+   */
   me.onMessage = function (topic, message) {
     let i;
     const length = me.messageHandler.length;
+    const handled = [];
     /**
          * Iterate over the messageHandler to match topic patter,
          * and dispatch message to only proper handler
@@ -176,9 +212,10 @@ function Broker (conf, logger) {
       const obj = me.messageHandler[i];
       if (tryPattern(obj.t, topic)) {
         me.logger.debug('Fired STATUS: ' + topic + JSON.stringify(message));
-        obj.h.call(obj.c, topic, message);
+        handled.push(obj.h.call(obj.c, topic, message));
       }
     }
+    return Promise.all(handled);
   };
   me.bind = function (topic, handler, context, callback) {
     /**

--- a/KafkaBridge/lib/mqtt_connector.js
+++ b/KafkaBridge/lib/mqtt_connector.js
@@ -190,7 +190,15 @@ function Broker (conf, logger) {
       me.logger.debug('Subscribing to: ' + topic);
       me.client.subscribe(topic, { qos: 1 }, function (err, granted) {
         if (err) {
-          throw new Error('Cannot bind handler.');
+          // Report it instead of throwing out of an mqtt.js callback. Throwing
+          // here surfaced as an uncaughtException with no indication of which
+          // topic failed, and callers that passed a callback never learned that
+          // their subscription does not exist.
+          me.logger.error('Cannot bind handler for topic ' + topic + ': ' + err);
+          if (toCallBack) {
+            toCallBack(err);
+          }
+          return;
         }
         me.logger.debug('grant ' + JSON.stringify(granted));
         const topicAsPattern = granted[0].topic.replace(/\+/g, '[^<>]*');

--- a/KafkaBridge/mqttBridge/app.js
+++ b/KafkaBridge/mqttBridge/app.js
@@ -37,6 +37,11 @@ const startListener = async function () {
 
   logger.info('Now starting MQTT auth service.');
   await authService.init(config);
+  // Ready as soon as the auth API is listening, because that API is the only
+  // thing the mqtt-bridge Service carries and EMQX cannot authorise anyone --
+  // this bridge included -- until the Service has an endpoint to send the
+  // callbacks to. Whether the subscription then works is a liveness question.
+  health.serving();
 
   logger.info('Now starting MQTT-Kafka bridge forwarding.');
   // SparkplugB connector

--- a/KafkaBridge/mqttBridge/app.js
+++ b/KafkaBridge/mqttBridge/app.js
@@ -43,7 +43,9 @@ const startListener = async function () {
       try {
         console.log(`process.on ${type}`);
         console.error(e);
-        process.exit(0);
+        // Non-zero: exiting 0 on an unhandled error makes a crash-looping
+        // bridge look like a clean stop.
+        process.exit(1);
       } catch (_) {
         process.exit(1);
       }

--- a/KafkaBridge/mqttBridge/app.js
+++ b/KafkaBridge/mqttBridge/app.js
@@ -40,14 +40,17 @@ const startListener = async function () {
 
   logger.info('Now starting MQTT-Kafka bridge forwarding.');
   // SparkplugB connector
-  const sparkplugapiDataConnector = new SparkplugApiData(config);
+  // The aggregator buffers measurements when Kafka is unreachable; once that
+  // buffer is full the next thing it would do is lose them, so it fails the pod
+  // instead.
+  const sparkplugapiDataConnector = new SparkplugApiData(config, reason => health.fatal(reason));
   sparkplugapiDataConnector.init();
   // bind() only starts connecting. Readiness has to wait for the SUBSCRIBE to
   // be granted -- declaring it here, as this used to, made the pod Ready within
   // milliseconds even when the broker was unreachable.
   sparkplugapiDataConnector.bind(brokerConnector, sparkplugapiDataConnector, err => {
     if (err) {
-      health.fail(err);
+      health.fatal(`MQTT subscription failed: ${err}`);
       return;
     }
     health.ready();

--- a/KafkaBridge/mqttBridge/app.js
+++ b/KafkaBridge/mqttBridge/app.js
@@ -20,15 +20,20 @@ const SparkplugApiData = require('./sparkplug_data_ingestion');
 const config = require('../config/config.json');
 const authService = require('../lib/authService');
 const Logger = require('../lib/logger');
-const fs = require('fs');
+const MqttHealth = require('../lib/mqttHealth');
 
 process.env.APP_ROOT = __dirname;
 const logger = Logger(config);
 const brokerConnector = Broker.singleton(config.mqtt, logger);
+const runningAsMain = require.main === module;
 
 const startListener = async function () {
   const errorTypes = ['unhandledRejection', 'uncaughtException'];
   const signalTraps = ['SIGTERM', 'SIGINT', 'SIGUSR2'];
+
+  // Armed before anything can block, so a broker that never accepts the
+  // connection ends as a restart instead of a bridge that waits forever.
+  const health = new MqttHealth(brokerConnector, logger).start();
 
   logger.info('Now starting MQTT auth service.');
   await authService.init(config);
@@ -37,7 +42,17 @@ const startListener = async function () {
   // SparkplugB connector
   const sparkplugapiDataConnector = new SparkplugApiData(config);
   sparkplugapiDataConnector.init();
-  sparkplugapiDataConnector.bind(brokerConnector, sparkplugapiDataConnector);
+  // bind() only starts connecting. Readiness has to wait for the SUBSCRIBE to
+  // be granted -- declaring it here, as this used to, made the pod Ready within
+  // milliseconds even when the broker was unreachable.
+  sparkplugapiDataConnector.bind(brokerConnector, sparkplugapiDataConnector, err => {
+    if (err) {
+      health.fail(err);
+      return;
+    }
+    health.ready();
+  });
+
   errorTypes.map(type =>
     process.on(type, async e => {
       try {
@@ -53,14 +68,19 @@ const startListener = async function () {
 
   signalTraps.map(type =>
     process.once(type, async () => {
+      health.shutdown();
       process.kill(process.pid, type);
     }));
-  try {
-    fs.writeFileSync('/tmp/ready', 'ready');
-    fs.writeFileSync('/tmp/healthy', 'healthy');
-  } catch (err) {
-    logger.error(err);
-  }
 };
 
-startListener();
+// Guarded like the other bridges: without it, requiring this module for a test
+// opens a real broker connection and arms the real startup deadline.
+if (runningAsMain) {
+  // Explicit: startup happens before the uncaughtException handler above is
+  // registered, so without this a failing authService.init would rely on Node's
+  // default unhandled-rejection behaviour to be noticed at all.
+  startListener().catch(e => {
+    logger.error('Could not start MQTT bridge: ' + e);
+    process.exit(1);
+  });
+}

--- a/KafkaBridge/mqttBridge/sparkplug_data_ingestion.js
+++ b/KafkaBridge/mqttBridge/sparkplug_data_ingestion.js
@@ -328,8 +328,8 @@ module.exports = class SparkplugHandler {
     }
   };
 
-  connectTopics (context) {
-    this.broker.bind(this.topics_subscribe.sparkplugb_data_ingestion, this.processDataIngestion, context);
+  connectTopics (context, callback) {
+    this.broker.bind(this.topics_subscribe.sparkplugb_data_ingestion, this.processDataIngestion, context, callback);
     return true;
   };
 
@@ -355,10 +355,14 @@ module.exports = class SparkplugHandler {
   /**
     * @description It's bind to the MQTT topics
     * @param broker
+    * @param context
+    * @param callback called with no argument once the subscription is granted,
+    *        or with the error if the broker connection or the SUBSCRIBE failed.
+    *        Without it a failure to subscribe is only visible in the log.
     */
-  bind (broker, context) {
+  bind (broker, context, callback) {
     this.broker = broker;
     this.handshake();
-    this.connectTopics(context);
+    this.connectTopics(context, callback);
   };
 };

--- a/KafkaBridge/mqttBridge/sparkplug_data_ingestion.js
+++ b/KafkaBridge/mqttBridge/sparkplug_data_ingestion.js
@@ -55,6 +55,12 @@ const RoundRobinPartitioner = () => {
 // Reaching it is a hard failure rather than a drop -- see enforceLimit.
 const DEFAULT_MAX_BUFFERED_MESSAGES = 50000;
 
+// How long delivery may be stuck before the bridge gives up and restarts. With
+// awaitDelivery the buffer stays tiny, so a count limit alone would never
+// notice a Kafka outage -- the bridge would just stop acknowledging and sit
+// there looking healthy, which is the failure this whole branch is about.
+const DEFAULT_MAX_DELIVERY_STALL_MS = 300000;
+
 // @brief Aggregates messages for periodic executed Kafka producer
 class KafkaAggregator {
   /**
@@ -68,10 +74,20 @@ class KafkaAggregator {
     this.config = config;
     this.spbMessageArray = [];
     this.ngsildMessageArray = [];
+    // Resolved when the batch a message went out in was acknowledged by Kafka.
+    // This is what lets the MQTT side withhold its PUBACK until then.
+    this.waiters = { spbMessageArray: [], ngsildMessageArray: [] };
+    // When the oldest still-undelivered message in each buffer arrived.
+    this.pendingSince = { spbMessageArray: null, ngsildMessageArray: null };
     this.running = false;
+    this.flushing = false;
     this.flushTimer = null;
-    this.maxBufferedMessages = (config.mqtt.kafka && config.mqtt.kafka.maxBufferedMessages) ||
-      DEFAULT_MAX_BUFFERED_MESSAGES;
+    const kafkaConfig = config.mqtt.kafka || {};
+    this.maxBufferedMessages = kafkaConfig.maxBufferedMessages || DEFAULT_MAX_BUFFERED_MESSAGES;
+    this.maxDeliveryStallMs = kafkaConfig.maxDeliveryStallMs || DEFAULT_MAX_DELIVERY_STALL_MS;
+    // Withhold the MQTT acknowledgement until Kafka has the message. Set false
+    // to go back to acknowledging on receipt, which is faster and lossy.
+    this.awaitDelivery = kafkaConfig.awaitDelivery !== false;
     this.onFatal = onFatal || (reason => {
       this.logger.error(`Kafka aggregator cannot guarantee delivery: ${reason}`);
       process.exit(1);
@@ -131,19 +147,55 @@ class KafkaAggregator {
       return;
     }
     this.flushTimer = setTimeout(() => {
-      // The catch is what keeps the loop alive: an unexpected throw in here
-      // would otherwise break the chain and stop every future flush, silently.
-      this.flush()
-        .catch(err => this.logger.error('Unexpected error while flushing to Kafka: ' + err))
-        .then(() => this.scheduleFlush());
+      this.flushTimer = null;
+      this.runFlushCycle();
     }, this.flushIntervalMs);
+  }
+
+  runFlushCycle () {
+    this.flushing = true;
+    this.checkStall();
+    // The catch is what keeps the loop alive: an unexpected throw in here
+    // would otherwise break the chain and stop every future flush, silently.
+    this.flush()
+      .catch(err => {
+        this.logger.error('Unexpected error while flushing to Kafka: ' + err);
+        return false;
+      })
+      .then(delivered => {
+        this.flushing = false;
+        // Straight on to the next batch when there is more and the last send
+        // worked; wait a linger when it did not, so a broker outage does not
+        // become a hot retry loop.
+        if (delivered && this.hasPending()) {
+          this.runFlushCycle();
+        } else {
+          this.scheduleFlush();
+        }
+      });
+  }
+
+  // With awaitDelivery the sender is blocked on us, so waiting out the linger
+  // would add it to every single message's latency.
+  requestImmediateFlush () {
+    if (!this.running || this.flushing || this.flushTimer === null) {
+      return;
+    }
+    clearTimeout(this.flushTimer);
+    this.flushTimer = null;
+    this.runFlushCycle();
+  }
+
+  hasPending () {
+    return this.spbMessageArray.length > 0 || this.ngsildMessageArray.length > 0;
   }
 
   async flush () {
     // If config enabled for producing kafka message on SparkPlugB topic
-    await this.sendBuffer('spbMessageArray', this.config.mqtt.sparkplug.spBkafKaTopic);
+    const spb = await this.sendBuffer('spbMessageArray', this.config.mqtt.sparkplug.spBkafKaTopic);
     // If config enabled for producing kafka message on NGSI-LDSpB topic
-    await this.sendBuffer('ngsildMessageArray', this.config.mqtt.sparkplug.ngsildKafkaTopic);
+    const ngsild = await this.sendBuffer('ngsildMessageArray', this.config.mqtt.sparkplug.ngsildKafkaTopic);
+    return spb && ngsild;
   }
 
   /**
@@ -151,23 +203,33 @@ class KafkaAggregator {
    *
    * The buffer used to be cleared in the same tick the send was started, so a
    * rejected send lost the whole batch with nothing but a log line.
+   *
+   * @returns false if the send failed, so the caller can back off
    */
   async sendBuffer (bufferName, topic) {
     const messages = this[bufferName];
     if (messages.length === 0) {
-      return;
+      return true;
     }
+    const waiters = this.waiters[bufferName];
     this[bufferName] = [];
+    this.waiters[bufferName] = [];
     this.logger.debug('will now deliver Kafka message  on topic :  ' + topic + ' with ' + messages.length + ' messages');
     try {
       await this.kafkaProducer.send({ topic, messages });
     } catch (err) {
       this.logger.error('Could not send message to Kafka on topic: ' + topic + ' with error msg:  ' + err);
       // In front of whatever arrived while this batch was in flight, so a retry
-      // does not reorder the stream.
+      // does not reorder the stream. The waiters stay unresolved, which is what
+      // keeps the MQTT acknowledgement withheld.
       this[bufferName] = messages.concat(this[bufferName]);
+      this.waiters[bufferName] = waiters.concat(this.waiters[bufferName]);
       this.enforceLimit(bufferName, topic);
+      return false;
     }
+    this.pendingSince[bufferName] = this[bufferName].length === 0 ? null : Date.now();
+    waiters.forEach(resolve => resolve());
+    return true;
   }
 
   // Holding messages forever is its own silent failure: memory grows without
@@ -179,6 +241,24 @@ class KafkaAggregator {
     }
   }
 
+  // A bridge that has stopped acknowledging is not losing anything, but it is
+  // also not doing its job, and it would otherwise sit there indefinitely with
+  // a healthy pod. Restarting also ends the MQTT session, which is what makes
+  // the broker redeliver everything we never acknowledged.
+  checkStall () {
+    ['spbMessageArray', 'ngsildMessageArray'].forEach(bufferName => {
+      const since = this.pendingSince[bufferName];
+      if (since === null) {
+        return;
+      }
+      const stalled = Date.now() - since;
+      if (stalled > this.maxDeliveryStallMs) {
+        this.onFatal(`nothing delivered to Kafka for ${Math.round(stalled / 1000)}s ` +
+          `with ${this[bufferName].length} messages waiting`);
+      }
+    });
+  }
+
   stop () {
     this.running = false;
     if (this.flushTimer !== null) {
@@ -187,14 +267,32 @@ class KafkaAggregator {
     }
   }
 
+  /**
+   * @returns a promise that settles when this message is in Kafka. Callers that
+   *          do not care can ignore it; the MQTT side awaits it before
+   *          acknowledging, which is what makes a Kafka outage backpressure
+   *          rather than data loss.
+   */
   addMessage (message, topic) {
+    let bufferName = null;
     if (topic === this.config.mqtt.sparkplug.spBkafKaTopic) {
-      this.spbMessageArray.push(message);
-      this.enforceLimit('spbMessageArray', topic);
+      bufferName = 'spbMessageArray';
     } else if (topic === this.config.mqtt.sparkplug.ngsildKafkaTopic) {
-      this.ngsildMessageArray.push(message);
-      this.enforceLimit('ngsildMessageArray', topic);
+      bufferName = 'ngsildMessageArray';
+    } else {
+      return Promise.resolve();
     }
+    this[bufferName].push(message);
+    if (this.pendingSince[bufferName] === null) {
+      this.pendingSince[bufferName] = Date.now();
+    }
+    this.enforceLimit(bufferName, topic);
+    if (!this.awaitDelivery) {
+      return Promise.resolve();
+    }
+    const delivered = new Promise(resolve => this.waiters[bufferName].push(resolve));
+    this.requestImmediateFlush();
+    return delivered;
   }
 }
 
@@ -287,12 +385,17 @@ module.exports = class SparkplugHandler {
     }
   };
 
+  /**
+   * @returns a promise resolved once every message this produced is in Kafka.
+   *          The MQTT side withholds its acknowledgement until then.
+   */
   createKafakaPubData (topic, bodyMessage) {
     /** * For forwarding sparkplugB data directly without kafka metrics format
         * @param ngsildKafkaProduce is set in the config file
         *  */
     const subTopic = topic.split('/');
     const devID = subTopic[4];
+    const delivered = [];
 
     if (this.config.mqtt.sparkplug.spBKafkaProduce) {
       /* Validating each component of metric payload if they are valid or not
@@ -304,7 +407,7 @@ module.exports = class SparkplugHandler {
           const key = topic;
           const message = { key, value: JSON.stringify(kafkaMessage) };
           this.logger.debug('Selecting kafka message topic SparkplugB with spB format payload for data type: ' + subTopic[2]);
-          this.kafkaAggregator.addMessage(message, this.config.mqtt.sparkplug.spBkafKaTopic);
+          delivered.push(this.kafkaAggregator.addMessage(message, this.config.mqtt.sparkplug.spBkafKaTopic));
           return true;
         }
       });
@@ -328,27 +431,27 @@ module.exports = class SparkplugHandler {
             ngsiMappedKafkaMessage = ngsildMapper.mapSpbRelationshipToKafka(devID, kafkaMessage);
             this.logger.debug(' Mapped SpB Relationship data to NGSI-LD relationship type:  ' + JSON.stringify(ngsiMappedKafkaMessage));
             const message = { key, value: JSON.stringify(ngsiMappedKafkaMessage) };
-            this.kafkaAggregator.addMessage(message, this.config.mqtt.sparkplug.ngsildKafkaTopic);
+            delivered.push(this.kafkaAggregator.addMessage(message, this.config.mqtt.sparkplug.ngsildKafkaTopic));
           } else if (metricType === 'Property' || metricType === 'LiteralProperty') {
             ngsiMappedKafkaMessage = ngsildMapper.mapSpbPropertyToKafka(devID, kafkaMessage);
             this.logger.debug(' Mapped SpB Properties data to NGSI-LD properties type:  ' + JSON.stringify(ngsiMappedKafkaMessage));
             const message = { key, value: JSON.stringify(ngsiMappedKafkaMessage) };
-            this.kafkaAggregator.addMessage(message, this.config.mqtt.sparkplug.ngsildKafkaTopic);
+            delivered.push(this.kafkaAggregator.addMessage(message, this.config.mqtt.sparkplug.ngsildKafkaTopic));
           } else if (metricType === 'IriProperty') {
             ngsiMappedKafkaMessage = ngsildMapper.mapSpbPropertyIriToKafka(devID, kafkaMessage);
             this.logger.debug(' Mapped SpB IriProperty data to NGSI-LD IRI type:  ' + JSON.stringify(ngsiMappedKafkaMessage));
             const message = { key, value: JSON.stringify(ngsiMappedKafkaMessage) };
-            this.kafkaAggregator.addMessage(message, this.config.mqtt.sparkplug.ngsildKafkaTopic);
+            delivered.push(this.kafkaAggregator.addMessage(message, this.config.mqtt.sparkplug.ngsildKafkaTopic));
           } else if (metricType === 'JsonProperty') {
             ngsiMappedKafkaMessage = ngsildMapper.mapSpbPropertyJsonToKafka(devID, kafkaMessage);
             this.logger.debug(' Mapped SpB JsonProperty data to NGSI-LD IRI type:  ' + JSON.stringify(ngsiMappedKafkaMessage));
             const message = { key, value: JSON.stringify(ngsiMappedKafkaMessage) };
-            this.kafkaAggregator.addMessage(message, this.config.mqtt.sparkplug.ngsildKafkaTopic);
+            delivered.push(this.kafkaAggregator.addMessage(message, this.config.mqtt.sparkplug.ngsildKafkaTopic));
           } else if (metricType === 'ListProperty') {
             ngsiMappedKafkaMessage = ngsildMapper.mapSpbPropertyListToKafka(devID, kafkaMessage);
             this.logger.debug(' Mapped SpB ListProperty data to NGSI-LD IRI type:  ' + JSON.stringify(ngsiMappedKafkaMessage));
             const message = { key, value: JSON.stringify(ngsiMappedKafkaMessage) };
-            this.kafkaAggregator.addMessage(message, this.config.mqtt.sparkplug.ngsildKafkaTopic);
+            delivered.push(this.kafkaAggregator.addMessage(message, this.config.mqtt.sparkplug.ngsildKafkaTopic));
           } else {
             this.logger.debug(' Unable to create kafka message topic for SpBNGSI-LD topic for Metric Name: ' + kafkaMessage.name + " ,doesn't match NGSI-LD Name type: ");
           }
@@ -356,20 +459,28 @@ module.exports = class SparkplugHandler {
         }
       });
     }
+    return Promise.all(delivered);
   };
 
+  /**
+   * @returns a promise resolved once everything this message produced is in
+   *          Kafka. The broker's acknowledgement waits on it, so every path
+   *          that forwards nothing has to resolve rather than return undefined
+   *          -- a path that never settles would wedge the MQTT queue.
+   */
   processDataIngestion (topic, message) {
     /*  It will be checked if the ttl exist, if it exits the package need to be discarded
         */
     const subTopic = topic.split('/');
     if (subTopic[2] !== 'DDATA') {
-      return;
+      return Promise.resolve();
     }
     this.logger.debug('Data Submission Detected : ' + topic + ' Message: ' + JSON.stringify(message));
     if (Object.values(MESSAGE_TYPE.WITHSEQ).includes(subTopic[2])) {
       const validationResult = this.validator.validate(message, dataSchema.SPARKPLUGB);
       if (validationResult.errors.length > 0) {
         this.logger.warn('Schema rejected message! Message will be discarded: ' + JSON.stringify(message) + ' with validation result: ' + validationResult);
+        return Promise.resolve();
       } else {
         /* Validating SpB seq number if it is alligned with previous or not
             *  To Do: If seq number is incorrect, send command to device for resend Birth Message
@@ -385,12 +496,12 @@ module.exports = class SparkplugHandler {
           this.logger.warn('Invalid SpB Sequance number, still moving forward to create Kafka pub data ' + err);
           //        return null;
         });
-        this.createKafakaPubData(topic, message);
-        return true;
+        return this.createKafakaPubData(topic, message);
       }
     } else {
       this.logger.warn('Invalid SparkplugB topic');
     }
+    return Promise.resolve();
   };
 
   connectTopics (context, callback) {

--- a/KafkaBridge/mqttBridge/sparkplug_data_ingestion.js
+++ b/KafkaBridge/mqttBridge/sparkplug_data_ingestion.js
@@ -51,13 +51,31 @@ const RoundRobinPartitioner = () => {
   };
 };
 
+// Bound on how many messages the bridge will hold while Kafka is unavailable.
+// Reaching it is a hard failure rather than a drop -- see enforceLimit.
+const DEFAULT_MAX_BUFFERED_MESSAGES = 50000;
+
 // @brief Aggregates messages for periodic executed Kafka producer
 class KafkaAggregator {
-  constructor (config) {
+  /**
+   * @param config
+   * @param onFatal called when the bridge can no longer guarantee delivery.
+   *        app.js routes this into MqttHealth so it removes /tmp/healthy and
+   *        exits, the same way a dead consumer or a dead broker connection does.
+   */
+  constructor (config, onFatal) {
     this.logger = new Logger(config);
     this.config = config;
     this.spbMessageArray = [];
     this.ngsildMessageArray = [];
+    this.running = false;
+    this.flushTimer = null;
+    this.maxBufferedMessages = (config.mqtt.kafka && config.mqtt.kafka.maxBufferedMessages) ||
+      DEFAULT_MAX_BUFFERED_MESSAGES;
+    this.onFatal = onFatal || (reason => {
+      this.logger.error(`Kafka aggregator cannot guarantee delivery: ${reason}`);
+      process.exit(1);
+    });
     try {
       const kafka = new Kafka({
         logLevel: logLevel.INFO,
@@ -69,84 +87,131 @@ class KafkaAggregator {
           retries: config.mqtt.kafka.retries
         }
       });
+      // idempotent pins maxInFlightRequests to 1 and acks to -1. Without it a
+      // retried batch can be appended after the batch behind it, and since these
+      // messages carry no explicit timestamp the record timestamp is assigned on
+      // append -- so a reordered retry makes a stale value win the
+      // ROW_NUMBER() ... ORDER BY ts DESC dedup that reads this topic.
+      const producerOptions = { idempotent: true };
       if (config.mqtt.kafka.partitioner === 'roundRobinPartitioner') {
-        this.kafkaProducer = kafka.producer({ createPartitioner: RoundRobinPartitioner });
+        producerOptions.createPartitioner = RoundRobinPartitioner;
+        this.kafkaProducer = kafka.producer(producerOptions);
         this.logger.info('Round Robin partitioner enforced');
       } else {
-        this.kafkaProducer = kafka.producer({ createPartitioner: Partitioners.DefaultPartitioner });
+        producerOptions.createPartitioner = Partitioners.DefaultPartitioner;
+        this.kafkaProducer = kafka.producer(producerOptions);
         this.logger.info('Default partitioner is used');
       }
       const { CONNECT, DISCONNECT } = this.kafkaProducer.events;
       this.kafkaProducer.on(DISCONNECT, e => {
         this.logger.warn(`SparkplugB Metric producer disconnected!: ${e.timestamp}`);
-        this.kafkaProducer.connect();
+        this.kafkaProducer.connect().catch(err =>
+          this.logger.error('Could not reconnect Kafka producer: ' + err));
       });
       this.kafkaProducer.on(CONNECT, e => this.logger.info('Kafka SparkplugB metric producer connected: ' + e));
-      this.kafkaProducer.connect();
+      this.kafkaProducer.connect().catch(err =>
+        this.logger.error('Could not connect Kafka producer: ' + err));
     } catch (e) {
       this.logger.error('Exception occured while creating Kafka SparkplugB Producer: ' + e);
     }
   }
 
   start (timer) {
-    this.intervalObj = setInterval(() => {
-      if (this.spbMessageArray.length === 0 && this.ngsildMessageArray.length === 0) {
-        return;
-      }
-      let spbKafkaPayloads, ngsildKafkaPayloads;
-      // If config enabled for producing kafka message on SparkPlugB topic
-      if (this.spbMessageArray.length !== 0) {
-        spbKafkaPayloads = {
-          topic: this.config.mqtt.sparkplug.spBkafKaTopic,
-          messages: this.spbMessageArray
-        };
-        this.logger.info('will now deliver Kafka message  on topic :  ' + spbKafkaPayloads.topic + ' with message: ' + JSON.stringify(spbKafkaPayloads));
-        this.kafkaProducer.send(spbKafkaPayloads)
-          .catch((err) => {
-            return this.logger.error('Could not send message to Kafka on topic: ' + spbKafkaPayloads.topic + ' with error msg:  ' + err);
-          }
-          );
-      }
-      // If config enabled for producing kafka message on NGSI-LDSpB topic
-      if (this.ngsildMessageArray.length !== 0) {
-        ngsildKafkaPayloads = {
-          topic: this.config.mqtt.sparkplug.ngsildKafkaTopic,
-          messages: this.ngsildMessageArray
-        };
-        this.logger.debug('will now deliver Kafka message  on topic :  ' + ngsildKafkaPayloads.topic + ' with message:  ' + JSON.stringify(ngsildKafkaPayloads));
-        this.kafkaProducer.send(ngsildKafkaPayloads)
-          .catch((err) => {
-            return this.logger.error('Could not send message to Kafka on topic: ' + ngsildKafkaPayloads.topic + ' with error msg:  ' + err);
-          }
-          );
-      }
-      this.spbMessageArray = [];
-      this.ngsildMessageArray = [];
-    }, timer);
+    this.running = true;
+    this.flushIntervalMs = timer;
+    this.scheduleFlush();
+  }
+
+  // Self-scheduling rather than setInterval: the previous flush has to settle
+  // before the next one starts. With setInterval a send that took its full
+  // requestTimeout piled up hundreds of concurrent flushes behind it, and the
+  // buffer below could never bound anything because nothing waited for it.
+  scheduleFlush () {
+    if (!this.running) {
+      return;
+    }
+    this.flushTimer = setTimeout(() => {
+      // The catch is what keeps the loop alive: an unexpected throw in here
+      // would otherwise break the chain and stop every future flush, silently.
+      this.flush()
+        .catch(err => this.logger.error('Unexpected error while flushing to Kafka: ' + err))
+        .then(() => this.scheduleFlush());
+    }, this.flushIntervalMs);
+  }
+
+  async flush () {
+    // If config enabled for producing kafka message on SparkPlugB topic
+    await this.sendBuffer('spbMessageArray', this.config.mqtt.sparkplug.spBkafKaTopic);
+    // If config enabled for producing kafka message on NGSI-LDSpB topic
+    await this.sendBuffer('ngsildMessageArray', this.config.mqtt.sparkplug.ngsildKafkaTopic);
+  }
+
+  /**
+   * Send one buffer, and keep its messages if the send fails.
+   *
+   * The buffer used to be cleared in the same tick the send was started, so a
+   * rejected send lost the whole batch with nothing but a log line.
+   */
+  async sendBuffer (bufferName, topic) {
+    const messages = this[bufferName];
+    if (messages.length === 0) {
+      return;
+    }
+    this[bufferName] = [];
+    this.logger.debug('will now deliver Kafka message  on topic :  ' + topic + ' with ' + messages.length + ' messages');
+    try {
+      await this.kafkaProducer.send({ topic, messages });
+    } catch (err) {
+      this.logger.error('Could not send message to Kafka on topic: ' + topic + ' with error msg:  ' + err);
+      // In front of whatever arrived while this batch was in flight, so a retry
+      // does not reorder the stream.
+      this[bufferName] = messages.concat(this[bufferName]);
+      this.enforceLimit(bufferName, topic);
+    }
+  }
+
+  // Holding messages forever is its own silent failure: memory grows without
+  // bound and nothing observes it. Past the cap, say so and let the pod restart.
+  enforceLimit (bufferName, topic) {
+    if (this[bufferName].length > this.maxBufferedMessages) {
+      this.onFatal(`Kafka unreachable and ${this[bufferName].length} messages are buffered for ${topic} ` +
+        `(limit ${this.maxBufferedMessages}); undelivered messages will be lost`);
+    }
   }
 
   stop () {
-    clearInterval(this.intervalObj);
+    this.running = false;
+    if (this.flushTimer !== null) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
   }
 
   addMessage (message, topic) {
     if (topic === this.config.mqtt.sparkplug.spBkafKaTopic) {
       this.spbMessageArray.push(message);
+      this.enforceLimit('spbMessageArray', topic);
     } else if (topic === this.config.mqtt.sparkplug.ngsildKafkaTopic) {
       this.ngsildMessageArray.push(message);
+      this.enforceLimit('ngsildMessageArray', topic);
     }
   }
 }
 
 module.exports = class SparkplugHandler {
-  constructor (config) {
+  /**
+   * @param config
+   * @param onFatal called when delivery to Kafka can no longer be guaranteed,
+   *        so the caller can fail the pod rather than drop measurements quietly.
+   */
+  constructor (config, onFatal) {
     const logger = new Logger(config);
     this.topics_subscribe = config.mqtt.sparkplug.topics.subscribe;
     this.topics_publish = config.mqtt.sparkplug.topics.publish;
 
     const validator = new Validator();
     const cache = new Cache(config);
-    this.kafkaAggregator = new KafkaAggregator(config);
+    this.kafkaAggregator = new KafkaAggregator(config, onFatal);
     this.kafkaAggregator.start(config.mqtt.kafka.linger);
 
     this.logger = logger;

--- a/KafkaBridge/ngsildUpdates/app.js
+++ b/KafkaBridge/ngsildUpdates/app.js
@@ -18,10 +18,10 @@
 const GROUPID = 'statekafkabridge';
 const CLIENTID = 'statekafkaclient';
 const { Kafka } = require('kafkajs');
-const fs = require('fs');
 const config = require('../config/config.json');
 const State = require('../lib/ngsildUpdates.js');
 const Logger = require('../lib/logger.js');
+const KafkaHealth = require('../lib/kafkaHealth.js');
 
 const state = new State(config);
 const logger = new Logger(config);
@@ -34,6 +34,7 @@ const kafka = new Kafka({
 const consumer = kafka.consumer({ groupId: GROUPID, allowAutoTopicCreation: false });
 
 const startListener = async function () {
+  const health = new KafkaHealth(consumer, logger);
   await consumer.connect();
   await consumer.subscribe({ topic: config.ngsildUpdates.topic, fromBeginning: false });
 
@@ -46,7 +47,13 @@ const startListener = async function () {
         logger.error('could not process message: ' + e);
       }
     }
-  }).catch(e => logger.error(`[StateUpdater/consumer] ${e.message}`, e));
+  }).catch(e => {
+    // Rethrow: a consumer.run() that rejects leaves the bridge with no message
+    // loop at all, and swallowing it here let startup continue on to declare
+    // the pod ready.
+    logger.error(`[StateUpdater/consumer] ${e.message}`, e);
+    throw e;
+  });
 
   const errorTypes = ['unhandledRejection', 'uncaughtException'];
   const signalTraps = ['SIGTERM', 'SIGINT', 'SIGUSR2'];
@@ -56,8 +63,12 @@ const startListener = async function () {
       try {
         console.log(`process.on ${type}`);
         console.error(e);
+        health.shutdown();
         await consumer.disconnect();
-        process.exit(0);
+        // Non-zero: this path is only reached on an unhandled error, and
+        // exiting 0 made a crash-looping bridge indistinguishable from a clean
+        // stop in kubectl and in any exit-code based alerting.
+        process.exit(1);
       } catch (_) {
         process.exit(1);
       }
@@ -66,14 +77,14 @@ const startListener = async function () {
   signalTraps.map(type =>
     process.once(type, async () => {
       try {
+        health.shutdown();
         await consumer.disconnect();
       } finally {
         process.kill(process.pid, type);
       }
     }));
   try {
-    fs.writeFileSync('/tmp/ready', 'ready');
-    fs.writeFileSync('/tmp/healthy', 'healthy');
+    health.start();
   } catch (err) {
     logger.error(err);
   }

--- a/KafkaBridge/test/lib_healthStateTest.js
+++ b/KafkaBridge/test/lib_healthStateTest.js
@@ -62,6 +62,22 @@ describe('Test HealthState', function () {
       'readiness is left alone: the pod is going away, not being taken out of service');
   });
 
+  // serving() exists so the MQTT bridge can join its Service before its own
+  // input works -- EMQX's auth callbacks arrive over that Service, so gating it
+  // on the subscription deadlocks the subscription.
+  it('Should write only the ready file on serving, leaving liveness unclaimed', function () {
+    const files = tmpFiles('serving');
+    const state = new HealthState(fakeLogger(),
+      Object.assign({ exit: () => {} }, files));
+    state.serving();
+    assert.isTrue(fs.existsSync(files.readyFile), 'the Service may route to it');
+    assert.isFalse(fs.existsSync(files.healthyFile),
+      'liveness must stay unclaimed until the input is proven, or never subscribing looks healthy');
+
+    state.up();
+    assert.isTrue(fs.existsSync(files.healthyFile), 'up() still claims both');
+  });
+
   it('Should not complain that the healthy file is missing when it never became healthy', function () {
     const files = tmpFiles('never-up');
     const logger = fakeLogger();

--- a/KafkaBridge/test/lib_healthStateTest.js
+++ b/KafkaBridge/test/lib_healthStateTest.js
@@ -1,0 +1,123 @@
+/**
+* Copyright (c) 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* global describe it */
+'use strict';
+
+const chai = require('chai');
+const assert = chai.assert;
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const HealthState = require('../lib/healthState.js');
+
+const fakeLogger = function () {
+  const errors = [];
+  return {
+    errors,
+    error: function (msg) { errors.push(msg); },
+    info: function () {},
+    debug: function () {},
+    warn: function () {}
+  };
+};
+
+const tmpFiles = function (name) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `healthstate-${name}-`));
+  return {
+    dir,
+    readyFile: path.join(dir, 'ready'),
+    healthyFile: path.join(dir, 'healthy')
+  };
+};
+
+describe('Test HealthState', function () {
+  it('Should write both files on up and remove only the healthy one on fail', function () {
+    const files = tmpFiles('updown');
+    const exits = [];
+    const state = new HealthState(fakeLogger(),
+      Object.assign({ exit: code => exits.push(code) }, files));
+    state.up();
+    assert.isTrue(fs.existsSync(files.readyFile));
+    assert.isTrue(fs.existsSync(files.healthyFile));
+
+    state.fail('because');
+
+    assert.deepEqual(exits, [1]);
+    assert.isFalse(fs.existsSync(files.healthyFile), 'liveness must fail');
+    assert.isTrue(fs.existsSync(files.readyFile),
+      'readiness is left alone: the pod is going away, not being taken out of service');
+  });
+
+  it('Should not complain that the healthy file is missing when it never became healthy', function () {
+    const files = tmpFiles('never-up');
+    const logger = fakeLogger();
+    const state = new HealthState(logger, Object.assign({ exit: () => {} }, files));
+    // No up() first -- this is the normal startup-failure path.
+    state.fail('failed before ever being ready');
+    assert.equal(logger.errors.length, 1, 'the failure itself, and no noise about a missing file');
+    assert.include(logger.errors[0], 'failed before ever being ready');
+  });
+
+  it('Should report a healthy file it genuinely cannot remove', function () {
+    const files = tmpFiles('unremovable');
+    const logger = fakeLogger();
+    // A directory where the file should be: unlink refuses with something that
+    // is not ENOENT, which is worth saying out loud.
+    fs.mkdirSync(files.healthyFile);
+    const state = new HealthState(logger, Object.assign({ exit: () => {} }, files));
+    state.fail('some reason');
+    assert.equal(logger.errors.length, 2);
+    assert.include(logger.errors[1], 'Could not remove');
+  });
+
+  it('Should run cleanups on fail and on shutdown', function () {
+    ['fail', 'shutdown'].forEach(function (method) {
+      const files = tmpFiles('cleanup-' + method);
+      const state = new HealthState(fakeLogger(), Object.assign({ exit: () => {} }, files));
+      let cleaned = 0;
+      state.addCleanup(() => { cleaned += 1; });
+      state.addCleanup(() => { cleaned += 1; });
+      state[method]('reason');
+      assert.equal(cleaned, 2, `${method} must stop the timers it was given`);
+    });
+  });
+
+  it('Should report only the first failure', function () {
+    const files = tmpFiles('once');
+    const logger = fakeLogger();
+    const exits = [];
+    const state = new HealthState(logger, Object.assign({ exit: code => exits.push(code) }, files));
+    state.up();
+    state.fail('first');
+    state.fail('second');
+    assert.deepEqual(exits, [1]);
+    assert.equal(logger.errors.length, 1);
+    assert.include(logger.errors[0], 'first');
+  });
+
+  it('Should stay quiet when a shutdown is followed by a failure report', function () {
+    const files = tmpFiles('shutdown-first');
+    const logger = fakeLogger();
+    const exits = [];
+    const state = new HealthState(logger, Object.assign({ exit: code => exits.push(code) }, files));
+    state.up();
+    state.shutdown();
+    state.fail('disconnect during SIGTERM');
+    assert.deepEqual(exits, [], 'a graceful stop must not be reported as a crash');
+    assert.deepEqual(logger.errors, []);
+  });
+});

--- a/KafkaBridge/test/lib_kafkaHealthTest.js
+++ b/KafkaBridge/test/lib_kafkaHealthTest.js
@@ -180,4 +180,27 @@ describe('Test KafkaHealth', function () {
     consumer.emit(EVENTS.DISCONNECT);
     assert.deepEqual(exits, [1], 'the cascade of stop/disconnect is one failure');
   });
+  it('Should survive a crash event that carries no payload', function () {
+    const files = tmpFiles('nopayload');
+    const consumer = fakeConsumer();
+    const logger = fakeLogger();
+    const exits = [];
+    const health = new KafkaHealth(consumer, logger,
+      Object.assign({ exit: code => exits.push(code) }, files));
+    health.start();
+    // kafkajs normally supplies one, but a malformed event must not turn into a
+    // TypeError inside the very handler that is supposed to report failures.
+    consumer.emit(consumer.events.CRASH, undefined);
+    assert.deepEqual(exits, [1]);
+  });
+
+  it('Should work without any options, which is how the bridges construct it', function () {
+    const consumer = fakeConsumer();
+    // No options at all: the real bridges pass only consumer and logger, so the
+    // default file names and windows have to hold up.
+    const health = new KafkaHealth(consumer, fakeLogger());
+    assert.isFunction(health.start);
+    assert.isFunction(health.shutdown);
+    health.shutdown();
+  });
 });

--- a/KafkaBridge/test/lib_kafkaHealthTest.js
+++ b/KafkaBridge/test/lib_kafkaHealthTest.js
@@ -1,0 +1,183 @@
+/**
+* Copyright (c) 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* global describe it */
+'use strict';
+
+const chai = require('chai');
+const assert = chai.assert;
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const KafkaHealth = require('../lib/kafkaHealth.js');
+
+const EVENTS = {
+  HEARTBEAT: 'consumer.heartbeat',
+  FETCH: 'consumer.fetch',
+  END_BATCH_PROCESS: 'consumer.end_batch_process',
+  COMMIT_OFFSETS: 'consumer.commit_offsets',
+  GROUP_JOIN: 'consumer.group_join',
+  CRASH: 'consumer.crash',
+  STOP: 'consumer.stop',
+  DISCONNECT: 'consumer.disconnect'
+};
+
+// Minimal stand-in for a kafkajs consumer: just the event surface KafkaHealth
+// subscribes to, plus a way for the test to fire those events.
+const fakeConsumer = function () {
+  const handlers = {};
+  return {
+    events: EVENTS,
+    on: function (event, handler) {
+      if (handlers[event] === undefined) {
+        handlers[event] = [];
+      }
+      handlers[event].push(handler);
+    },
+    emit: function (event, payload) {
+      (handlers[event] || []).forEach(h => h({ payload }));
+    }
+  };
+};
+
+const fakeLogger = function () {
+  const errors = [];
+  return {
+    errors,
+    error: function (msg) { errors.push(msg); },
+    info: function () {},
+    debug: function () {},
+    warn: function () {}
+  };
+};
+
+const tmpFiles = function (name) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `kafkahealth-${name}-`));
+  return {
+    readyFile: path.join(dir, 'ready'),
+    healthyFile: path.join(dir, 'healthy')
+  };
+};
+
+describe('Test KafkaHealth', function () {
+  it('Should write ready and healthy files on start', function () {
+    const files = tmpFiles('start');
+    const health = new KafkaHealth(fakeConsumer(), fakeLogger(), files);
+    health.start();
+    assert.equal(fs.readFileSync(files.readyFile, 'utf8'), 'ready');
+    assert.equal(fs.readFileSync(files.healthyFile, 'utf8'), 'healthy');
+    health.shutdown();
+  });
+
+  it('Should exit non-zero and remove the healthy file when the consumer crashes for good', function () {
+    const files = tmpFiles('crash');
+    const consumer = fakeConsumer();
+    const logger = fakeLogger();
+    const exits = [];
+    const health = new KafkaHealth(consumer, logger,
+      Object.assign({ exit: code => exits.push(code) }, files));
+    health.start();
+
+    consumer.emit(EVENTS.CRASH, { error: 'boom', restart: false });
+
+    assert.deepEqual(exits, [1]);
+    assert.isFalse(fs.existsSync(files.healthyFile), 'healthy file should be gone');
+    assert.equal(logger.errors.length, 1);
+    assert.include(logger.errors[0], 'boom');
+  });
+
+  it('Should stay alive when kafkajs says it will restart the consumer', function () {
+    const files = tmpFiles('restart');
+    const consumer = fakeConsumer();
+    const logger = fakeLogger();
+    const exits = [];
+    const health = new KafkaHealth(consumer, logger,
+      Object.assign({ exit: code => exits.push(code) }, files));
+    health.start();
+
+    consumer.emit(EVENTS.CRASH, { error: 'transient', restart: true });
+
+    assert.deepEqual(exits, [], 'a self-healing crash must not kill the process');
+    assert.isTrue(fs.existsSync(files.healthyFile));
+    assert.include(logger.errors[0], 'transient');
+    health.shutdown();
+  });
+
+  it('Should exit when the consumer stops or disconnects unexpectedly', function () {
+    [EVENTS.STOP, EVENTS.DISCONNECT].forEach(function (event) {
+      const files = tmpFiles('stop');
+      const consumer = fakeConsumer();
+      const exits = [];
+      const health = new KafkaHealth(consumer, fakeLogger(),
+        Object.assign({ exit: code => exits.push(code) }, files));
+      health.start();
+      consumer.emit(event);
+      assert.deepEqual(exits, [1], `${event} should force a restart`);
+      assert.isFalse(fs.existsSync(files.healthyFile));
+    });
+  });
+
+  it('Should not report a failure when the stop is a graceful shutdown', function () {
+    const files = tmpFiles('graceful');
+    const consumer = fakeConsumer();
+    const exits = [];
+    const health = new KafkaHealth(consumer, fakeLogger(),
+      Object.assign({ exit: code => exits.push(code) }, files));
+    health.start();
+
+    health.shutdown();
+    consumer.emit(EVENTS.STOP);
+    consumer.emit(EVENTS.DISCONNECT);
+
+    assert.deepEqual(exits, [], 'SIGTERM must not look like a crash');
+    assert.isTrue(fs.existsSync(files.healthyFile));
+  });
+
+  it('Should exit when the consumer loop goes quiet, and not before', function (done) {
+    const files = tmpFiles('watchdog');
+    const consumer = fakeConsumer();
+    const exits = [];
+    const health = new KafkaHealth(consumer, fakeLogger(),
+      Object.assign({ staleAfterMs: 40, checkIntervalMs: 10, exit: code => exits.push(code) }, files));
+    health.start();
+
+    // Keep the loop ticking across more than one staleness window: a bridge on
+    // an idle topic still emits FETCH, and must not be restarted for it.
+    const keepAlive = setInterval(() => consumer.emit(EVENTS.FETCH), 10);
+    setTimeout(function () {
+      assert.deepEqual(exits, [], 'an idle but live consumer must not be restarted');
+      clearInterval(keepAlive);
+      // Now let it go silent.
+      setTimeout(function () {
+        assert.deepEqual(exits, [1]);
+        assert.isFalse(fs.existsSync(files.healthyFile));
+        done();
+      }, 90);
+    }, 100);
+  });
+
+  it('Should report a stopped consumer only once', function () {
+    const files = tmpFiles('once');
+    const consumer = fakeConsumer();
+    const exits = [];
+    const health = new KafkaHealth(consumer, fakeLogger(),
+      Object.assign({ exit: code => exits.push(code) }, files));
+    health.start();
+    consumer.emit(EVENTS.STOP);
+    consumer.emit(EVENTS.DISCONNECT);
+    assert.deepEqual(exits, [1], 'the cascade of stop/disconnect is one failure');
+  });
+});

--- a/KafkaBridge/test/lib_mqtt-connector_connectorTests.js
+++ b/KafkaBridge/test/lib_mqtt-connector_connectorTests.js
@@ -657,4 +657,35 @@ describe(fileToTest, function () {
     };
     myBroker.publish(myTopic, myMessage, {}, callback);
   });
+  it('Shall report a failed subscription through the callback', function (done) {
+    toTest.__set__('mqtt', mqtt);
+    const config = {
+      host: 'myHosttest',
+      port: 9090909,
+      secure: false,
+      retries: 2
+    };
+    const client = new mqtt.MqttClient();
+    client.on = function () {};
+    const myBroker = toTest.singleton(config, logger);
+    myBroker.pingActivate = false;
+    mqtt.connect = function () {
+      client.connected = true;
+      return client;
+    };
+    // A refused SUBSCRIBE used to throw out of this callback, which surfaced as
+    // an uncaughtException naming no topic and left callers believing they were
+    // subscribed. It has to come back as an error instead.
+    client.subscribe = function (vtopic, option, cb) {
+      cb(new Error('not authorized'), null);
+    };
+    myBroker.connect(function (err) {
+      assert.isNull(err, 'None error shall returned');
+      myBroker.bind('dev/+/act', function () {}, null, function (bindErr) {
+        assert.instanceOf(bindErr, Error, 'The subscribe error shall reach the caller');
+        assert.equal(bindErr.message, 'not authorized');
+        done();
+      });
+    });
+  });
 });

--- a/KafkaBridge/test/lib_mqtt-connector_connectorTests.js
+++ b/KafkaBridge/test/lib_mqtt-connector_connectorTests.js
@@ -19,6 +19,14 @@ const rewire = require('rewire');
 
 const fileToTest = '../lib/mqtt_connector';
 
+// mqtt.js calls handleMessage for every incoming PUBLISH and only sends the
+// PUBACK once its callback fires. The connector dispatches from there so it can
+// hold the acknowledgement until the message has been forwarded, so that is
+// what these tests have to drive.
+const deliver = function (client, topic, payload, cb) {
+  client.handleMessage({ topic, payload }, cb || function () {});
+};
+
 describe(fileToTest, function () {
   const toTest = rewire(fileToTest);
 
@@ -283,12 +291,7 @@ describe(fileToTest, function () {
     const myBroker = toTest.singleton(config, logger);
     const client = new mqtt.MqttClient();
     myBroker.pingActivate = false;
-    let callHandler = null;
-    client.on = function (event, handler) {
-      assert.isFunction(handler, 'The handle shall be a function');
-      assert.isString(event, 'The event shall be string');
-      callHandler = handler;
-    };
+    client.on = function () {};
 
     mqtt.connect = function () {
       client.connected = true;
@@ -297,7 +300,7 @@ describe(fileToTest, function () {
 
     myBroker.connect(function (err) {
       assert.isNull(err, 'None error shall returned');
-      callHandler('conmector', JSON.stringify(msg));
+      deliver(client, 'conmector', JSON.stringify(msg));
       done();
     });
   });
@@ -315,15 +318,9 @@ describe(fileToTest, function () {
       a: 1,
       c: 2
     };
-    let callHandler = null;
     const client = new mqtt.MqttClient();
 
-    client.on = function (event, handler) {
-      assert.isFunction(handler, 'The handle shall be a function');
-      assert.isString(event, 'The event shall be string');
-      // assert.equal(event, "message", "Invalid event listeneter");
-      callHandler = handler;
-    };
+    client.on = function () {};
 
     const myBroker = toTest.singleton(config, logger);
     myBroker.pingActivate = false;
@@ -345,7 +342,7 @@ describe(fileToTest, function () {
     myBroker.connect(function (err) {
       assert.isNull(err, 'None error shall returned');
       myBroker.bind(topicPattern, topicHandler);
-      callHandler('dev/' + id + '/act', JSON.stringify(msg));
+      deliver(client, 'dev/' + id + '/act', JSON.stringify(msg));
     });
   });
   it('Shall Listen to on Message > discard improper message format >', function (done) {
@@ -357,13 +354,8 @@ describe(fileToTest, function () {
       retries: 2
     };
     const id = '0a-03-12-22';
-    let callHandler = null;
     const client = new mqtt.MqttClient();
-    client.on = function (event, handler) {
-      assert.isFunction(handler, 'The handle shall be a function');
-      assert.isString(event, 'The event shall be string');
-      callHandler = handler;
-    };
+    client.on = function () {};
     const crd = {
       username: 'TuUser',
       password: 'tuPassword'
@@ -387,7 +379,7 @@ describe(fileToTest, function () {
     myBroker.connect(function (err) {
       assert.isNull(err, 'None error shall returned');
       myBroker.bind(topicPattern, topicHandler);
-      callHandler('dev/' + id + '/act', 'pepep');
+      deliver(client, 'dev/' + id + '/act', 'pepep');
       // myBroker.onMessage(realTopic, msg);
       done();
     });
@@ -406,13 +398,8 @@ describe(fileToTest, function () {
       a: 1,
       c: 2
     };
-    let callHandler = null;
     const client = new mqtt.MqttClient();
-    client.on = function (event, handler) {
-      assert.isFunction(handler, 'The handle shall be a function');
-      assert.isString(event, 'The event shall be string');
-      callHandler = handler;
-    };
+    client.on = function () {};
 
     const myBroker = toTest.singleton(config, logger);
     myBroker.pingActivate = false;
@@ -434,7 +421,7 @@ describe(fileToTest, function () {
     myBroker.connect(function (err) {
       assert.isNull(err, 'None error shall returned');
       myBroker.bind(topicPattern, topicHandler, null, function () {
-        callHandler('dev/' + id + '/act', JSON.stringify(msg));
+        deliver(client, 'dev/' + id + '/act', JSON.stringify(msg));
       });
       // myBroker.onMessage(realTopic, msg);
     });
@@ -684,6 +671,73 @@ describe(fileToTest, function () {
       myBroker.bind('dev/+/act', function () {}, null, function (bindErr) {
         assert.instanceOf(bindErr, Error, 'The subscribe error shall reach the caller');
         assert.equal(bindErr.message, 'not authorized');
+        done();
+      });
+    });
+  });
+  it('Shall withhold the acknowledgement until the handler has forwarded the message', function (done) {
+    toTest.__set__('mqtt', mqtt);
+    const config = { host: 'myHosttest', port: 9090909, secure: false, retries: 2 };
+    const client = new mqtt.MqttClient();
+    client.on = function () {};
+    const myBroker = toTest.singleton(config, logger);
+    myBroker.pingActivate = false;
+    mqtt.connect = function () {
+      client.connected = true;
+      return client;
+    };
+    client.subscribe = function (vtopic, option, cb) {
+      cb(null, [{ topic: vtopic }]);
+    };
+
+    // The handler stays unfinished until the test lets it finish, standing in
+    // for a Kafka send that has not been acknowledged yet.
+    let finishForwarding = null;
+    const topicHandler = function () {
+      return new Promise(resolve => { finishForwarding = resolve; });
+    };
+
+    myBroker.connect(function (err) {
+      assert.isNull(err, 'None error shall returned');
+      myBroker.bind('dev/+/act', topicHandler);
+      let acknowledged = false;
+      deliver(client, 'dev/1/act', JSON.stringify({ a: 1 }), function () {
+        acknowledged = true;
+      });
+      setTimeout(function () {
+        assert.isFalse(acknowledged,
+          'acknowledging before the message is forwarded is what loses messages on a Kafka outage');
+        finishForwarding();
+        setTimeout(function () {
+          assert.isTrue(acknowledged, 'the message must be acknowledged once it is safely forwarded');
+          done();
+        }, 5);
+      }, 20);
+    });
+  });
+
+  it('Shall acknowledge a malformed payload rather than wedge the queue', function (done) {
+    toTest.__set__('mqtt', mqtt);
+    const config = { host: 'myHosttest', port: 9090909, secure: false, retries: 2 };
+    const client = new mqtt.MqttClient();
+    client.on = function () {};
+    const myBroker = toTest.singleton(config, logger);
+    myBroker.pingActivate = false;
+    mqtt.connect = function () {
+      client.connected = true;
+      return client;
+    };
+    client.subscribe = function (vtopic, option, cb) {
+      cb(null, [{ topic: vtopic }]);
+    };
+    myBroker.connect(function (err) {
+      assert.isNull(err, 'None error shall returned');
+      myBroker.bind('dev/+/act', function () {
+        assert.fail('a payload that does not parse must not reach the handler');
+      });
+      // Not acknowledging this one would stop the packet queue for good, since
+      // it will never parse on redelivery either.
+      deliver(client, 'dev/1/act', 'not json', function () {
         done();
       });
     });

--- a/KafkaBridge/test/lib_mqttHealthTest.js
+++ b/KafkaBridge/test/lib_mqttHealthTest.js
@@ -1,0 +1,152 @@
+/**
+* Copyright (c) 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* global describe it */
+'use strict';
+
+const chai = require('chai');
+const assert = chai.assert;
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const MqttHealth = require('../lib/mqttHealth.js');
+
+const fakeBroker = function (connected) {
+  return {
+    state: connected,
+    connected: function () { return this.state; }
+  };
+};
+
+const fakeLogger = function () {
+  const errors = [];
+  return {
+    errors,
+    error: function (msg) { errors.push(msg); },
+    info: function () {},
+    debug: function () {},
+    warn: function () {}
+  };
+};
+
+const tmpFiles = function (name) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `mqtthealth-${name}-`));
+  return {
+    readyFile: path.join(dir, 'ready'),
+    healthyFile: path.join(dir, 'healthy')
+  };
+};
+
+describe('Test MqttHealth', function () {
+  it('Should not declare the bridge ready merely because bind was called', function () {
+    const files = tmpFiles('notready');
+    const health = new MqttHealth(fakeBroker(false), fakeLogger(),
+      Object.assign({ exit: () => {} }, files));
+    health.start();
+    assert.isFalse(fs.existsSync(files.readyFile),
+      'readiness must wait for the subscription, not for bind() to return');
+    health.shutdown();
+  });
+
+  it('Should become ready once the subscription is granted', function () {
+    const files = tmpFiles('ready');
+    const health = new MqttHealth(fakeBroker(true), fakeLogger(),
+      Object.assign({ exit: () => {} }, files));
+    health.start().ready();
+    assert.equal(fs.readFileSync(files.readyFile, 'utf8'), 'ready');
+    assert.equal(fs.readFileSync(files.healthyFile, 'utf8'), 'healthy');
+    health.shutdown();
+  });
+
+  it('Should exit when the subscription never arrives', function (done) {
+    const files = tmpFiles('deadline');
+    const logger = fakeLogger();
+    const exits = [];
+    const health = new MqttHealth(fakeBroker(false), logger,
+      Object.assign({ startupTimeoutMs: 30, exit: code => exits.push(code) }, files));
+    health.start();
+    setTimeout(function () {
+      assert.deepEqual(exits, [1]);
+      assert.include(logger.errors[0], 'not established');
+      health.shutdown();
+      done();
+    }, 70);
+  });
+
+  it('Should not fire the startup deadline once ready', function (done) {
+    const files = tmpFiles('deadline-ok');
+    const exits = [];
+    const health = new MqttHealth(fakeBroker(true), fakeLogger(),
+      Object.assign({ startupTimeoutMs: 30, checkIntervalMs: 1000, exit: code => exits.push(code) }, files));
+    health.start().ready();
+    setTimeout(function () {
+      assert.deepEqual(exits, []);
+      health.shutdown();
+      done();
+    }, 70);
+  });
+
+  it('Should tolerate a short disconnect and exit on a long one', function (done) {
+    const files = tmpFiles('flap');
+    const broker = fakeBroker(true);
+    const exits = [];
+    const health = new MqttHealth(broker, fakeLogger(),
+      Object.assign({ graceMs: 60, checkIntervalMs: 10, exit: code => exits.push(code) }, files));
+    health.start().ready();
+
+    // A blip mqtt.js repairs by itself must not restart the pod.
+    broker.state = false;
+    setTimeout(function () { broker.state = true; }, 30);
+    setTimeout(function () {
+      assert.deepEqual(exits, [], 'a reconnect within the grace window is normal');
+      assert.isTrue(fs.existsSync(files.healthyFile));
+      // Now stay down past the grace window.
+      broker.state = false;
+      setTimeout(function () {
+        assert.deepEqual(exits, [1]);
+        assert.isFalse(fs.existsSync(files.healthyFile));
+        done();
+      }, 110);
+    }, 60);
+  });
+
+  it('Should exit when the subscription fails outright', function () {
+    const files = tmpFiles('failed');
+    const logger = fakeLogger();
+    const exits = [];
+    const health = new MqttHealth(fakeBroker(false), logger,
+      Object.assign({ exit: code => exits.push(code) }, files));
+    health.start();
+    health.fail(new Error('Maximal connection tries reached'));
+    assert.deepEqual(exits, [1]);
+    assert.include(logger.errors[0], 'Maximal connection tries reached');
+  });
+
+  it('Should not report a failure when shutting down gracefully', function (done) {
+    const files = tmpFiles('graceful');
+    const broker = fakeBroker(true);
+    const exits = [];
+    const health = new MqttHealth(broker, fakeLogger(),
+      Object.assign({ graceMs: 10, checkIntervalMs: 10, exit: code => exits.push(code) }, files));
+    health.start().ready();
+    health.shutdown();
+    broker.state = false;
+    setTimeout(function () {
+      assert.deepEqual(exits, [], 'SIGTERM must not look like a broker outage');
+      done();
+    }, 60);
+  });
+});

--- a/KafkaBridge/test/lib_mqttHealthTest.js
+++ b/KafkaBridge/test/lib_mqttHealthTest.js
@@ -130,7 +130,7 @@ describe('Test MqttHealth', function () {
     const health = new MqttHealth(fakeBroker(false), logger,
       Object.assign({ exit: code => exits.push(code) }, files));
     health.start();
-    health.fail(new Error('Maximal connection tries reached'));
+    health.fatal('MQTT subscription failed: ' + new Error('Maximal connection tries reached'));
     assert.deepEqual(exits, [1]);
     assert.include(logger.errors[0], 'Maximal connection tries reached');
   });

--- a/KafkaBridge/test/lib_mqttHealthTest.js
+++ b/KafkaBridge/test/lib_mqttHealthTest.js
@@ -51,14 +51,37 @@ const tmpFiles = function (name) {
 };
 
 describe('Test MqttHealth', function () {
-  it('Should not declare the bridge ready merely because bind was called', function () {
+  it('Should claim neither probe merely because bind was called', function () {
     const files = tmpFiles('notready');
     const health = new MqttHealth(fakeBroker(false), fakeLogger(),
       Object.assign({ exit: () => {} }, files));
     health.start();
+    assert.isFalse(fs.existsSync(files.healthyFile),
+      'liveness must wait for the subscription, not for bind() to return');
     assert.isFalse(fs.existsSync(files.readyFile),
-      'readiness must wait for the subscription, not for bind() to return');
+      'readiness follows the auth API listening, which start() says nothing about');
     health.shutdown();
+  });
+
+  // Readiness is what lets EMQX reach the auth API over the mqtt-bridge
+  // Service, and the subscription cannot be authorised until it can. So
+  // serving() has to be able to run first, and must not imply liveness.
+  it('Should become ready on serving() without claiming to be healthy', function () {
+    const files = tmpFiles('serving');
+    const health = new MqttHealth(fakeBroker(false), fakeLogger(),
+      Object.assign({ exit: () => {} }, files));
+    health.start().serving();
+    assert.equal(fs.readFileSync(files.readyFile, 'utf8'), 'ready');
+    assert.isFalse(fs.existsSync(files.healthyFile),
+      'a bridge that is merely serving auth has not proven its input works');
+    health.shutdown();
+  });
+
+  it('Should still exit when the subscription never arrives after serving', function (done) {
+    const files = tmpFiles('serving-then-dead');
+    const health = new MqttHealth(fakeBroker(false), fakeLogger(),
+      Object.assign({ startupTimeoutMs: 20, exit: () => { done(); } }, files));
+    health.start().serving();
   });
 
   it('Should become ready once the subscription is granted', function () {

--- a/KafkaBridge/test/lib_mqttHealthTest.js
+++ b/KafkaBridge/test/lib_mqttHealthTest.js
@@ -149,4 +149,18 @@ describe('Test MqttHealth', function () {
       done();
     }, 60);
   });
+  it('Should ignore a second ready(), so a resubscribe does not stack watchdogs', function (done) {
+    const files = tmpFiles('twice');
+    const broker = fakeBroker(true);
+    const exits = [];
+    const health = new MqttHealth(broker, fakeLogger(),
+      Object.assign({ graceMs: 20, checkIntervalMs: 5, exit: code => exits.push(code) }, files));
+    health.start().ready().ready();
+    broker.state = false;
+    setTimeout(function () {
+      // One watchdog means one report, not one per ready() call.
+      assert.equal(exits.length, 1, 'a second ready() must not start a second watchdog');
+      done();
+    }, 60);
+  });
 });

--- a/KafkaBridge/test/mqttBridgeAppTest.js
+++ b/KafkaBridge/test/mqttBridgeAppTest.js
@@ -31,6 +31,7 @@ const stubHealth = function () {
   const health = {
     calls,
     start: function () { calls.push('start'); return health; },
+    serving: function () { calls.push('serving'); return health; },
     ready: function () { calls.push('ready'); return health; },
     fatal: function (reason) { calls.push('fatal:' + reason); },
     shutdown: function () { calls.push('shutdown'); }
@@ -74,10 +75,30 @@ describe('Test mqttBridge app wiring', function () {
       'the startup deadline must be armed first, or a broker that never answers is never noticed');
   });
 
-  it('Should not become ready until the subscription callback succeeds', async function () {
+  it('Should not become healthy until the subscription callback succeeds', async function () {
     const health = await runApp(function () {});
     assert.notInclude(health.calls, 'ready',
       'returning from bind() is not evidence of a subscription');
+  });
+
+  // The deadlock this guards against: EMQX resolves its authn/authz callbacks
+  // through the mqtt-bridge Service, and a Service drops endpoints that are not
+  // Ready. If readiness waits for the subscription, the subscription waits for
+  // an authorisation that can never arrive, and EMQX rejects every client.
+  it('Should serve the Service as soon as the auth API listens, before subscribing', async function () {
+    const health = await runApp(function () {});
+    assert.include(health.calls, 'serving',
+      'readiness must not wait for the subscription -- EMQX cannot authorise it until the pod is Ready');
+    assert.isBelow(health.calls.indexOf('serving'), health.calls.indexOf('ready') === -1
+      ? Infinity
+      : health.calls.indexOf('ready'),
+    'readiness has to be declared before the subscription is awaited');
+  });
+
+  it('Should stay ready-but-unhealthy while the subscription is still pending', async function () {
+    const health = await runApp(function () {});
+    assert.include(health.calls, 'serving', 'the auth API is up, so the Service can route to it');
+    assert.notInclude(health.calls, 'ready', 'but the input is not working yet, so liveness must not pass');
   });
 
   it('Should become ready when the subscription is granted', async function () {

--- a/KafkaBridge/test/mqttBridgeAppTest.js
+++ b/KafkaBridge/test/mqttBridgeAppTest.js
@@ -1,0 +1,95 @@
+/**
+* Copyright (c) 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* global describe it */
+'use strict';
+
+const chai = require('chai');
+const assert = chai.assert;
+const rewire = require('rewire');
+
+const toTest = rewire('../mqttBridge/app.js');
+
+// The point of these: bind() only *starts* connecting, so readiness has to come
+// from the subscription callback. config.mqtt.retries is 30000, i.e. a ~12.5h
+// connect budget, so the callback is not a fast path either -- the startup
+// deadline in mqttHealth is what actually bounds it.
+const stubHealth = function () {
+  const calls = [];
+  const health = {
+    calls,
+    start: function () { calls.push('start'); return health; },
+    ready: function () { calls.push('ready'); return health; },
+    fail: function (reason) { calls.push('fail:' + reason); },
+    shutdown: function () { calls.push('shutdown'); }
+  };
+  return health;
+};
+
+const runApp = async function (bindBehaviour) {
+  const health = stubHealth();
+  const captured = {};
+  const revert = toTest.__set__({
+    MqttHealth: function () { return health; },
+    authService: { init: async function () {} },
+    SparkplugApiData: function () {
+      return {
+        init: function () {},
+        bind: function (broker, context, callback) {
+          captured.callback = callback;
+          bindBehaviour(callback);
+        }
+      };
+    },
+    process: {
+      on: function () {},
+      once: function () {},
+      exit: function () {},
+      env: {},
+      kill: function () {}
+    }
+  });
+  const startListener = toTest.__get__('startListener');
+  await startListener();
+  revert();
+  return health;
+};
+
+describe('Test mqttBridge app wiring', function () {
+  it('Should arm the health watchdog before it can block on the broker', async function () {
+    const health = await runApp(function () {});
+    assert.equal(health.calls[0], 'start',
+      'the startup deadline must be armed first, or a broker that never answers is never noticed');
+  });
+
+  it('Should not become ready until the subscription callback succeeds', async function () {
+    const health = await runApp(function () {});
+    assert.notInclude(health.calls, 'ready',
+      'returning from bind() is not evidence of a subscription');
+  });
+
+  it('Should become ready when the subscription is granted', async function () {
+    const health = await runApp(function (callback) { callback(); });
+    assert.include(health.calls, 'ready');
+    assert.notInclude(health.calls.join(','), 'fail');
+  });
+
+  it('Should report a failure when the subscription errors', async function () {
+    const health = await runApp(function (callback) { callback(new Error('Maximal connection tries reached')); });
+    assert.include(health.calls.join(','), 'fail:');
+    assert.include(health.calls.join(','), 'Maximal connection tries reached');
+    assert.notInclude(health.calls, 'ready');
+  });
+});

--- a/KafkaBridge/test/mqttBridgeAppTest.js
+++ b/KafkaBridge/test/mqttBridgeAppTest.js
@@ -32,7 +32,7 @@ const stubHealth = function () {
     calls,
     start: function () { calls.push('start'); return health; },
     ready: function () { calls.push('ready'); return health; },
-    fail: function (reason) { calls.push('fail:' + reason); },
+    fatal: function (reason) { calls.push('fatal:' + reason); },
     shutdown: function () { calls.push('shutdown'); }
   };
   return health;
@@ -83,12 +83,12 @@ describe('Test mqttBridge app wiring', function () {
   it('Should become ready when the subscription is granted', async function () {
     const health = await runApp(function (callback) { callback(); });
     assert.include(health.calls, 'ready');
-    assert.notInclude(health.calls.join(','), 'fail');
+    assert.notInclude(health.calls.join(','), 'fatal');
   });
 
   it('Should report a failure when the subscription errors', async function () {
     const health = await runApp(function (callback) { callback(new Error('Maximal connection tries reached')); });
-    assert.include(health.calls.join(','), 'fail:');
+    assert.include(health.calls.join(','), 'fatal:');
     assert.include(health.calls.join(','), 'Maximal connection tries reached');
     assert.notInclude(health.calls, 'ready');
   });

--- a/KafkaBridge/test/mqttBridge_kafkaAggregatorTest.js
+++ b/KafkaBridge/test/mqttBridge_kafkaAggregatorTest.js
@@ -1,0 +1,201 @@
+/**
+* Copyright (c) 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+/* global describe it beforeEach */
+'use strict';
+
+const chai = require('chai');
+const assert = chai.assert;
+const rewire = require('rewire');
+
+const ToTest = rewire('../mqttBridge/sparkplug_data_ingestion.js');
+
+const SPB_TOPIC = 'sparkplugB';
+const NGSILD_TOPIC = 'iff.ngsild.attributes';
+
+const config = {
+  kafka: { brokers: ['broker:9092'] },
+  mqtt: {
+    kafka: { requestTimeout: 100, maxRetryTime: 100, retries: 1, linger: 5 },
+    sparkplug: { spBkafKaTopic: SPB_TOPIC, ngsildKafkaTopic: NGSILD_TOPIC }
+  },
+  logger: { loglevel: 'error' }
+};
+
+// A producer whose sends can be made to fail on demand, so the tests can ask
+// what happened to the messages rather than what was logged.
+const fakeProducer = function () {
+  return {
+    sent: [],
+    failing: false,
+    events: { CONNECT: 'producer.connect', DISCONNECT: 'producer.disconnect' },
+    on: function () {},
+    connect: function () { return Promise.resolve(); },
+    send: function (payload) {
+      if (this.failing) {
+        return Promise.reject(new Error('Broker not connected'));
+      }
+      this.sent.push(payload);
+      return Promise.resolve();
+    }
+  };
+};
+
+const buildAggregator = function (producer, onFatal, overrides) {
+  const KafkaAggregator = ToTest.__get__('KafkaAggregator');
+  const cfg = JSON.parse(JSON.stringify(config));
+  Object.assign(cfg.mqtt.kafka, overrides || {});
+  const aggregator = new KafkaAggregator(cfg, onFatal);
+  aggregator.kafkaProducer = producer;
+  aggregator.logger = { info: () => {}, debug: () => {}, warn: () => {}, error: () => {} };
+  return aggregator;
+};
+
+describe('Test KafkaAggregator delivery', function () {
+  let producer;
+  let capturedKafkaOptions;
+
+  beforeEach(function () {
+    producer = fakeProducer();
+    capturedKafkaOptions = {};
+    ToTest.__set__('Kafka', function () {
+      return {
+        producer: function (options) {
+          capturedKafkaOptions = options;
+          return producer;
+        }
+      };
+    });
+  });
+
+  it('Should create an idempotent producer so retries cannot reorder the topic', function () {
+    buildAggregator(producer, () => {});
+    assert.isTrue(capturedKafkaOptions.idempotent,
+      'without idempotence a retried batch can be appended after the batch behind it');
+  });
+
+  it('Should keep the messages when the send fails', async function () {
+    const aggregator = buildAggregator(producer, () => {});
+    aggregator.addMessage({ key: 'k', value: 'v' }, NGSILD_TOPIC);
+    producer.failing = true;
+
+    await aggregator.flush();
+
+    assert.equal(producer.sent.length, 0);
+    assert.equal(aggregator.ngsildMessageArray.length, 1,
+      'a failed batch must survive for the next flush, not vanish with a log line');
+  });
+
+  it('Should deliver the kept messages once Kafka comes back', async function () {
+    const aggregator = buildAggregator(producer, () => {});
+    aggregator.addMessage({ key: 'a', value: '1' }, NGSILD_TOPIC);
+    producer.failing = true;
+    await aggregator.flush();
+
+    producer.failing = false;
+    aggregator.addMessage({ key: 'b', value: '2' }, NGSILD_TOPIC);
+    await aggregator.flush();
+
+    assert.equal(producer.sent.length, 1);
+    assert.deepEqual(producer.sent[0].messages.map(m => m.key), ['a', 'b'],
+      'the retried batch must go out ahead of what arrived while it was in flight');
+    assert.equal(aggregator.ngsildMessageArray.length, 0);
+  });
+
+  it('Should clear the buffer on a successful send', async function () {
+    const aggregator = buildAggregator(producer, () => {});
+    aggregator.addMessage({ key: 'k', value: 'v' }, NGSILD_TOPIC);
+    await aggregator.flush();
+    assert.equal(producer.sent.length, 1);
+    assert.equal(aggregator.ngsildMessageArray.length, 0);
+  });
+
+  it('Should route each buffer to its own topic', async function () {
+    const aggregator = buildAggregator(producer, () => {});
+    aggregator.addMessage({ key: 'spb', value: '1' }, SPB_TOPIC);
+    aggregator.addMessage({ key: 'ngsild', value: '2' }, NGSILD_TOPIC);
+    await aggregator.flush();
+    assert.deepEqual(producer.sent.map(p => p.topic), [SPB_TOPIC, NGSILD_TOPIC]);
+  });
+
+  it('Should fail the bridge rather than buffer without bound', async function () {
+    const fatals = [];
+    const aggregator = buildAggregator(producer, r => fatals.push(r), { maxBufferedMessages: 3 });
+    producer.failing = true;
+    for (let i = 0; i < 3; i++) {
+      aggregator.addMessage({ key: String(i), value: 'v' }, NGSILD_TOPIC);
+    }
+    await aggregator.flush();
+    assert.deepEqual(fatals, [], 'at the limit is still fine');
+
+    aggregator.addMessage({ key: 'overflow', value: 'v' }, NGSILD_TOPIC);
+    assert.equal(fatals.length, 1, 'past the limit the bridge must say so');
+    assert.include(fatals[0], NGSILD_TOPIC);
+    assert.include(fatals[0], 'will be lost');
+  });
+
+  it('Should not start the next flush before the previous one settles', async function () {
+    const aggregator = buildAggregator(producer, () => {});
+    let inFlight = 0;
+    let maxConcurrent = 0;
+    producer.send = function (payload) {
+      inFlight += 1;
+      maxConcurrent = Math.max(maxConcurrent, inFlight);
+      return new Promise(resolve => setTimeout(function () {
+        inFlight -= 1;
+        resolve();
+      }, 30));
+    };
+    aggregator.start(1);
+    const feeder = setInterval(() => aggregator.addMessage({ key: 'k', value: 'v' }, NGSILD_TOPIC), 1);
+
+    await new Promise(resolve => setTimeout(resolve, 150));
+    clearInterval(feeder);
+    aggregator.stop();
+
+    assert.equal(maxConcurrent, 1,
+      'setInterval used to stack a new flush every linger ms regardless of the one in flight');
+  });
+
+  it('Should keep flushing after an unexpected error', async function () {
+    const aggregator = buildAggregator(producer, () => {});
+    let calls = 0;
+    const realFlush = aggregator.flush.bind(aggregator);
+    aggregator.flush = function () {
+      calls += 1;
+      if (calls === 1) {
+        return Promise.reject(new Error('something unexpected'));
+      }
+      return realFlush();
+    };
+    aggregator.start(5);
+    aggregator.addMessage({ key: 'k', value: 'v' }, NGSILD_TOPIC);
+
+    await new Promise(resolve => setTimeout(resolve, 60));
+    aggregator.stop();
+
+    assert.isAbove(calls, 1, 'one bad flush must not end the flush loop');
+    assert.equal(producer.sent.length, 1, 'and the buffered message still has to go out');
+  });
+
+  it('Should stop flushing after stop()', async function () {
+    const aggregator = buildAggregator(producer, () => {});
+    aggregator.start(1);
+    aggregator.stop();
+    aggregator.addMessage({ key: 'k', value: 'v' }, NGSILD_TOPIC);
+    await new Promise(resolve => setTimeout(resolve, 30));
+    assert.equal(producer.sent.length, 0);
+  });
+});

--- a/KafkaBridge/test/mqttBridge_kafkaAggregatorTest.js
+++ b/KafkaBridge/test/mqttBridge_kafkaAggregatorTest.js
@@ -272,4 +272,18 @@ describe('Test KafkaAggregator delivery', function () {
     assert.deepEqual(fatals, [], 'a bridge that keeps delivering must never be called stalled');
     aggregator.stop();
   });
+  it('Should exit by itself when no onFatal was supplied', function () {
+    const aggregator = buildAggregator(producer, undefined, { maxBufferedMessages: 1 });
+    const realExit = process.exit;
+    const exits = [];
+    process.exit = code => exits.push(code);
+    try {
+      aggregator.addMessage({ key: 'a', value: 'v' }, NGSILD_TOPIC);
+      aggregator.addMessage({ key: 'b', value: 'v' }, NGSILD_TOPIC);
+    } finally {
+      process.exit = realExit;
+    }
+    assert.deepEqual(exits, [1],
+      'the default has to be as loud as the wired-up one, or a caller that forgets it loses messages quietly');
+  });
 });

--- a/KafkaBridge/test/mqttBridge_kafkaAggregatorTest.js
+++ b/KafkaBridge/test/mqttBridge_kafkaAggregatorTest.js
@@ -198,4 +198,78 @@ describe('Test KafkaAggregator delivery', function () {
     await new Promise(resolve => setTimeout(resolve, 30));
     assert.equal(producer.sent.length, 0);
   });
+  it('Should resolve a message only once Kafka has it', async function () {
+    const aggregator = buildAggregator(producer, () => {});
+    aggregator.start(5);
+    let delivered = false;
+    let releaseSend = null;
+    producer.send = function (payload) {
+      this.sent.push(payload);
+      return new Promise(resolve => { releaseSend = resolve; });
+    };
+
+    const promise = aggregator.addMessage({ key: 'k', value: 'v' }, NGSILD_TOPIC)
+      .then(() => { delivered = true; });
+
+    await new Promise(resolve => setTimeout(resolve, 30));
+    assert.isFalse(delivered, 'resolving before the broker acknowledged would let the MQTT side ack too early');
+    releaseSend();
+    await promise;
+    assert.isTrue(delivered);
+    aggregator.stop();
+  });
+
+  it('Should leave a message unresolved while the send keeps failing', async function () {
+    const aggregator = buildAggregator(producer, () => {});
+    aggregator.start(5);
+    producer.failing = true;
+    let delivered = false;
+    aggregator.addMessage({ key: 'k', value: 'v' }, NGSILD_TOPIC).then(() => { delivered = true; });
+
+    await new Promise(resolve => setTimeout(resolve, 40));
+    assert.isFalse(delivered, 'an unresolved message is what keeps the broker holding it');
+
+    producer.failing = false;
+    await new Promise(resolve => setTimeout(resolve, 40));
+    assert.isTrue(delivered, 'and it must resolve once the broker recovers');
+    assert.equal(producer.sent.length, 1);
+    aggregator.stop();
+  });
+
+  it('Should resolve immediately when awaitDelivery is off', async function () {
+    const aggregator = buildAggregator(producer, () => {}, { awaitDelivery: false });
+    let delivered = false;
+    producer.send = function () { return new Promise(() => {}); };
+    aggregator.addMessage({ key: 'k', value: 'v' }, NGSILD_TOPIC).then(() => { delivered = true; });
+    await new Promise(resolve => setTimeout(resolve, 10));
+    assert.isTrue(delivered, 'the opt-out has to stay non-blocking');
+  });
+
+  it('Should fail the bridge when delivery stays stuck', async function () {
+    const fatals = [];
+    const aggregator = buildAggregator(producer, r => fatals.push(r), { maxDeliveryStallMs: 30 });
+    producer.failing = true;
+    aggregator.addMessage({ key: 'k', value: 'v' }, NGSILD_TOPIC);
+    aggregator.start(5);
+
+    await new Promise(resolve => setTimeout(resolve, 20));
+    assert.deepEqual(fatals, [], 'a short outage is not a reason to restart');
+
+    await new Promise(resolve => setTimeout(resolve, 40));
+    assert.isAbove(fatals.length, 0, 'a bridge that stopped acknowledging must not sit there looking healthy');
+    assert.include(fatals[0], 'nothing delivered to Kafka');
+    aggregator.stop();
+  });
+
+  it('Should clear the stall clock once delivery succeeds', async function () {
+    const fatals = [];
+    const aggregator = buildAggregator(producer, r => fatals.push(r), { maxDeliveryStallMs: 40 });
+    aggregator.start(5);
+    for (let i = 0; i < 6; i++) {
+      aggregator.addMessage({ key: String(i), value: 'v' }, NGSILD_TOPIC);
+      await new Promise(resolve => setTimeout(resolve, 15));
+    }
+    assert.deepEqual(fatals, [], 'a bridge that keeps delivering must never be called stalled');
+    aggregator.stop();
+  });
 });

--- a/KafkaBridge/test/mqttBridge_spb_data_ingestionTest.js
+++ b/KafkaBridge/test/mqttBridge_spb_data_ingestionTest.js
@@ -370,9 +370,11 @@ describe(fileToTest, function () {
     spbdataIngestion.sendErrorOverChannel = sendErrorOverChannel;
 
     const kafkaPubReturn = spbdataIngestion.createKafakaPubData('spBv1.0/accountId/DBIRTH/eonID/deviceId', DataMessage);
-    assert.oneOf(kafkaPubReturn, [false, undefined], ' Possible to produce kafka message for wrong alias/CID id: ' + kafkaPubReturn);
-    revert();
-    done();
+    kafkaPubReturn.then(forwarded => {
+      assert.deepEqual(forwarded, [], ' Possible to produce kafka message for wrong alias/CID id: ' + JSON.stringify(forwarded));
+      revert();
+      done();
+    }).catch(done);
   });
 
   it('KafkaProduce for SparkplugB metric fails for only ngsild topic due to empty sparkplugB message', function (done) {
@@ -402,9 +404,11 @@ describe(fileToTest, function () {
     spbdataIngestion.sendErrorOverChannel = sendErrorOverChannel;
 
     const kafkaPubReturn = spbdataIngestion.createKafakaPubData('spBv1.0/accountId/DBIRTH/eonID/deviceId', DataMessage);
-    assert.oneOf(kafkaPubReturn, [false, undefined], ' Possible to produce kafka message for wrong alias/CID id: ' + kafkaPubReturn);
-    revert();
-    done();
+    kafkaPubReturn.then(forwarded => {
+      assert.deepEqual(forwarded, [], ' Possible to produce kafka message for wrong alias/CID id: ' + JSON.stringify(forwarded));
+      revert();
+      done();
+    }).catch(done);
   });
 
   it('Create Kafka  publish data on Spb topic', function (done) {
@@ -679,9 +683,11 @@ describe(fileToTest, function () {
       seq: 0
     };
     const processDataIngestReturn = spbdataIngestion.processDataIngestion('spBv1.0/accountId/MATA/eonID/deviceId', message);
-    assert.deepEqual(processDataIngestReturn, undefined, 'Unable to validate SParkplugB schema');
-    revert();
-    done();
+    Promise.resolve(processDataIngestReturn).then(result => {
+      assert.deepEqual(result, undefined, 'Unable to validate SParkplugB schema');
+      revert();
+      done();
+    }).catch(done);
   });
 
   it('Process data Ingestion with 2nd array component of SparkplugB Metric empty', function (done) {
@@ -714,9 +720,11 @@ describe(fileToTest, function () {
       seq: 0
     };
     const processDataIngestReturn = spbdataIngestion.processDataIngestion('spBv1.0/accountId/DDATA/eonID/deviceId', message);
-    assert.deepEqual(processDataIngestReturn, undefined, 'Unable to validate SParkplugB schema');
-    revert();
-    done();
+    Promise.resolve(processDataIngestReturn).then(result => {
+      assert.deepEqual(result, undefined, 'Unable to validate SParkplugB schema');
+      revert();
+      done();
+    }).catch(done);
   });
 
   it('Process data Ingestion with wrong type for SparkplugB Metric', function (done) {
@@ -749,9 +757,11 @@ describe(fileToTest, function () {
       seq: 0
     };
     const processDataIngestReturn = spbdataIngestion.processDataIngestion('spBv1.0/accountId/DDATA/eonID/deviceId', message);
-    assert.deepEqual(processDataIngestReturn, undefined, 'Unable to validate SParkplugB schema');
-    revert();
-    done();
+    Promise.resolve(processDataIngestReturn).then(result => {
+      assert.deepEqual(result, undefined, 'Unable to validate SParkplugB schema');
+      revert();
+      done();
+    }).catch(done);
   });
 
   it('Process data Ingestion with wrong format SparkplugB Metric', function (done) {
@@ -778,9 +788,11 @@ describe(fileToTest, function () {
       seq: 0
     };
     const processDataIngestReturn = spbdataIngestion.processDataIngestion('spBv1.0/accountId/DDATA/eonID/deviceId', message);
-    assert.deepEqual(processDataIngestReturn, undefined, 'Unable to validate SParkplugB schema');
-    revert();
-    done();
+    Promise.resolve(processDataIngestReturn).then(result => {
+      assert.deepEqual(result, undefined, 'Unable to validate SParkplugB schema');
+      revert();
+      done();
+    }).catch(done);
   });
   it('Process data Ingestion with missing metric in SparkplugB payload', function (done) {
     const revert = ToTest.__set__({
@@ -804,9 +816,11 @@ describe(fileToTest, function () {
       seq: 0
     };
     const processDataIngestReturn = spbdataIngestion.processDataIngestion('spBv1.0/accountId/DDATA/eonID/deviceId', message);
-    assert.deepEqual(processDataIngestReturn, undefined, 'Unable to validate SParkplugB schema');
-    revert();
-    done();
+    Promise.resolve(processDataIngestReturn).then(result => {
+      assert.deepEqual(result, undefined, 'Unable to validate SParkplugB schema');
+      revert();
+      done();
+    }).catch(done);
   });
 
   it('Process data Ingestion with INVALID seq of SparkplugB Metric', function (done) {
@@ -839,9 +853,11 @@ describe(fileToTest, function () {
       seq: 290
     };
     const processDataIngestReturn = spbdataIngestion.processDataIngestion('spBv1.0/accountId/DDATA/eonID/deviceId', message);
-    assert.deepEqual(processDataIngestReturn, true, 'Unable to validate SParkplugB schema');
-    revert();
-    done();
+    Promise.resolve(processDataIngestReturn).then(result => {
+      assert.deepEqual(result, true, 'Unable to validate SParkplugB schema');
+      revert();
+      done();
+    }).catch(done);
   });
 
   it('Shall check mqtt bind to topic', function (done) {

--- a/KafkaBridge/test/testDebeziumBridgeApp.js
+++ b/KafkaBridge/test/testDebeziumBridgeApp.js
@@ -344,19 +344,12 @@ describe('Test startListener', function () {
     const producer = {
       connect: function () {}
     };
-    const fs = {
-      writeFileSync: function (file, message) {
-        expect(file).to.satisfy(function (str) {
-          if (str === '/tmp/ready' || str === '/tmp/healthy') {
-            return true;
-          }
-        });
-        expect(message).to.satisfy(function (str) {
-          if (str === 'ready' || str === 'healthy') {
-            return true;
-          }
-        });
-      }
+    // The bridges now hand their liveness files to KafkaHealth, which needs a
+    // consumer that can report on its own state. Stub it out here so this test
+    // keeps exercising the app wiring rather than the watchdog -- the watchdog has
+    // its own test in lib_kafkaHealthTest.js.
+    const KafkaHealth = function () {
+      return { start: function () {}, shutdown: function () {} };
     };
     const config = {
       debeziumBridge: {
@@ -385,7 +378,7 @@ describe('Test startListener', function () {
     const processOnceSpy = sinon.spy(process, 'once');
     const revert = toTest.__set__('consumer', consumer);
     toTest.__set__('producer', producer);
-    toTest.__set__('fs', fs);
+    toTest.__set__('KafkaHealth', KafkaHealth);
     toTest.__set__('config', config);
     toTest.__set__('process', process);
     const startListener = toTest.__get__('startListener');
@@ -393,7 +386,7 @@ describe('Test startListener', function () {
     consumerDisconnectSpy.callCount.should.equal(5);
     assert(consumerConnectSpy.calledOnce);
     assert(producerConnectSpy.calledOnce);
-    processExitSpy.withArgs(0).callCount.should.equal(2);
+    processExitSpy.withArgs(1).callCount.should.equal(2);
     assert(processOnceSpy.calledThrice);
     revert();
   });

--- a/KafkaBridge/test/testTimescaledbApp.js
+++ b/KafkaBridge/test/testTimescaledbApp.js
@@ -455,11 +455,12 @@ describe('Test startListener', function () {
     disconnect: function () {
     }
   };
-  const fs = {
-    writeFileSync: function (file, message) {
-      assert.oneOf(file, ['/tmp/ready', '/tmp/healthy'], 'Wrong file for filesync');
-      assert.oneOf(message, ['ready', 'healthy'], 'Wrong filesync message.');
-    }
+  // The bridges now hand their liveness files to KafkaHealth, which needs a
+  // consumer that can report on its own state. Stub it out here so this test
+  // keeps exercising the app wiring rather than the watchdog -- the watchdog has
+  // its own test in lib_kafkaHealthTest.js.
+  const KafkaHealth = function () {
+    return { start: function () {}, shutdown: function () {} };
   };
   const config = {
     timescaledb: {
@@ -503,7 +504,7 @@ describe('Test startListener', function () {
     const sequelizeObj = new SequelizeClassNoQuery();
     const revert = toTest.__set__('consumer', consumer);
     toTest.__set__('sequelize', sequelizeObj);
-    toTest.__set__('fs', fs);
+    toTest.__set__('KafkaHealth', KafkaHealth);
     toTest.__set__('config', config);
     toTest.__set__('process', process);
     const startListener = toTest.__get__('startListener');
@@ -518,7 +519,7 @@ describe('Test startListener', function () {
     const processOnceSpy = sinon.spy(process, 'once');
     const revert = toTest.__set__('consumer', consumer);
     toTest.__set__('sequelize', sequelizeObj);
-    toTest.__set__('fs', fs);
+    toTest.__set__('KafkaHealth', KafkaHealth);
     toTest.__set__('config', config);
     toTest.__set__('process', process);
     const startListener = toTest.__get__('startListener');

--- a/KafkaBridge/timescaledb/app.js
+++ b/KafkaBridge/timescaledb/app.js
@@ -18,11 +18,11 @@
 const GROUPID = 'timescaledbkafkabridge';
 const CLIENTID = 'timescaledbkafkaclient';
 const { Kafka } = require('kafkajs');
-const fs = require('fs');
 const config = require('../config/config.json');
 const sequelize = require('./utils/tsdb-connect'); // Import sequelize object, Database connection pool managed by Sequelize.
 const { QueryTypes } = require('sequelize');
 const Logger = require('../lib/logger.js');
+const KafkaHealth = require('../lib/kafkaHealth.js');
 const attributeHistoryTable = require('./model/attribute_history.js'); // Import attributeHistory model/table defined
 const entityHistoryTable = require('./model/entity_history.js'); // Import entityHistory model/table defined
 const attributeHistoryTableName = config.timescaledb.attributeTablename;
@@ -142,6 +142,7 @@ const processEntityMessage = function (message) {
 };
 
 const startListener = async function () {
+  const health = new KafkaHealth(consumer, logger);
   let hypertableStatus = false;
   sequelize.authenticate().then(() => {
     logger.info('TSDB connection has been established.');
@@ -201,7 +202,13 @@ const startListener = async function () {
   await consumer.subscribe({ topic: config.timescaledb.entityTopic, fromBeginning: false });
   await consumer.run({
     eachMessage: async ({ topic, partition, message }) => processMessage({ topic, partition, message })
-  }).catch(e => console.error(`[example/consumer] ${e.message}`, e));
+  }).catch(e => {
+    // Rethrow: a consumer.run() that rejects leaves the bridge with no message
+    // loop at all, and swallowing it here let startup continue on to declare
+    // the pod ready.
+    console.error(`[example/consumer] ${e.message}`, e);
+    throw e;
+  });
 
   const errorTypes = ['unhandledRejection', 'uncaughtException'];
   const signalTraps = ['SIGTERM', 'SIGINT', 'SIGUSR2'];
@@ -211,8 +218,12 @@ const startListener = async function () {
       try {
         console.log(`process.on ${type}`);
         console.error(e);
+        health.shutdown();
         await consumer.disconnect();
-        process.exit(0);
+        // Non-zero: this path is only reached on an unhandled error, and
+        // exiting 0 made a crash-looping bridge indistinguishable from a clean
+        // stop in kubectl and in any exit-code based alerting.
+        process.exit(1);
       } catch (_) {
         process.exit(1);
       }
@@ -221,6 +232,7 @@ const startListener = async function () {
   signalTraps.map(type =>
     process.once(type, async () => {
       try {
+        health.shutdown();
         await consumer.disconnect();
       } finally {
         process.kill(process.pid, type);
@@ -228,8 +240,7 @@ const startListener = async function () {
     }));
 
   try {
-    fs.writeFileSync('/tmp/ready', 'ready');
-    fs.writeFileSync('/tmp/healthy', 'healthy');
+    health.start();
   } catch (err) {
     logger.error(err);
   }

--- a/helm/charts/kafka-bridges/templates/bridge-configmap.yaml
+++ b/helm/charts/kafka-bridges/templates/bridge-configmap.yaml
@@ -102,7 +102,9 @@ data:
                         "retries": {{ .Values.mqtt.kafka.retries }},
                         "linger": {{ .Values.mqtt.kafka.linger }},
                         "partitioner": {{ .Values.mqtt.kafka.partitioner | quote }},
-                        "maxBufferedMessages": {{ .Values.mqtt.kafka.maxBufferedMessages | default 50000 }}
+                        "maxBufferedMessages": {{ dig "maxBufferedMessages" 50000 .Values.mqtt.kafka }},
+                        "awaitDelivery": {{ dig "awaitDelivery" true .Values.mqtt.kafka }},
+                        "maxDeliveryStallMs": {{ dig "maxDeliveryStallMs" 300000 .Values.mqtt.kafka }}
                 }
         },
         "cache": {

--- a/helm/charts/kafka-bridges/templates/bridge-configmap.yaml
+++ b/helm/charts/kafka-bridges/templates/bridge-configmap.yaml
@@ -101,7 +101,8 @@ data:
                         "maxRetryTime": {{ .Values.mqtt.kafka.maxRetryTime }},
                         "retries": {{ .Values.mqtt.kafka.retries }},
                         "linger": {{ .Values.mqtt.kafka.linger }},
-                        "partitioner": {{ .Values.mqtt.kafka.partitioner | quote }}
+                        "partitioner": {{ .Values.mqtt.kafka.partitioner | quote }},
+                        "maxBufferedMessages": {{ .Values.mqtt.kafka.maxBufferedMessages | default 50000 }}
                 }
         },
         "cache": {

--- a/helm/values.yaml.gotmpl
+++ b/helm/values.yaml.gotmpl
@@ -444,6 +444,9 @@ mqtt:
     retries: 10
     maxRetryTime: 5000
     "requestTimeout": 20000
+    # Messages held while Kafka is unreachable. Past this the bridge exits
+    # rather than drop measurements silently, so size it for the device count.
+    maxBufferedMessages: 50000
   cache:
     host: redis
     port: 6379

--- a/helm/values.yaml.gotmpl
+++ b/helm/values.yaml.gotmpl
@@ -447,6 +447,15 @@ mqtt:
     # Messages held while Kafka is unreachable. Past this the bridge exits
     # rather than drop measurements silently, so size it for the device count.
     maxBufferedMessages: 50000
+    # Hold the MQTT acknowledgement until the message is in Kafka, so a Kafka
+    # outage becomes backpressure on the broker instead of lost measurements.
+    # Costs throughput: mqtt.js processes one message at a time, so each one
+    # pays a Kafka round trip. Set false to acknowledge on receipt instead.
+    awaitDelivery: true
+    # How long delivery may be stuck before the bridge restarts. Restarting ends
+    # the MQTT session, which is what makes the broker redeliver what was never
+    # acknowledged.
+    maxDeliveryStallMs: 300000
   cache:
     host: redis
     port: 6379

--- a/test/bats/linting.bats
+++ b/test/bats/linting.bats
@@ -37,6 +37,9 @@ load "lib/linter"
 	run lint "test-bridges/test-ngsild-updates-bridge.bats"
 	[ "$status" -eq 0 ]
 
+	run lint "test-bridges/test-bridge-health.bats"
+	[ "$status" -eq 0 ]
+
 	run lint ./*/*.bats
 	[ "$status" -eq 0 ]
 }

--- a/test/bats/test-bridges/test-bridge-health.bats
+++ b/test/bats/test-bridges/test-bridge-health.bats
@@ -154,29 +154,48 @@ restart_count() {
     # with "Not authorized" for the one reason it was meant to catch.
     ready=$(pod_is_ready mqtt-bridge)
     [ "$ready" = "true" ] || { echo "# mqtt-bridge is not Ready, so EMQX has no auth backend"; false; }
-    emqx=$(get_pod ${EMQX_LABEL})
-    [ -n "$emqx" ] || skip "no emqx pod found"
 
-    # Readiness means the auth API is serving; the subscription is what liveness
-    # covers. Both have to have happened by now: the bridge writes /tmp/healthy
-    # from the SUBSCRIBE callback, so a Ready bridge with no client on the broker
-    # is the silent failure this suite exists to catch.
-    clients=$(kubectl -n ${NAMESPACE} exec "$emqx" -- emqx ctl clients list 2>/dev/null)
+    # The hard gate, and it is entirely ours: /tmp/healthy is written from the
+    # SUBSCRIBE callback and from nowhere else, so the file existing *is* the
+    # broker having granted the subscription. Readiness only says the auth API
+    # is listening -- a bridge that served auth but never subscribed would be
+    # Ready with no /tmp/healthy, which is exactly the silent failure this suite
+    # exists to catch, and it is caught here without asking the broker anything.
+    pod_has_file mqtt-bridge /tmp/healthy || {
+        echo "# mqtt-bridge is Ready but never wrote /tmp/healthy: it is serving auth without a subscription"
+        false
+    }
+
+    # Everything below cross-checks the same fact from the broker's side. It is
+    # deliberately not a gate: `emqx ctl` is an operator-image detail, and when
+    # it fails it says so on stderr, which the previous version sent to
+    # /dev/null -- so a broken CLI failed the test with no way to tell why.
+    emqx=$(get_pod ${EMQX_LABEL})
+    if [ -z "$emqx" ]; then
+        echo "# no emqx pod found; the /tmp/healthy assertion above stands on its own"
+        return 0
+    fi
+
+    clients=$(kubectl -n ${NAMESPACE} exec "$emqx" -- emqx ctl clients list 2>&1) || {
+        echo "# 'emqx ctl clients list' failed on ${emqx}: ${clients}"
+        return 0
+    }
     echo "# emqx clients: $clients"
     # Deliberately not `grep -v`: with a single "No clients." line an inverted
     # match happens to fail for the right reason, but any banner line the broker
     # prints would make it pass while nothing is connected.
     if echo "$clients" | grep -q "No clients"; then
-        echo "# mqtt-bridge reports Ready but the broker has no client connected"
+        echo "# mqtt-bridge holds a subscription but the broker reports no client connected"
         false
     fi
 
-    # The connected client above is the hard gate, because that is unambiguous.
-    # The subscription listing is only checked when the broker actually reports
-    # subscriptions: the bridge subscribes as $share/kafka/spBv1.0/+/+/+/+, and
-    # whether a shared subscription shows up here is an EMQX detail we should
-    # not turn into a false red.
-    subs=$(kubectl -n ${NAMESPACE} exec "$emqx" -- emqx ctl subscriptions list 2>/dev/null)
+    # The bridge subscribes as $share/kafka/spBv1.0/+/+/+/+, and whether a shared
+    # subscription is listed here is an EMQX detail we should not turn into a
+    # false red -- so this only asserts when the broker lists subscriptions.
+    subs=$(kubectl -n ${NAMESPACE} exec "$emqx" -- emqx ctl subscriptions list 2>&1) || {
+        echo "# 'emqx ctl subscriptions list' failed on ${emqx}: ${subs}"
+        return 0
+    }
     echo "# emqx subscriptions: $subs"
     if echo "$subs" | grep -q "No subscriptions"; then
         echo "# broker lists no subscriptions; connected client is the only assertion here"

--- a/test/bats/test-bridges/test-bridge-health.bats
+++ b/test/bats/test-bridges/test-bridge-health.bats
@@ -145,16 +145,22 @@ restart_count() {
     [ "$before" = "$after" ] || echo "# note: $app restarted during the test ($before -> $after)"
 }
 
-@test "a Ready mqtt bridge is connected to the broker and subscribed" {
+@test "the mqtt bridge is Ready and connected to the broker and subscribed" {
     $SKIP
+    # Not a skip: mqtt-bridge is always deployed, and EMQX resolves every
+    # authn/authz callback through its Service, so a not-Ready mqtt-bridge takes
+    # MQTT down for every client. Skipping here once hid exactly that -- this
+    # test reported "ok (skipped)" while 23 device and subscription tests failed
+    # with "Not authorized" for the one reason it was meant to catch.
     ready=$(pod_is_ready mqtt-bridge)
-    [ "$ready" = "true" ] || skip "mqtt-bridge is not Ready"
+    [ "$ready" = "true" ] || { echo "# mqtt-bridge is not Ready, so EMQX has no auth backend"; false; }
     emqx=$(get_pod ${EMQX_LABEL})
     [ -n "$emqx" ] || skip "no emqx pod found"
 
-    # Readiness is supposed to mean the subscription exists. It used to be
-    # written milliseconds after bind() was called, before the broker had even
-    # answered, so a bridge that never connected still looked Ready.
+    # Readiness means the auth API is serving; the subscription is what liveness
+    # covers. Both have to have happened by now: the bridge writes /tmp/healthy
+    # from the SUBSCRIBE callback, so a Ready bridge with no client on the broker
+    # is the silent failure this suite exists to catch.
     clients=$(kubectl -n ${NAMESPACE} exec "$emqx" -- emqx ctl clients list 2>/dev/null)
     echo "# emqx clients: $clients"
     # Deliberately not `grep -v`: with a single "No clients." line an inverted

--- a/test/bats/test-bridges/test-bridge-health.bats
+++ b/test/bats/test-bridges/test-bridge-health.bats
@@ -1,0 +1,197 @@
+#!/usr/bin/env bats
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# The bridges can stop doing their job while still reporting themselves
+# healthy: alerta-bridge was observed 1/1 Ready with its Kafka consumer group
+# Empty, forwarding nothing, because the liveness file is written once at
+# startup and the heartbeat producer kept logging success from a separate
+# code path. These tests assert on what the bridge is actually attached to --
+# its consumer group, its broker connection -- rather than on the pod phase,
+# which is the thing that lied.
+#
+# No kubefwd: everything here runs through kubectl exec, so the tests do not
+# depend on a forwarded port being up.
+
+SKIP= # set =skip to skip all tests (and only remove $SKIP from the test you are interested in)
+NAMESPACE=iff
+KAFKA_LABEL=app.kubernetes.io/name=kafka
+EMQX_LABEL=apps.emqx.io/instance=emqx
+
+# Bridges that consume from Kafka, with the consumer group each one joins.
+# Group ids come from GROUPID in the respective KafkaBridge/*/app.js.
+KAFKA_BRIDGES="alerta-bridge:alertakafkabridge \
+debezium-bridge:debeziumBridgeGroup \
+ngsild-updates-bridge:statekafkabridge \
+timescaledb-bridge:timescaledbkafkabridge"
+
+ALL_BRIDGES="alerta-bridge debezium-bridge ngsild-updates-bridge timescaledb-bridge mqtt-bridge"
+
+# $1: label selector
+get_pod() {
+    kubectl -n ${NAMESPACE} get pods -l "$1" \
+        -o jsonpath='{.items[0].metadata.name}' 2>/dev/null
+}
+
+kafka_pod() {
+    get_pod ${KAFKA_LABEL}
+}
+
+# Ask Kafka about a consumer group.
+# $1: group id
+describe_group_state() {
+    kubectl -n ${NAMESPACE} exec "$(kafka_pod)" -- \
+        bin/kafka-consumer-groups.sh --bootstrap-server localhost:9092 \
+        --group "$1" --describe --state 2>/dev/null
+}
+
+# $1: deployment/app name
+pod_is_ready() {
+    kubectl -n ${NAMESPACE} get pods -l app="$1" \
+        -o jsonpath='{.items[0].status.containerStatuses[0].ready}' 2>/dev/null
+}
+
+# $1: app name, $2: file
+pod_has_file() {
+    kubectl -n ${NAMESPACE} exec "$(get_pod app="$1")" -- cat "$2" >/dev/null 2>&1
+}
+
+# $1: app name
+restart_count() {
+    kubectl -n ${NAMESPACE} get pods -l app="$1" \
+        -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}' 2>/dev/null
+}
+
+@test "every Kafka bridge has actually joined its consumer group" {
+    $SKIP
+    failures=""
+    for entry in ${KAFKA_BRIDGES}; do
+        app=${entry%%:*}
+        group=${entry##*:}
+        ready=$(pod_is_ready "$app")
+        if [ "$ready" != "true" ]; then
+            echo "# $app is not Ready, skipping its group check"
+            continue
+        fi
+        state=$(describe_group_state "$group")
+        echo "# $app / $group -> $(echo "$state" | tail -1)"
+        # STATE and #MEMBERS are the last two columns of the single data row.
+        # Read from the right: when a group is Empty the ASSIGNMENT-STRATEGY
+        # column is blank, so counting from the left shifts by one.
+        members=$(echo "$state" | tail -1 | awk '{print $NF}')
+        stable=$(echo "$state" | tail -1 | awk '{print $(NF-1)}')
+        case "$members" in
+            ''|*[!0-9]*) members=0 ;;
+        esac
+        # A pod that is Ready but whose group is Empty is exactly the failure
+        # this suite exists for: it forwards nothing and nothing complains.
+        if [ "$stable" != "Stable" ] || [ "$members" -lt 1 ]; then
+            failures="${failures} ${app}(group=${group},state=${stable},members=${members})"
+        fi
+    done
+    [ -z "$failures" ] || { echo "# bridges Ready but not consuming:${failures}"; false; }
+}
+
+@test "every Ready bridge exposes the liveness and readiness files its probes read" {
+    $SKIP
+    failures=""
+    for app in ${ALL_BRIDGES}; do
+        ready=$(pod_is_ready "$app")
+        if [ "$ready" != "true" ]; then
+            echo "# $app is not Ready, skipping"
+            continue
+        fi
+        pod_has_file "$app" /tmp/ready || failures="${failures} ${app}:/tmp/ready"
+        pod_has_file "$app" /tmp/healthy || failures="${failures} ${app}:/tmp/healthy"
+    done
+    [ -z "$failures" ] || { echo "# missing probe files:${failures}"; false; }
+}
+
+@test "removing the liveness file makes the liveness probe fail" {
+    $SKIP
+    app=alerta-bridge
+    ready=$(pod_is_ready "$app")
+    [ "$ready" = "true" ] || skip "$app is not Ready"
+    pod=$(get_pod app=${app})
+    before=$(restart_count "$app")
+
+    # The whole design rests on this: the bridge removes /tmp/healthy when its
+    # input dies, and the kubelet then restarts it. Before, the file was written
+    # once and never removed, so the probe could never fail no matter what
+    # happened to the consumer. Assert the probe command itself reacts, rather
+    # than waiting out initialDelaySeconds=300 plus three probe periods.
+    kubectl -n ${NAMESPACE} exec "$pod" -- rm -f /tmp/healthy
+    run kubectl -n ${NAMESPACE} exec "$pod" -- cat /tmp/healthy
+    echo "# probe command exit status without the file: $status"
+    [ "$status" -ne 0 ]
+
+    # Put it back so the kubelet does not restart the bridge for a test.
+    kubectl -n ${NAMESPACE} exec "$pod" -- sh -c 'echo -n healthy > /tmp/healthy'
+    run kubectl -n ${NAMESPACE} exec "$pod" -- cat /tmp/healthy
+    [ "$status" -eq 0 ]
+
+    after=$(restart_count "$app")
+    [ "$before" = "$after" ] || echo "# note: $app restarted during the test ($before -> $after)"
+}
+
+@test "a Ready mqtt bridge is connected to the broker and subscribed" {
+    $SKIP
+    ready=$(pod_is_ready mqtt-bridge)
+    [ "$ready" = "true" ] || skip "mqtt-bridge is not Ready"
+    emqx=$(get_pod ${EMQX_LABEL})
+    [ -n "$emqx" ] || skip "no emqx pod found"
+
+    # Readiness is supposed to mean the subscription exists. It used to be
+    # written milliseconds after bind() was called, before the broker had even
+    # answered, so a bridge that never connected still looked Ready.
+    clients=$(kubectl -n ${NAMESPACE} exec "$emqx" -- emqx ctl clients list 2>/dev/null)
+    echo "# emqx clients: $clients"
+    # Deliberately not `grep -v`: with a single "No clients." line an inverted
+    # match happens to fail for the right reason, but any banner line the broker
+    # prints would make it pass while nothing is connected.
+    if echo "$clients" | grep -q "No clients"; then
+        echo "# mqtt-bridge reports Ready but the broker has no client connected"
+        false
+    fi
+
+    # The connected client above is the hard gate, because that is unambiguous.
+    # The subscription listing is only checked when the broker actually reports
+    # subscriptions: the bridge subscribes as $share/kafka/spBv1.0/+/+/+/+, and
+    # whether a shared subscription shows up here is an EMQX detail we should
+    # not turn into a false red.
+    subs=$(kubectl -n ${NAMESPACE} exec "$emqx" -- emqx ctl subscriptions list 2>/dev/null)
+    echo "# emqx subscriptions: $subs"
+    if echo "$subs" | grep -q "No subscriptions"; then
+        echo "# broker lists no subscriptions; connected client is the only assertion here"
+    else
+        echo "$subs" | grep -q "spBv1.0" || { echo "# broker has subscriptions but none on the sparkplug topic"; false; }
+    fi
+}
+
+@test "no bridge is stuck in a restart loop" {
+    $SKIP
+    # The bridges now exit non-zero when their input is broken, which is the
+    # point -- but a bridge restarting over and over is a failure that should be
+    # read as such and not mistaken for the fix working.
+    failures=""
+    for app in ${ALL_BRIDGES}; do
+        pod=$(get_pod app="$app")
+        [ -n "$pod" ] || continue
+        waiting=$(kubectl -n ${NAMESPACE} get pod "$pod" \
+            -o jsonpath='{.status.containerStatuses[0].state.waiting.reason}' 2>/dev/null)
+        echo "# $app restarts=$(restart_count "$app") waiting=${waiting:-none}"
+        [ "$waiting" != "CrashLoopBackOff" ] || failures="${failures} ${app}"
+    done
+    [ -z "$failures" ] || { echo "# bridges in CrashLoopBackOff:${failures}"; false; }
+}


### PR DESCRIPTION
`alerta-bridge` was found 1/1 Ready with its Kafka consumer group `Empty`, forwarding nothing. SHACL alerts were being produced correctly by Flink and were sitting in `iff.alerts`, but Alerta was empty. Nothing anywhere reported a problem.

Three things had to be true at once, and all were:

1. **The consumer and the heartbeat are independent.** `startListener()` and `startPeriodicProducer()` are two unconnected async calls, so the consumer can die while the producer keeps logging `Alert heartbeat sent successfully` once a second.
2. **kafkajs reported it and nobody listened.** The consumer emits `CRASH`, `STOP` and `DISCONNECT`. There were no subscribers to any of them.
3. **The probe could not fail.** `/tmp/healthy` is written once at startup and never touched again, so `cat /tmp/healthy` succeeds forever regardless of consumer state.

## What this changes

**`lib/healthState.js`** — the two probe files and the one way to fail, shared so all five bridges report a broken input identically: remove `/tmp/healthy`, exit non-zero.

**`lib/kafkaHealth.js`**, wired into alerta, debeziumBridge, ngsildUpdates and timescaledb:
- subscribes to the `CRASH`/`STOP`/`DISCONNECT` events kafkajs already emits. A crash kafkajs says it will restart is logged and left alone; anything terminal exits.
- a watchdog over the consumer's own loop for the stalls kafkajs does not report at all. It ticks off `FETCH`/`HEARTBEAT`/`GROUP_JOIN`/`COMMIT_OFFSETS`, which keep firing on an idle topic, so a bridge that legitimately sees no traffic is not mistaken for a dead one.

**`lib/mqttHealth.js`** — the mqtt bridge could fail the same way by a different route. It wrote its probe files immediately after calling `bind()`, but `bind()` only *starts* connecting, and its failure was reported through a callback no caller passed. With `config.mqtt.retries` at 30000 the connector's own budget is ~12.5 hours, so there was no path by which "never connected" became visible. Readiness now comes from the SUBSCRIBE callback, plus a startup deadline and a connection watchdog that tolerates the short disconnects mqtt.js repairs by itself.

**Delivery.** `KafkaAggregator` cleared its buffer in the same tick it started the send, so a rejected send lost the whole batch behind one log line — into `iff.ngsild.attributes`, the topic Flink's `attributes` table consumes. Now the batch survives a failed send and is retried ahead of what arrived behind it; flushes self-schedule instead of stacking every `linger` ms; the buffer is bounded and overflow is a hard failure; and the producer is `idempotent` so retries cannot reorder the topic.

**Backpressure.** The MQTT acknowledgement is now withheld until the message is in Kafka. mqtt.js sends the PUBACK when `handleMessage` calls back and its packet loop takes the next packet only once that fires, so overriding it gives both halves: the ack waits for Kafka, and a Kafka outage stops the flow instead of filling a buffer. Costs throughput — the packet loop is sequential, so each message pays a Kafka round trip. Set `mqtt.kafka.awaitDelivery=false` to go back to acknowledging on receipt.

Also: `consumer.run()` rejections were logged and swallowed in three bridges, letting a bridge with no message loop declare itself ready; and the `unhandledRejection`/`uncaughtException` handlers exited `0`, making a crash-looping bridge look like a clean stop.

## Tests

209 unit tests pass, eslint clean, coverage 87.7%. `healthState`, `kafkaHealth` and `mqttHealth` are at 100% lines.

`test/bats/test-bridges/test-bridge-health.bats` asserts what the bridges are attached to rather than the pod phase, since the pod phase is what lied. It runs entirely through `kubectl exec`, so it needs no kubefwd, and CI picks it up via `bats */*.bats`.

Run against a live cluster it immediately found two real defects: `ngsild-updates-bridge` sitting Ready with an `Empty` consumer group (the same failure on a second bridge), and `mqtt-bridge` Ready for four days with no MQTT connection at all (`Connection refused: Not authorized`).

## Note for reviewers

The one behaviour that is unit-only is a consumer dying mid-flight — that cannot be induced end-to-end without taking Kafka down, so it is covered by simulated `CRASH`/`STOP`/`DISCONNECT` events rather than in bats.

Client-side, no message is acknowledged before it is in Kafka. Whether an unacknowledged message is actually redelivered is the broker's call and is not changed here: the client still connects with mqtt.js defaults (`clean: true`, random clientId). The subscription is shared (`$share/kafka/...`), and EMQX normally requeues unacknowledged shared-subscription messages when a session ends, but that depends on your EMQX ack configuration and is worth confirming before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)