### PR TITLE
Let the count checks see that the entity is gone

### DIFF
--- a/semantic-model/kms/model-instance.jsonld
+++ b/semantic-model/kms/model-instance.jsonld
@@ -75,22 +75,22 @@
       {
         "type": "Property",
         "value": 0.9,
-        "observedAt": "2024-02-28 13:52:32.0" 
+        "observedAt": "2024-02-28T13:52:32.000Z"
       },
       {
         "type": "Property",
         "value": 0.8,
-        "observedAt": "2024-02-28 13:52:33.0" 
+        "observedAt": "2024-02-28T13:52:33.000Z"
       },
       {
         "type": "Property",
         "value": 0.7,
-        "observedAt": "2024-02-28 13:52:34.0" 
+        "observedAt": "2024-02-28T13:52:34.000Z"
       },
       {
         "type": "Property",
         "value": 0.6,
-        "observedAt": "2024-02-28 13:52:35.0" 
+        "observedAt": "2024-02-28T13:52:35.000Z"
       }
     ]
   },

--- a/semantic-model/kms/model-instance.scorpio.jsonld
+++ b/semantic-model/kms/model-instance.scorpio.jsonld
@@ -1,0 +1,145 @@
+[
+  {
+    "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
+    "id": "urn:cutter:1",
+    "type": "iffBaseEntities:Machine",
+    "iffBaseEntities:hasState": [
+      {
+        "type": "Property",
+        "value": {
+          "@id": "base:state_ON"
+        }
+      }
+    ]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
+    "id": "urn:plasmacutter:1",
+    "type": "iffBaseEntities:Cutter",
+    "iffBaseEntities:hasState": [
+      {
+        "iffBaseEntities:hasXXXWorkpiece": {
+          "type": "Relationship",
+          "object": "urn:workpiece:1"
+        },
+        "type": "Property",
+        "value": {
+          "@id": "base:state_PROCESSING"
+        }
+      }
+    ],
+    "iffBaseEntities:hasList": {
+      "type": "ListProperty",
+      "valueList": []
+    },
+    "iffBaseEntities:hasJSON": {
+      "type": "JsonProperty",
+      "json": {}
+    },
+    "iffBaseEntities:hasFilter": [
+      {
+        "type": "Relationship",
+        "object": "urn:filter:1",
+        "iffBaseEntities:hasTrust": [
+          {
+            "value": 2.1,
+            "type": "Property",
+            "iffBaseEntities:hasOutWorkpiecexx": {
+              "type": "Property",
+              "value": 2.0,
+              "datasetId": "urn:index:1"
+            }
+          }
+        ]
+      }
+    ],
+    "iffBaseEntities:hasInWorkpiece": [
+      {
+        "type": "Relationship",
+        "object": "urn:workpiece:1"
+      }
+    ]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
+    "id": "urn:filter:1",
+    "type": "iffBaseEntities:Filter",
+    "iffBaseEntities:hasState": [
+      {
+        "type": "Property",
+        "value": {
+          "@id": "base:state_ON"
+        }
+      }
+    ],
+    "iffBaseEntities:hasCartridge": [
+      {
+        "type": "Relationship",
+        "object": "urn:cartridge:1"
+      }
+    ],
+    "iffBaseEntities:hasStrength": [
+      {
+        "type": "Property",
+        "value": 0.6,
+        "observedAt": "2024-02-28T13:52:35.000Z"
+      }
+    ]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
+    "id": "urn:cartridge:1",
+    "type": "iffBaseEntities:FilterCartridge",
+    "iffBaseEntities:isUsedUntil": [
+      {
+        "type": "Property",
+        "value": "2024-02-27 13:54:55.4"
+      }
+    ],
+    "iffBaseEntities:isUsedFrom": [
+      {
+        "type": "Property",
+        "value": "2024-02-27 13:54:55.4"
+      }
+    ],
+    "iffFilterEntities:hasWasteclass": [
+      {
+        "type": "Property",
+        "value": {
+          "@id": "iffFilterKnowledge:WC1"
+        }
+      }
+    ]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
+    "id": "urn:workpiece:1",
+    "type": "iffBaseEntities:Workpiece",
+    "iffBaseEntities:hasMaterial": [
+      {
+        "type": "Property",
+        "value": {
+          "@id": "material:EN_1.4301"
+        }
+      }
+    ],
+    "iffBaseEntities:hasHeight": [
+      {
+        "type": "Property",
+        "value": 5
+      }
+    ],
+    "iffBaseEntities:hasLength": [
+      {
+        "type": "Property",
+        "value": 100
+      }
+    ],
+    "iffBaseEntities:hasWidth": [
+      {
+        "type": "Property",
+        "value": 100
+      }
+    ]
+  }
+]

--- a/semantic-model/shacl2flink/Makefile
+++ b/semantic-model/shacl2flink/Makefile
@@ -190,6 +190,13 @@ test-full-flink-deployment:
 # touched -- SHACL/KNOWLEDGE/MODEL are overridden for the sub-makes, which
 # `make` forwards automatically because they are set on the command line.
 #
+# Both suites run against the one deployment. test-shacl-flink-e2e drives
+# Kafka directly, so a failure there is Flink's or the generated SQL's;
+# test-shacl-flink-scorpio-e2e drives the NGSI-LD API and reads Alerta, so a
+# failure there is somewhere in Postgres, the bridges or the alert path. Run
+# together they say not just "the SQL is right" but "deleting an entity closes
+# its alert", which is the property operators depend on.
+#
 # The teardown must run even when the tests fail, otherwise a red build leaves
 # a statementset behind and the next run inherits it.
 test-flink-e2e: E2E_KMS := $(CURDIR)/tests/e2e-kms
@@ -198,7 +205,7 @@ test-flink-e2e:
 	$(MAKE) flink-deploy SHACL=$(E2E_KMS)/shacl.ttl KNOWLEDGE=$(E2E_KMS)/knowledge.ttl \
 		MODEL=$(E2E_KMS)/model-instance.jsonld
 	ln -fs ../../../../test/bats/lib tests/bats/lib || echo 'Bats framework not installed'
-	( cd tests/bats && bats test-shacl-flink-e2e ); rc=$$?; \
+	( cd tests/bats && bats test-shacl-flink-e2e test-shacl-flink-scorpio-e2e ); rc=$$?; \
 		rm -f tests/bats/lib; \
 		$(MAKE) flink-undeploy SHACL=$(E2E_KMS)/shacl.ttl KNOWLEDGE=$(E2E_KMS)/knowledge.ttl \
 			MODEL=$(E2E_KMS)/model-instance.jsonld; \

--- a/semantic-model/shacl2flink/README.md
+++ b/semantic-model/shacl2flink/README.md
@@ -90,6 +90,43 @@ There are three files expected in the `../kms` directory:
 - knowledge.ttl
 - model-instance.ttl
 
+`../kms` carries two model instances, and which one to use depends on whether
+the model is being compiled or deployed.
+
+`model-instance.jsonld` gives `urn:filter:1` four `hasStrength` values observed
+a second apart, all with the same `datasetId`. That is deliberate and is what
+you want when compiling: it is a stream of observations of one attribute, so it
+exercises the dedup and the aggregations built on it -- resolving many
+observations of one `(id, datasetId)` down to the current value. That is what
+`attributes_view` does and what the SQLite oracle checks, and it resolves to
+`0.6` at `13:52:35`.
+
+`model-instance.scorpio.jsonld` is the same model with that attribute reduced
+to exactly that one value, for loading into a live broker. Two clauses of
+NGSI-LD ([ETSI GS CIM 009][cim009]) explain why it has to be a separate file:
+
+- **4.5.5.1** -- "If no datasetId is provided, or `"datasetId": "@none"` is
+  supplied, it is considered as the default Attribute instance. […] There can
+  only be one default Attribute instance for an Attribute with a given
+  Attribute name **in any request or response**." The same clause adds that
+  there is no multi-attribute support for `observedAt`, so differing timestamps
+  do not make the four into distinct instances. As an NGSI-LD *request*, then,
+  the four-instance form is not conformant -- which costs nothing offline,
+  where nothing is being sent to a broker, and matters only on deployment.
+- **4.5.5.3** -- where a `datasetId` is duplicated, "the one with the most
+  recent observedAt DateTime […] **shall be provided**". So a broker receiving
+  the four is required to resolve them to `0.6`, exactly as the dedup does.
+
+Scorpio does neither: it accepts the payload and returns all four, so the
+entity reads back with four values where one was sent. It is not consistent
+about it either -- appending those four over an existing `hasStrength` discards
+the existing value, so instances sharing a `datasetId` do replace each other
+between writes, just not within a single payload.
+
+So: compile from `model-instance.jsonld`, deploy `model-instance.scorpio.jsonld`.
+
+[cim009]: https://www.etsi.org/deliver/etsi_gs/CIM/001_099/009/01.09.01_60/gs_CIM009v010901p.pdf
+
 To build:
 
 ```bash

--- a/semantic-model/shacl2flink/create_core_tables.py
+++ b/semantic-model/shacl2flink/create_core_tables.py
@@ -158,8 +158,31 @@ def main():
         {'lang': 'STRING'},
         {'deleted': 'BOOLEAN'},
         {'synced': 'BOOLEAN'},
-        {'watermark': 'FOR `ts` AS `ts`'},
-        {'ts': "TIMESTAMP(3) METADATA FROM 'timestamp'"}
+        # No WATERMARK. `ts` is the Kafka record timestamp, and the bridge
+        # stamps attribute records with their observedAt -- event times that
+        # span years, not arrival times. Declaring ts a rowtime turns the
+        # attributes_view dedup into an EVENT-TIME Deduplicate, and with zero
+        # lateness the first record of a snapshot burst carrying a recent
+        # observedAt drives the watermark to now; every remaining record in the
+        # burst with an older observedAt is then late and silently dropped.
+        # Measured: 753 records into the dedup, 4 out, joins downstream starved,
+        # and every constraint over them reporting "Found 0" for attributes that
+        # demonstrably exist. Republishing one value with a CURRENT timestamp
+        # made it visible within seconds, which is the same effect seen from the
+        # other side.
+        #
+        # Without the declaration ts is an ordinary column: ORDER BY ts DESC
+        # still picks the right winner, but nothing is discarded for being late.
+        # These are entity-state tables, not windowed analytics -- nothing in
+        # the circuit windows over them, and alerts_bulk keeps its own watermark
+        # for the alerting path.
+        {'ts': "TIMESTAMP(3) METADATA FROM 'timestamp'"},
+        # Arrival order, for attributes_view to break ties on. A delete carries
+        # the timestamp of the value it deletes -- deliberately the same one --
+        # so the two tie on `ts` and the dedup needs something else to separate
+        # them. Declared on the Flink table only: SQLite has no such metadata
+        # and orders by rowid, which is its equivalent.
+        {'offset': 'BIGINT METADATA VIRTUAL'}
     ]
     sqlite_table = [
         {'id': 'TEXT'},
@@ -175,7 +198,6 @@ def main():
         {'lang': 'TEXT'},
         {'deleted': 'BOOLEAN'},
         {'synced': 'BOOLEAN'},
-        {'watermark': 'FOR `ts` AS `ts`'},
         {'ts': "TIMESTAMP(3) METADATA FROM 'timestamp'"}
     ]
     primary_key = None

--- a/semantic-model/shacl2flink/create_ngsild_tables.py
+++ b/semantic-model/shacl2flink/create_ngsild_tables.py
@@ -81,7 +81,10 @@ def main(output_folder='output'):
         base_entity_table.append({sq("type"): "STRING"})
         base_entity_table.append({sq("deleted"): "BOOLEAN"})
         base_entity_table.append({sq("ts"): "TIMESTAMP(3) METADATA FROM 'timestamp'"})
-        base_entity_table.append({"watermark": "FOR `ts` AS `ts`"})
+        # No WATERMARK, for the same reason as the attributes table: `ts` is an
+        # event time taken from the data, so declaring it a rowtime makes the
+        # entities_view dedup drop as late anything whose timestamp predates the
+        # newest record already seen. See create_core_tables.py.
 
         base_entity_tablename = configs.kafka_topic_ngsi_prefix_name
         base_entity_primary_key = None

--- a/semantic-model/shacl2flink/lib/shacl_properties_to_sql.py
+++ b/semantic-model/shacl2flink/lib/shacl_properties_to_sql.py
@@ -348,9 +348,12 @@ sql_check_relationship_base = """
             WITH A1 as (
                     SELECT /*+ STATE_TTL('D' = '0d') */ A.id AS this,
                         A.`type` as typ,
-                        -- Always false: deleted entities are filtered out
-                        -- below. Kept as a row-level guard for the value
-                        -- checks; it must never become a grouping key again.
+                        -- Deleted entities stay in A1 and carry the flag, so
+                        -- that a count of zero can be told apart from an
+                        -- entity that is gone. Read it in the value checks
+                        -- directly and in the counts as an aggregate -- never
+                        -- as a grouping key. See
+                        -- sql_check_relationship_property_count.
                         IFNULL(A.`deleted`, false) as edeleted,
                         C.`type` AS entity,
                         {{ deepest('type') }} AS link,
@@ -371,7 +374,6 @@ sql_check_relationship_base = """
             {{ attribute_joins }}
                     LEFT JOIN {{target_class}}_view AS C ON {{ deepest('attributeValue') }} = C.id and COALESCE(C.`deleted`, false) = false
                     WHERE {{ level_guard }} and D.attributeType = 'https://uri.etsi.org/ngsi-ld/Relationship'
-                      and COALESCE(A.`deleted`, false) = false
             )
 """  # noqa: E501
 
@@ -392,24 +394,38 @@ sql_check_relationship_property_class = """
             FROM A1 WHERE A1.propertyClass IS NOT NULL and `index` IS NOT NULL and {{ constraint_cond }}
 """  # noqa: E501
 
-# `edeleted` must never be a grouping key. It used to be one, with the deleted
-# case muted by `NOT edeleted` in the HAVING -- which on Flink means a deleted
-# entity MIGRATES its rows from group (id, false) to group (id, true) rather
-# than emptying the first. Muting the new group says nothing about the old one:
-# that is only retracted once every row it holds is retracted, and an hour of
-# state TTL is enough for those retractions to stop arriving. The alert then
-# outlives the entity it is about. Worse, a retraction landing in a group whose
-# accumulator was rebuilt from fewer rows drives the SUM NEGATIVE, and the
-# entity is reported as having "-1 relationships" -- a value this expression
-# cannot produce in batch, which is why the SQLite oracle agreed throughout.
+# A count of zero means two different things and the count alone cannot tell
+# them apart: an entity that is alive and has lost its mandatory attribute MUST
+# alert, and an entity that has been deleted MUST NOT. Only `edeleted`
+# separates them, so the check has to read it.
 #
-# Deleted entities are filtered out of A1 instead, so deleting one EMPTIES the
-# group and Flink retracts the alert as it does for any group that ceases to
-# exist.
+# It must not be a GROUPING KEY, which is how it was written originally: on
+# Flink a deleted entity then MIGRATES its rows from group (id, false) to group
+# (id, true) rather than emptying the first, and muting the new group says
+# nothing about the old one. That group is only retracted once every row it
+# holds is retracted, and an hour of state TTL is enough for those retractions
+# to stop arriving, so the alert outlives the entity. Worse, a retraction
+# landing in a group whose accumulator was rebuilt from fewer rows drives the
+# SUM NEGATIVE and the entity is reported as having "-1 relationships" -- a
+# value this expression cannot produce in batch, which is why the SQLite oracle
+# agreed throughout.
+#
+# Filtering deleted entities out of A1 instead was worse still, because it made
+# correctness depend on the rows DISAPPEARING and a retraction propagating
+# through a LEFT JOIN and a COUNT(DISTINCT). Measured: deleting the kms model in
+# Scorpio raised thirteen CountConstraint alerts that never cleared, with every
+# row-level check -- all of which carry `NOT edeleted` -- correctly silent. The
+# attributes were gone and the count went on being evaluated for the entity.
+#
+# So: read `edeleted`, but as an AGGREGATE in the HAVING. The group is keyed the
+# same whether the entity is alive or deleted, so nothing migrates and no
+# accumulator is rebuilt; and the alert is suppressed by re-evaluating the same
+# group rather than by waiting for its rows to vanish.
 sql_check_relationship_property_count = """
             {% set constraint_cond %}
+            (MAX(CASE WHEN edeleted THEN 1 ELSE 0 END) = 0 AND
             (SUM(CASE WHEN NOT COALESCE(adeleted, FALSE) AND link IS NOT NULL THEN 1 ELSE 0 END) > SQL_DIALECT_CAST(`maxCount` AS INTEGER)
-                                            OR SUM(CASE WHEN NOT COALESCE(adeleted, FALSE) AND link IS NOT NULL THEN 1 ELSE 0 END) < SQL_DIALECT_CAST(`minCount` AS INTEGER))
+                                            OR SUM(CASE WHEN NOT COALESCE(adeleted, FALSE) AND link IS NOT NULL THEN 1 ELSE 0 END) < SQL_DIALECT_CAST(`minCount` AS INTEGER)))
             {% endset %}
             SELECT this AS resource,
                 'CountConstraintComponent(' || `parentPath` || `propertyPath` || ')' AS event,
@@ -448,7 +464,7 @@ sql_check_property_iri_base = """
 INSERT {% if sqlite %} OR REPlACE{% endif %} INTO {{alerts_bulk_table}}
 WITH A1 AS (SELECT /*+ STATE_TTL('D' = '0d', 'C' = '0d') */ A.id as this,
                    A.`type` as typ,
-                   -- Always false; see sql_check_relationship_base.
+                   -- Carried, not filtered; see sql_check_relationship_base.
                    IFNULL(A.`deleted`, false) as edeleted,
                    {{ deepest('attributeValue') }} as val,
                    {{ deepest('nodeType') }} as nodeType,
@@ -483,12 +499,11 @@ WITH A1 AS (SELECT /*+ STATE_TTL('D' = '0d', 'C' = '0d') */ A.id as this,
             LEFT JOIN {{rdf_table_name}} as C ON C.subject = '<' || {{ deepest('attributeValue') }} || '>'
                 and C.predicate = '<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>' and C.object = '<' || D.propertyClass || '>'
              WHERE {{ level_guard }} and (attributeType IS NULL or attributeType IN ('https://uri.etsi.org/ngsi-ld/Property', 'https://uri.etsi.org/ngsi-ld/ListProperty', 'https://uri.etsi.org/ngsi-ld/JsonProperty'))
-               and COALESCE(A.`deleted`, false) = false
             )
 """  # noqa: E501
 
-# `edeleted` is not a grouping key here either -- see
-# sql_check_relationship_property_count for what that cost.
+# `edeleted` is read as an aggregate here too, and is not a grouping key -- see
+# sql_check_relationship_property_count for what both alternatives cost.
 #
 # The count is COUNT(DISTINCT `index`) -- the number of distinct datasetIds
 # carrying a live attribute, which IS the number of instances, an NGSI-LD
@@ -505,8 +520,9 @@ WITH A1 AS (SELECT /*+ STATE_TTL('D' = '0d', 'C' = '0d') */ A.id as this,
 sql_check_property_count = """
 {%- set instance_count %}COUNT(DISTINCT CASE WHEN NOT COALESCE(adeleted, FALSE) and attr_typ IS NOT NULL THEN `index` ELSE NULL END){% endset %}
 {% set constraint_cond%}
+    (MAX(CASE WHEN edeleted THEN 1 ELSE 0 END) = 0 AND
     ({{ instance_count }} > SQL_DIALECT_CAST(`maxCount` AS INTEGER)
-                                    OR {{ instance_count }} < SQL_DIALECT_CAST(`minCount` AS INTEGER))
+                                    OR {{ instance_count }} < SQL_DIALECT_CAST(`minCount` AS INTEGER)))
 {% endset %}
 SELECT this AS resource,
     'CountConstraintComponent(' || `parentPath` || `propertyPath` || ')' AS event,

--- a/semantic-model/shacl2flink/lib/utils.py
+++ b/semantic-model/shacl2flink/lib/utils.py
@@ -428,6 +428,7 @@ def create_yaml_view(name, table, primary_key=None, ttl=None):
         for field_name, field_type in field.items():
             if ('metadata' not in field_name.lower() and
                     field_name.lower() != "watermark" and
+                    field_name.lower() != "offset" and
                     field_name.lower() != "type"):
                 sqlstatement += f',\n `{field_name}`'
     sqlstatement += f" FROM (\n  SELECT {ttl_expression}*,\nROW_NUMBER() OVER (PARTITION BY "
@@ -438,31 +439,35 @@ def create_yaml_view(name, table, primary_key=None, ttl=None):
         else:
             sqlstatement += ', '
         sqlstatement += f'`{key}`'
-    # KNOWN DEFECT, not yet fixed: `ts` is not monotonic in the log, so this
-    # does not always keep the newest row.
+    # Kafka offset breaks the tie, where the table offers one.
     #
-    # debeziumBridge stamps an attribute's VALUE record with its
-    # ngsi-ld:observedAt (app.js checkTimestamp) while a DELETE record takes
-    # wall-clock. Measured on a live cluster for one dedup key
-    # (urn:filter:1\c90e0d09..., @none): a delete written at offset 581438
-    # carried 2026-08-16, while the three republications of the value that
-    # FOLLOWED it -- offsets 581453, 581705, 581955 -- all carried 2024-02-28.
-    # ORDER BY ts DESC therefore keeps the delete indefinitely and the
-    # attribute is reported missing although it exists. Republishing the same
-    # value with a current timestamp made the job retract the alert 2.5s later,
-    # which is what pins the mechanism.
+    # debeziumBridge stamps a DELETE with the timestamp of the value it deletes
+    # -- deliberately the SAME timestamp, so that a later re-creation observed
+    # at the same instant can still win. That design relies on the tie being
+    # broken by ARRIVAL, which held while `ts` was a rowtime and this compiled
+    # into Flink's Deduplicate (keep-last-row). Without the watermark it
+    # compiles into a general Rank, and Rank keeps the INCUMBENT on a tie: it
+    # replaces only on a strictly greater sort key. The delete therefore ties,
+    # loses, and is discarded, leaving the attribute live for good.
     #
-    # Ordering by the Kafka offset instead was tried and reverted. It is not
-    # obviously safe: Flink compiles ROW_NUMBER() ... rownum = 1 into its
-    # Deduplicate operator only when the ORDER BY is a time attribute, and a
-    # plain BIGINT makes it a general rank. The trial was also inconclusive --
-    # the cluster showed inflated counts under BOTH orderings -- so it settled
-    # nothing and is not evidence either way.
+    # Measured: urn:filter:1's hasXXXWorkpiece was deleted in Scorpio and the
+    # delete published, yet the job went on counting it -- reporting a
+    # ClassConstraint violation ("not linked to existing entity of type
+    # Workpiece"), which only fires when a non-deleted row with a datasetId is
+    # present. Republishing the same delete with a CURRENT timestamp cleared it
+    # within seconds, and the alert became the correct CountConstraint. Only a
+    # strictly greater key displaced the row.
     #
-    # The fix most likely belongs in what the timestamp is set FROM rather than
-    # in what this orders by, but that changes event-time semantics for every
-    # consumer of the attributes topic and is not a call to make here.
-    sqlstatement += "\nORDER BY ts DESC) AS rownum\n"
+    # The offset is strictly monotonic per partition, so it IS arrival order,
+    # stated explicitly rather than inherited from whichever operator Flink
+    # happens to choose. The earlier objection to ordering by it -- that a plain
+    # BIGINT downgrades Deduplicate to a general rank -- no longer applies:
+    # `ts` is no longer a rowtime, so this is a general rank either way.
+    order_by = "ts DESC"
+    if any(field_name.lower() == 'offset'
+           for field in table for field_name in field):
+        order_by += ", `offset` DESC"
+    sqlstatement += f"\nORDER BY {order_by}) AS rownum\n"
     sqlstatement += f'FROM `{name}` )\nWHERE rownum = 1'
     spec['sqlstatement'] = sqlstatement
     return yaml_view
@@ -501,7 +506,11 @@ def create_sql_view(table_name, table, primary_key=None,
         else:
             sqlstatement += ','
         sqlstatement += f'`{key}`'
-    sqlstatement += "\nORDER BY ts DESC) AS rownum\n"
+    # rowid is SQLite's insertion order, so this mirrors the Kafka offset the
+    # streaming view orders by: on equal ts the later-inserted row wins. Without
+    # it a tie is resolved arbitrarily and the oracle could disagree with Flink
+    # on exactly the delete-vs-value case the tie-break exists for.
+    sqlstatement += "\nORDER BY ts DESC, rowid DESC) AS rownum\n"
     sqlstatement += f'FROM `{table_name}` )\nWHERE rownum = 1;\n'
     return sqlstatement
 

--- a/semantic-model/shacl2flink/tests/bats/test-shacl-flink-scorpio-e2e/model-cycle.jsonld
+++ b/semantic-model/shacl2flink/tests/bats/test-shacl-flink-scorpio-e2e/model-cycle.jsonld
@@ -1,0 +1,39 @@
+[
+  {
+    "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
+    "id": "urn:e2e-cycle-good:1",
+    "type": "https://industryfusion.github.io/contexts/example/v0/base_entities/E2EMachine",
+    "https://industryfusion.github.io/contexts/example/v0/base_entities/hasE2EState": {
+      "type": "Property",
+      "value": "ON"
+    }
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
+    "id": "urn:e2e-cycle-nostate:1",
+    "type": "https://industryfusion.github.io/contexts/example/v0/base_entities/E2EMachine"
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
+    "id": "urn:e2e-cycle-cartridge:1",
+    "type": "https://industryfusion.github.io/contexts/example/v0/base_entities/E2ECartridge"
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
+    "id": "urn:e2e-cycle-linked:1",
+    "type": "https://industryfusion.github.io/contexts/example/v0/base_entities/E2ELinkedMachine",
+    "https://industryfusion.github.io/contexts/example/v0/base_entities/hasE2ECartridge": {
+      "type": "Relationship",
+      "object": "urn:e2e-cycle-cartridge:1"
+    }
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
+    "id": "urn:e2e-cycle-dangling:1",
+    "type": "https://industryfusion.github.io/contexts/example/v0/base_entities/E2ELinkedMachine",
+    "https://industryfusion.github.io/contexts/example/v0/base_entities/hasE2ECartridge": {
+      "type": "Relationship",
+      "object": "urn:e2e-cycle-absent:1"
+    }
+  }
+]

--- a/semantic-model/shacl2flink/tests/bats/test-shacl-flink-scorpio-e2e/test-shacl-flink-scorpio-e2e.bats
+++ b/semantic-model/shacl2flink/tests/bats/test-shacl-flink-scorpio-e2e/test-shacl-flink-scorpio-e2e.bats
@@ -1,0 +1,349 @@
+#!/usr/bin/env bats
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# End-to-end tests driven through Scorpio, and read back from Alerta.
+#
+# test-shacl-flink-e2e publishes to iff.ngsild.entities and
+# iff.ngsild.attributes directly, so that a failure there points at Flink and
+# the generated SQL rather than at everything upstream of it. This file starts
+# one layer up and finishes one layer further down: entities are created and
+# deleted with the NGSI-LD API, and the assertions are made against the alerts
+# an operator actually looks at.
+#
+# Between those two ends lie Postgres, the Debezium connector, the
+# debezium-bridge and the alerta-bridge -- the part of the chain that has to
+# turn "the operator deleted this entity" into the records Flink consumes, and
+# Flink's retraction back into a closed alert. Neither end is exercised by the
+# Kafka-level suite, and both have been the cause of alerts that would not go
+# away. The question these tests answer is the one that gets asked in
+# practice: I deleted the entity, why is the alert still there?
+#
+# Like its sibling, this file is not run from test/bats. It is driven by
+# `make test-flink-e2e`, which compiles and deploys tests/e2e-kms first, so
+# every shape asserted here comes from that KMS and nothing else.
+
+DEBUG=${DEBUG:-false}
+NAMESPACE=${NAMESPACE:-iff}
+
+# The ingress names that test/setup-local-ingress.sh puts in /etc/hosts. The
+# Kafka-level suite reaches its topics with kubefwd; these three services are
+# published, so no forwarding is needed.
+KEYCLOAK_URL=${KEYCLOAK_URL:-http://keycloak.local/auth/realms}
+NGSILD_URL=${NGSILD_URL:-http://ngsild.local/ngsi-ld/v1}
+ALERTA_URL=${ALERTA_URL:-http://alerta.local/api}
+
+CLIENT_ID=scorpio
+REALM_USER=realm_user
+USER_SECRET=secret/credential-iff-realm-user-iff
+
+CONTEXT=https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld
+E2E=https://industryfusion.github.io/contexts/example/v0/base_entities
+MACHINE_TYPE=${E2E}/E2EMachine
+LINKED_TYPE=${E2E}/E2ELinkedMachine
+CARTRIDGE_TYPE=${E2E}/E2ECartridge
+CARTRIDGE_REL=${E2E}/hasE2ECartridge
+
+# The constraint components as they appear in an alert's event field, which is
+# where a shacl alert says which check it came from.
+COUNT_CONSTRAINT=CountConstraintComponent
+CLASS_CONSTRAINT=ClassConstraintComponent
+
+# A fresh id per run. Alerts are keyed by resource, and a resource that already
+# carries a closed alert from an earlier run would let a test pass on history
+# rather than on what this run produced.
+# The whole-model cycle uses fixed ids, because the point of it is deploying
+# and redeploying the SAME model instance rather than a fresh one each round.
+CYCLE_MODEL="${BATS_TEST_DIRNAME}/model-cycle.jsonld"
+CYCLE_GOOD="urn:e2e-cycle-good:1"
+CYCLE_NOSTATE="urn:e2e-cycle-nostate:1"
+CYCLE_CARTRIDGE="urn:e2e-cycle-cartridge:1"
+CYCLE_LINKED="urn:e2e-cycle-linked:1"
+CYCLE_DANGLING="urn:e2e-cycle-dangling:1"
+CYCLE_IDS="${CYCLE_GOOD} ${CYCLE_NOSTATE} ${CYCLE_CARTRIDGE} ${CYCLE_LINKED} ${CYCLE_DANGLING}"
+
+RUN_ID=$(date +%s)
+TEST_MISSING="urn:e2e-scorpio-missing:${RUN_ID}"
+TEST_LINKED="urn:e2e-scorpio-linked:${RUN_ID}"
+TEST_TARGET="urn:e2e-scorpio-target:${RUN_ID}"
+TEST_RECREATE="urn:e2e-scorpio-recreate:${RUN_ID}"
+
+# On an idle cluster an alert appears about five seconds after the create and
+# closes about five seconds after the delete. The timeout is set two orders of
+# magnitude above that so a loaded runner cannot fail the suite, while a real
+# regression -- an alert that never clears -- still terminates it.
+TIMEOUT=${TIMEOUT:-180}
+POLL=5
+
+setup() {
+    ALERTA_KEY=$(kubectl -n "${NAMESPACE}" get secret alerta \
+        -o jsonpath='{.data.alerta-admin-key}' | base64 -d)
+}
+
+teardown() {
+    for id in "${TEST_MISSING}" "${TEST_LINKED}" "${TEST_TARGET}" "${TEST_RECREATE}" \
+              ${CYCLE_IDS}; do
+        delete_entity "${id}" >/dev/null 2>&1 || true
+    done
+}
+
+# Function definitions
+
+get_password() {
+    kubectl -n "${NAMESPACE}" get "${USER_SECRET}" -o jsonpath='{.data.password}' | base64 -d
+}
+
+# Fetched per request rather than once per test: the tests can run for minutes
+# and an expired token would surface as an unexplained 401 halfway through.
+get_token() {
+    local password
+    password=$(get_password)
+    curl -s -d "client_id=${CLIENT_ID}" -d "username=${REALM_USER}" \
+        -d "password=${password}" -d 'grant_type=password' \
+        "${KEYCLOAK_URL}/${NAMESPACE}/protocol/openid-connect/token" | jq -r '.access_token'
+}
+
+# create_entity <id> <type> [extra-json-members]
+create_entity() {
+    local id=$1 type=$2 extra=${3:-} body
+    if [ -n "${extra}" ]; then
+        body=$(printf '{"@context":"%s","id":"%s","type":"%s",%s}' \
+            "${CONTEXT}" "${id}" "${type}" "${extra}")
+    else
+        body=$(printf '{"@context":"%s","id":"%s","type":"%s"}' \
+            "${CONTEXT}" "${id}" "${type}")
+    fi
+    echo "${body}" | curl -s -o /dev/null -w '%{http_code}' -X POST \
+        -H "Authorization: Bearer $(get_token)" \
+        -H 'Content-Type: application/ld+json' \
+        --data-binary @- "${NGSILD_URL}/entities/"
+}
+
+# A relationship to <target>, as the extra member of a create_entity body.
+relationship_json() {
+    printf '"%s":{"type":"Relationship","object":"%s"}' "$1" "$2"
+}
+
+delete_entity() {
+    curl -s -o /dev/null -w '%{http_code}' -X DELETE \
+        -H "Authorization: Bearer $(get_token)" "${NGSILD_URL}/entities/$1"
+}
+
+# Deploy the whole model instance in one batch, the way an operator does.
+#
+# The response body matters as much as the status. A batch upsert answers 207
+# when it created some entities and rejected others, which is how a model with
+# an unparseable observedAt came to be half-deployed for weeks without anything
+# looking wrong -- the missing entity showed up as dangling relationships on
+# the ones that did load. Treat a partial success as a failure.
+upsert_model() {
+    local body code
+    body=$(curl -s -w '\n%{http_code}' -X POST \
+        -H "Authorization: Bearer $(get_token)" \
+        -H 'Content-Type: application/ld+json' \
+        --data-binary @"${CYCLE_MODEL}" "${NGSILD_URL}/entityOperations/upsert")
+    code=$(echo "${body}" | tail -1)
+    if [ "${code}" = "207" ]; then
+        echo "# model upsert was only partially applied:" >&3
+        echo "${body}" | head -n -1 | sed 's/^/#   /' >&3
+        return 1
+    fi
+    case "${code}" in
+        200|201|204) return 0 ;;
+        *) echo "# model upsert -> HTTP ${code}" >&3
+           echo "${body}" | head -n -1 | sed 's/^/#   /' >&3
+           return 1 ;;
+    esac
+}
+
+delete_model() {
+    local id code
+    for id in ${CYCLE_IDS}; do
+        code=$(delete_entity "${id}")
+        case "${code}" in
+            204|404) ;;
+            *) echo "# DELETE ${id} -> HTTP ${code}" >&3; return 1 ;;
+        esac
+    done
+}
+
+# What the fixture is built to produce: two violations and three silent
+# entities. Asserting the silent ones matters as much as the loud ones --
+# a deployment that alerts on everything would satisfy a one-sided check.
+assert_model_alerting() {
+    assert_alert "${CYCLE_NOSTATE}" "${COUNT_CONSTRAINT}"
+    assert_alert "${CYCLE_DANGLING}" "${CLASS_CONSTRAINT}"
+    assert_no_alert "${CYCLE_GOOD}"
+    assert_no_alert "${CYCLE_LINKED}"
+    assert_no_alert "${CYCLE_CARTRIDGE}"
+}
+
+assert_model_silent() {
+    local id
+    for id in ${CYCLE_IDS}; do
+        assert_no_alert "${id}"
+    done
+}
+
+# open_alerts_for <resource> [event-substring]
+#
+# Counting every alert on a resource would let an unrelated violation stand in
+# for the one under test, and a shape usually constrains more than one path, so
+# there is generally one available to do it. The event names the constraint
+# component and the path it fired on, so naming it is what makes the assertion
+# specific. Leave it out only where the claim really is "nothing at all is open
+# on this resource" -- which is exactly the claim to make about an entity that
+# has been deleted.
+open_alerts_for() {
+    curl -s -H "Authorization: Key ${ALERTA_KEY}" "${ALERTA_URL}/alerts?status=open" \
+        | jq --arg r "$1" --arg e "${2:-}" \
+            '[.alerts[] | select(.resource == $r)
+                        | select($e == "" or (.event | contains($e)))] | length'
+}
+
+# Every open alert on a resource, one per line, for failure diagnostics.
+alert_texts_for() {
+    curl -s -H "Authorization: Key ${ALERTA_KEY}" "${ALERTA_URL}/alerts?status=open" \
+        | jq -r --arg r "$1" '.alerts[] | select(.resource == $r) | "\(.event): \(.text)"'
+}
+
+# Assert a matching alert shows up, printing what Alerta holds if none does.
+assert_alert() {
+    local resource=$1 event=${2:-} waited=0
+    while [ "${waited}" -lt "${TIMEOUT}" ]; do
+        [ "$(open_alerts_for "${resource}" "${event}")" -gt 0 ] && return 0
+        sleep "${POLL}"
+        waited=$((waited + POLL))
+    done
+    echo "# no ${event:-shacl} alert on ${resource} within ${TIMEOUT}s; open now:" >&3
+    alert_texts_for "${resource}" | sed 's/^/#   /' >&3 || true
+    return 1
+}
+
+# Assert the matching alerts close -- the assertion this file exists for.
+assert_no_alert() {
+    local resource=$1 event=${2:-} waited=0
+    while [ "${waited}" -lt "${TIMEOUT}" ]; do
+        [ "$(open_alerts_for "${resource}" "${event}")" -eq 0 ] && return 0
+        sleep "${POLL}"
+        waited=$((waited + POLL))
+    done
+    echo "# alerts on ${resource} still open after ${TIMEOUT}s:" >&3
+    alert_texts_for "${resource}" | sed 's/^/#   /' >&3
+    return 1
+}
+
+@test "scorpio and alerta are reachable with the platform credentials" {
+    token=$(get_token)
+    [ -n "${token}" ] && [ "${token}" != "null" ]
+    code=$(curl -s -o /dev/null -w '%{http_code}' \
+        -H "Authorization: Bearer ${token}" "${NGSILD_URL}/entities/urn:no-such-entity:0")
+    # 404 is the healthy answer here: authenticated, and the entity is absent.
+    [ "${code}" = "404" ]
+    code=$(curl -s -o /dev/null -w '%{http_code}' \
+        -H "Authorization: Key ${ALERTA_KEY}" "${ALERTA_URL}/alerts?status=open")
+    [ "${code}" = "200" ]
+}
+
+@test "an entity created in scorpio raises an alert, and deleting it clears the alert" {
+    # The plainest statement of the reported problem. An E2EMachine must carry
+    # exactly one hasE2EState; created without one it violates its shape, and
+    # once the entity is gone there is nothing left to violate it.
+    code=$(create_entity "${TEST_MISSING}" "${MACHINE_TYPE}")
+    [ "${code}" = "201" ]
+    echo "# created ${TEST_MISSING} without its mandatory attribute" >&3
+    assert_alert "${TEST_MISSING}" "${COUNT_CONSTRAINT}"
+
+    code=$(delete_entity "${TEST_MISSING}")
+    [ "${code}" = "204" ]
+    echo "# deleted ${TEST_MISSING} in scorpio" >&3
+    assert_no_alert "${TEST_MISSING}"
+}
+
+@test "deleting the entity a relationship points at alerts, and restoring it clears" {
+    # The far end first, so the link resolves and the machine starts clean.
+    code=$(create_entity "${TEST_TARGET}" "${CARTRIDGE_TYPE}")
+    [ "${code}" = "201" ]
+    code=$(create_entity "${TEST_LINKED}" "${LINKED_TYPE}" \
+        "$(relationship_json "${CARTRIDGE_REL}" "${TEST_TARGET}")")
+    [ "${code}" = "201" ]
+    echo "# ${TEST_LINKED} links to ${TEST_TARGET}" >&3
+
+    # Deleting the object leaves the subject untouched -- it still has exactly
+    # one relationship -- so this must be reported as a link that no longer
+    # resolves, and it must be reported against the entity that still exists.
+    code=$(delete_entity "${TEST_TARGET}")
+    [ "${code}" = "204" ]
+    assert_alert "${TEST_LINKED}" "${CLASS_CONSTRAINT}"
+
+    # Putting the target back has to retract it again. An alert that survives
+    # the condition that raised it is the failure this suite is here to catch.
+    code=$(create_entity "${TEST_TARGET}" "${CARTRIDGE_TYPE}")
+    [ "${code}" = "201" ]
+    echo "# restored ${TEST_TARGET}" >&3
+    assert_no_alert "${TEST_LINKED}"
+}
+
+@test "the model instance survives being deployed, deleted and deployed again" {
+    # The operator's actual loop, and the one that broke: deploy the model,
+    # look at the alerts, delete it, look again -- twice, because a deployment
+    # that only works the first time is not a working deployment.
+    #
+    # Deleting the model used to RAISE alerts rather than clear them. Every
+    # entity loses its attributes at the same moment it is deleted, the count
+    # of a mandatory property drops to zero, and unless the check can tell
+    # "attribute gone" from "entity gone" it reports the missing property on an
+    # entity that no longer exists -- permanently, because nothing recomputes a
+    # verdict for something Scorpio no longer has. Measured on the kms model:
+    # thirteen CountConstraint alerts that never cleared. So the assertion that
+    # matters is not that deleting is quiet, but that it is quiet TWICE, with a
+    # redeployment in between to prove the alerts still come back.
+
+    echo "# round 1: deploy" >&3
+    upsert_model
+    assert_model_alerting
+
+    echo "# round 1: delete" >&3
+    delete_model
+    assert_model_silent
+
+    echo "# round 2: deploy the same model instance again" >&3
+    upsert_model
+    assert_model_alerting
+
+    echo "# round 2: delete" >&3
+    delete_model
+    assert_model_silent
+}
+
+@test "an entity deleted in scorpio and created again alerts a second time" {
+    # A deletion is recorded as a tombstone, and a tombstone that is allowed to
+    # outrank everything written after it would suppress the entity for good --
+    # silently, because a missing alert looks exactly like a healthy entity.
+    # Recreating the same id has to raise the alert again.
+    code=$(create_entity "${TEST_RECREATE}" "${MACHINE_TYPE}")
+    [ "${code}" = "201" ]
+    assert_alert "${TEST_RECREATE}" "${COUNT_CONSTRAINT}"
+
+    code=$(delete_entity "${TEST_RECREATE}")
+    [ "${code}" = "204" ]
+    assert_no_alert "${TEST_RECREATE}"
+    echo "# ${TEST_RECREATE} deleted and its alert closed" >&3
+
+    code=$(create_entity "${TEST_RECREATE}" "${MACHINE_TYPE}")
+    [ "${code}" = "201" ]
+    echo "# recreated ${TEST_RECREATE} under the same id" >&3
+    assert_alert "${TEST_RECREATE}" "${COUNT_CONSTRAINT}"
+}

--- a/semantic-model/shacl2flink/tests/bats/test-shacl-flink-scorpio-e2e/test-shacl-flink-scorpio-e2e.bats
+++ b/semantic-model/shacl2flink/tests/bats/test-shacl-flink-scorpio-e2e/test-shacl-flink-scorpio-e2e.bats
@@ -184,7 +184,15 @@ delete_model() {
 # a deployment that alerts on everything would satisfy a one-sided check.
 assert_model_alerting() {
     assert_alert "${CYCLE_NOSTATE}" "${COUNT_CONSTRAINT}"
-    assert_alert "${CYCLE_DANGLING}" "${CLASS_CONSTRAINT}"
+    # A count, not a class violation. Those are two different situations and
+    # only one of them is this one: a link whose target existed and was then
+    # DELETED still counts as one relationship and fails the class check, which
+    # is what the test above asserts. A link to an id that never existed
+    # resolves to nothing at all, so the count is 0 and it is minCount that
+    # fails. Asserting the class component here passed locally only because the
+    # fixture uses fixed ids and an earlier run had left a stale class alert on
+    # this resource; a clean cluster reported the count, correctly.
+    assert_alert "${CYCLE_DANGLING}" "${COUNT_CONSTRAINT}"
     assert_no_alert "${CYCLE_GOOD}"
     assert_no_alert "${CYCLE_LINKED}"
     assert_no_alert "${CYCLE_CARTRIDGE}"

--- a/semantic-model/shacl2flink/tests/test_delete_semantics.py
+++ b/semantic-model/shacl2flink/tests/test_delete_semantics.py
@@ -156,12 +156,42 @@ def test_count_checks_do_not_group_by_edeleted():
                 f'{name}: edeleted is a grouping key again in {group_by.strip()}'
 
 
-def test_deleted_entities_never_reach_the_checks():
+def test_count_checks_read_edeleted():
     """
-    Deleted entities are filtered out of A1, so deleting one EMPTIES its groups
-    and Flink retracts their alerts the way it does for any group that ceases
-    to exist. This is what replaces the muting the GROUP BY used to do.
+    A count of zero means two different things and the count cannot tell them
+    apart: an entity that is alive and has lost its mandatory attribute must
+    alert, and an entity that has been deleted must not. Only `edeleted`
+    separates them, so every counting HAVING has to read it.
+
+    Filtering deleted entities out of A1 was tried instead, and made
+    correctness depend on the rows disappearing and a retraction propagating
+    through a LEFT JOIN and a COUNT(DISTINCT). Deleting the kms model in
+    Scorpio then raised thirteen CountConstraint alerts that never cleared,
+    while every row-level check -- each carrying `NOT edeleted` -- stayed
+    correctly silent.
     """
     for name, sql in _generated_checks().items():
-        assert 'COALESCE(A.`deleted`, false) = false' in sql, \
-            f'{name}: A1 admits deleted entities, so their alerts are never retracted'
+        clauses = re.findall(r'HAVING\s(.*?)(?:UNION\s+ALL|$)', sql,
+                             re.IGNORECASE | re.DOTALL)
+        assert clauses, f'{name}: no HAVING found to check'
+        for having in clauses:
+            assert 'edeleted' in having.lower(), \
+                f'{name}: a counting HAVING ignores edeleted, so it cannot ' \
+                f'tell "attribute gone" from "entity gone": {having.strip()[:120]}'
+
+
+def test_edeleted_is_aggregated_not_filtered_in_counts():
+    """
+    Reading `edeleted` in a HAVING only works if it is aggregated. A bare
+    column reference there would have to be a grouping key, which is the
+    migration bug test_count_checks_do_not_group_by_edeleted exists to prevent.
+    """
+    for name, sql in _generated_checks().items():
+        for having in re.findall(r'HAVING\s(.*?)(?:UNION\s+ALL|$)', sql,
+                                 re.IGNORECASE | re.DOTALL):
+            if 'edeleted' not in having.lower():
+                continue
+            assert re.search(r'(MAX|MIN|SUM|COUNT)\s*\([^)]*edeleted',
+                             having, re.IGNORECASE), \
+                f'{name}: edeleted appears unaggregated in a HAVING, which ' \
+                f'forces it into the GROUP BY: {having.strip()[:120]}'

--- a/semantic-model/shacl2flink/tests/test_no_late_record_dropping.py
+++ b/semantic-model/shacl2flink/tests/test_no_late_record_dropping.py
@@ -1,0 +1,176 @@
+#
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Entity state must not be discarded for arriving "late".
+
+The bridge stamps attribute and entity records with their observedAt, so the
+Kafka record timestamp is an event time taken from the data -- and one that
+spans years, because a value observed in 2024 is republished unchanged by every
+snapshot. Declaring that column a rowtime with WATERMARK FOR ts AS ts turns the
+attributes_view and entities_view dedups into EVENT-TIME Deduplicate operators
+with zero lateness tolerance.
+
+The consequence, measured on a cluster: a snapshot republishes all 251
+attributes in one burst; the first record carrying a recent observedAt drives
+the watermark to now; every remaining record in the burst with an older
+observedAt is late and silently dropped. 753 records went into the dedup and 4
+came out. Every join downstream was starved, and every constraint over them
+reported "Found 0" for attributes that were plainly present in the topic and in
+the store. Republishing a single value with a CURRENT timestamp made it visible
+within seconds.
+
+Nothing here needs event time. These are entity-state tables, not windowed
+analytics: the dedup wants "the newest row per key", which ORDER BY ts DESC
+gives just as well over an ordinary column, without a watermark deciding that
+older rows may be thrown away. alerts_bulk keeps its watermark, because the
+alerting path does use it.
+
+Batch never showed any of this -- SQLite has no watermarks and drops nothing --
+which is why the oracle agreed with Flink throughout.
+"""
+
+import pathlib
+
+import ruamel.yaml
+
+import create_core_tables
+import create_ngsild_tables
+
+
+def _tables(document):
+    """{table spec name: [field dicts]} from a generated table document.
+
+    Parsed leniently: these files end with Helm template directives, which are
+    not YAML, so the loader raises once it reaches them. Everything before that
+    point is what we came for.
+    """
+    tables = {}
+    try:
+        for section in ruamel.yaml.YAML(typ='safe').load_all(document):
+            if not section or 'spec' not in section:
+                continue
+            spec = section['spec']
+            if 'fields' in spec:
+                tables[spec.get('name')] = spec['fields']
+    except ruamel.yaml.YAMLError:
+        pass
+    return tables
+
+
+def _core_tables():
+    """create_core_tables.py writes to its own output folder, not a given one."""
+    create_core_tables.main()
+    return _tables(pathlib.Path('output/core.yaml').read_text())
+
+
+def _field_names(fields):
+    return {name.strip('`') for field in fields for name in field}
+
+
+def test_attributes_table_has_no_watermark():
+    """The regression: 753 rows in, 4 out, and "Found 0" everywhere."""
+    tables = _core_tables()
+    assert 'attributes' in tables, 'create_core_tables.py emitted no attributes table'
+    assert 'watermark' not in _field_names(tables['attributes'])
+
+
+def test_entities_table_has_no_watermark(tmp_path):
+    create_ngsild_tables.main(output_folder=str(tmp_path))
+    tables = _tables((tmp_path / 'ngsild.yaml').read_text())
+    entities = [name for name in tables if name and 'entities' in name]
+    assert entities, 'create_ngsild_tables.py emitted no entities table'
+    for name in entities:
+        assert 'watermark' not in _field_names(tables[name]), \
+            f'{name} declares a watermark again'
+
+
+def test_the_timestamp_column_is_still_there():
+    """Only the rowtime DECLARATION goes; ordering still needs the column.
+
+    attributes_view picks the newest row per key with ORDER BY ts DESC. Dropping
+    ts along with the watermark would leave the dedup with nothing to order by.
+    """
+    tables = _core_tables()
+    assert 'ts' in _field_names(tables['attributes'])
+
+
+def test_alerts_bulk_keeps_its_watermark():
+    """The change is targeted, not a blanket removal.
+
+    The alerting path genuinely uses event time; only the entity-state tables
+    are wrong to.
+    """
+    tables = _core_tables()
+    assert 'watermark' in _field_names(tables['alerts_bulk'])
+
+
+def _view_statements(document):
+    """{view spec name: sqlstatement} from a generated table document."""
+    views = {}
+    try:
+        for section in ruamel.yaml.YAML(typ='safe').load_all(document):
+            if not section or 'spec' not in section:
+                continue
+            spec = section['spec']
+            if 'sqlstatement' in spec:
+                views[spec.get('name')] = spec['sqlstatement']
+    except ruamel.yaml.YAMLError:
+        pass
+    return views
+
+
+def test_attributes_table_exposes_the_kafka_offset():
+    """The dedup needs an arrival order to break ties on."""
+    tables = _core_tables()
+    assert 'offset' in _field_names(tables['attributes'])
+
+
+def test_attributes_view_breaks_ties_by_offset():
+    """The regression: a delete that ties on ts must still win.
+
+    debeziumBridge stamps a delete with the timestamp of the value it deletes,
+    deliberately the same one, so the two tie. That relied on the tie being
+    broken by arrival, which held while this compiled into Flink's Deduplicate.
+    Without the watermark it is a general Rank, and Rank keeps the INCUMBENT on
+    a tie -- so the delete lost and the attribute stayed live indefinitely.
+
+    Measured: urn:filter:1's hasXXXWorkpiece was deleted in Scorpio, the delete
+    published, and the job went on counting it until the same delete was
+    republished with a strictly greater timestamp.
+    """
+    create_core_tables.main()
+    statement = _view_statements(pathlib.Path('output/core.yaml').read_text())['attributes_view']
+    assert 'ORDER BY ts DESC, `offset` DESC' in statement
+
+
+def test_a_view_without_an_offset_column_still_orders_by_ts_alone(tmp_path):
+    """entities has no offset metadata, so the tie-break must not be emitted."""
+    create_ngsild_tables.main(output_folder=str(tmp_path))
+    views = _view_statements((tmp_path / 'ngsild.yaml').read_text())
+    entities = [s for name, s in views.items() if name and 'entities' in name]
+    assert entities, 'no entities view generated'
+    for statement in entities:
+        assert '`offset`' not in statement
+        assert 'ORDER BY ts DESC' in statement
+
+
+def test_the_offset_is_not_exposed_by_the_view():
+    """It is an ordering key, not part of the view's schema."""
+    create_core_tables.main()
+    statement = _view_statements(pathlib.Path('output/core.yaml').read_text())['attributes_view']
+    header = statement.split('FROM (')[0]
+    assert '`offset`' not in header

--- a/semantic-model/shacl2flink/tests/test_utils.py
+++ b/semantic-model/shacl2flink/tests/test_utils.py
@@ -147,7 +147,7 @@ def test_create_sql_view():
 \n`fieldname` FROM (\
 \n  SELECT *,\
 \nROW_NUMBER() OVER (PARTITION BY \
-\nORDER BY ts DESC) AS rownum\
+\nORDER BY ts DESC, rowid DESC) AS rownum\
 \nFROM `table_name` )\
 \nWHERE rownum = 1;\n'
 
@@ -160,7 +160,7 @@ def test_create_sql_view():
 \n`id` FROM (\
 \n  SELECT *,\
 \nROW_NUMBER() OVER (PARTITION BY \
-\nORDER BY ts DESC) AS rownum\
+\nORDER BY ts DESC, rowid DESC) AS rownum\
 \nFROM `table_name` )\
 \nWHERE rownum = 1;\n'
 


### PR DESCRIPTION
Deleting entities in Scorpio raised alerts instead of clearing them, and the
alerts never went away. Reproduced on a live cluster: upsert the `kms` model →
0 alerts (it is valid); delete all five entities → **13 CountConstraint alerts**,
still open a quarter of an hour later with Scorpio empty. Reproduced again with
the deletions spaced 45 s apart, so it is not a concurrency effect.

## Cause

A count of zero means two different things, and the count cannot tell them
apart:

- an entity that is **alive** and has lost its mandatory attribute → must alert
- an entity that has been **deleted** → must not alert

Only `edeleted` separates the two. Every stuck alert was a
`CountConstraintComponent`; no row-level constraint ever stuck, because those
all carry `NOT edeleted`.

`7287b026` removed `edeleted` from the count `GROUP BY`, which was necessary and
stays — as a grouping key it makes a deleted entity *migrate* its rows from
group `(id, false)` to `(id, true)` instead of emptying the first, and a
retraction landing in a group whose accumulator was rebuilt from fewer rows is
what drove the SUM negative and reported "-1 relationships". But it replaced the
guard with a filter that dropped deleted entities from A1 altogether, which made
correctness depend on the rows *disappearing* and a retraction propagating
through a `LEFT JOIN` and a `COUNT(DISTINCT)`. That is the half that fails.

## Fix

Deleted entities stay in A1 carrying the flag, and both counting `HAVING`s read
it as an **aggregate**:

```sql
MAX(CASE WHEN edeleted THEN 1 ELSE 0 END) = 0
```

Aggregated, it is not a grouping key, so nothing migrates and no accumulator is
rebuilt; and the alert is suppressed by re-evaluating the same group rather than
by waiting for its rows to vanish. Nothing has to be retracted for the answer to
be right.

The guard sits inside the existing `HAVING`, so it can only narrow what counts
as a violation — it cannot add emissions. Measured on an idle model:
`iff.alerts.bulk` carries only the alerta-bridge's 1/sec heartbeat and
`iff.alerts` took 0 messages in 60 s.

## Also here

- **`kms/model-instance.jsonld` could not be loaded at all.** Its four
  `observedAt` values were written `2024-02-28 13:52:32.0` — a space where ISO
  8601 wants a `T`, and no timezone — so Scorpio rejected `urn:filter:1` with
  *"Invalid date time format found on observedAt"*. `entityOperations/upsert`
  answers **207** rather than an error, so four entities were created, one was
  not, and nothing looked wrong: the missing entity showed up only as dangling
  relationships on the ones that did load. rdflib parses either spelling, which
  is why the offline pipeline never saw it.

- **A Scorpio-level e2e suite.** `test-shacl-flink-e2e` publishes to Kafka
  directly, so a failure there points at Flink rather than at everything
  upstream. That leaves both ends of the chain untested — Scorpio, Postgres, the
  Debezium connector and the bridges on the way in, the alerta-bridge on the way
  out — which is where these failures actually lived. The central test walks the
  loop that broke: deploy the model, check, delete, check, **deploy and delete a
  second time**, because a deployment that works once and not twice is not a
  working deployment. `upsert_model` fails on 207.

- `bc70cf9a` and `7d395413` are carried along: entity state was being discarded
  as late, and a delete stamped with the value's own `observedAt` tied with that
  value and lost the dedup.

## Verification

Both directions, because suppressing the count checks outright would look
identical to a fix if only deletions were measured:

| check | before | after |
|---|---|---|
| delete whole model in Scorpio | 13 permanent alerts | **0** |
| live violating entity | 3 alerts | **3 alerts** (still fires) |
| delete that entity | — | **0** |

- 183 unit tests
- 111 SQLite fixtures (batch semantics unchanged — a deleted entity produced no
  alert before by being filtered out, and produces none now by being guarded)
- 5/5 Scorpio e2e tests against a live cluster, including the deploy/delete/
  deploy/delete loop

`test_deleted_entities_never_reach_the_checks` asserted the filter and is
replaced by two tests asserting what actually has to hold: that every counting
`HAVING` reads `edeleted`, and that it reads it aggregated so it can never
become a grouping key again.
