### PR TITLE
Make the material waste-class use case work end to end

### DIFF
--- a/FlinkOperatorWithCoreServices/CoreServices/src/main/resources/sql_statements.sql
+++ b/FlinkOperatorWithCoreServices/CoreServices/src/main/resources/sql_statements.sql
@@ -23,9 +23,12 @@ FROM (
          because the bridge put it in the record stamp. `ts` is the write time
          now, so reading it here would stamp every attribute written back to
          Scorpio with the moment we happened to forward it. */
-      || '"observedAt":"' 
-         || DATE_FORMAT(COALESCE(`observedAt`, `ts`), 'yyyy-MM-dd''T''HH:mm:ss.') 
-         || CAST(EXTRACT(MILLISECOND FROM COALESCE(`observedAt`, `ts`)) AS STRING) || 'Z",'
+      || '"observedAt":"'
+         || DATE_FORMAT(COALESCE(`observedAt`, `ts`), 'yyyy-MM-dd''T''HH:mm:ss.')
+         /* zero-padded: '.10Z' would mean 10ms rendered as if it were 100ms,
+            and unpadded fractions break the fixed-width ISO form that makes
+            lexical comparison equal chronological comparison */
+         || LPAD(CAST(EXTRACT(MILLISECOND FROM COALESCE(`observedAt`, `ts`)) AS STRING), 3, '0') || 'Z",'
       || '"type":"' || type || '",'
       || '"datasetId":"' 
          || IF(datasetId IS NOT NULL, datasetId, '@none') || '"'
@@ -46,7 +49,18 @@ FROM (
                WHEN nodeType = '@json' THEN
                  ',"value":' || attributeValue
                WHEN nodeType = '@value' THEN
-                 ',"value":' || attributeValue
+                 /* a bare @value is only valid unquoted JSON when it IS a
+                    JSON literal (number, boolean, null). A string value --
+                    an ISO timestamp a rule copied from an observedAt, for
+                    instance -- must be quoted, or the whole ngsild_updates
+                    record is unparseable and the bridge drops it. */
+                 CASE
+                   WHEN REGEXP(attributeValue, '^-?[0-9]+(\.[0-9]+)?([eE][-+]?[0-9]+)?$')
+                        OR attributeValue IN ('true', 'false', 'null') THEN
+                     ',"value":' || attributeValue
+                   ELSE
+                     ',"value":"' || attributeValue || '"'
+                 END
                ELSE
                  ',"value":"' || attributeValue || '"'
              END

--- a/KafkaBridge/lib/ngsildUpdates.js
+++ b/KafkaBridge/lib/ngsildUpdates.js
@@ -63,6 +63,23 @@ const removeDefaultDatasetID = function (entities) {
   });
 };
 
+/**
+ * True when any attribute of the entity carries an IRI value ({"@id": ...}).
+ * Scorpio's batchMerge rejects those with 400/22023 while the per-entity
+ * attrs endpoint accepts them, so they must take the other route.
+ */
+const hasIriValue = function (entity) {
+  return Object.keys(entity).some(function (key) {
+    if (key === 'id' || key === 'type') {
+      return false;
+    }
+    const attrs = Array.isArray(entity[key]) ? entity[key] : [entity[key]];
+    return attrs.some(attr => attr !== null && typeof attr === 'object' &&
+      attr.value !== null && typeof attr.value === 'object' &&
+      (attr.value['@id'] !== undefined || attr.value.id !== undefined));
+  });
+};
+
 module.exports = function NgsildUpdates (conf) {
   const config = conf;
   const ngsild = new NgsiLd(config);
@@ -112,6 +129,10 @@ module.exports = function NgsildUpdates (conf) {
         entities = JSON.parse(body.entities);
       } catch (e) {
         logger.error('Could not parse entities field. Ignoring record.' + body.entities);
+        // without this return the undefined entities crashed the caller's
+        // batch loop, so one malformed record silenced every valid update
+        // behind it
+        return;
       }
     } else {
       entities = body.entities;
@@ -133,9 +154,31 @@ module.exports = function NgsildUpdates (conf) {
           logger.error('Unhealthy entities - ignoring it:' + JSON.stringify(entities));
         } else {
           logger.debug('Updating: ' + JSON.stringify(entities));
-          result = await ngsild.batchMerge(entities, { headers });
-          if (result.statusCode !== 204 && result.statusCode !== 207) {
-            logger.error('Entity cannot run merge:' + JSON.stringify(result.body) + ' and status code ' + result.statusCode); // throw no error, log it and ignore it, repeating would probably not solve it
+          // Scorpio's batchMerge cannot digest IRI-valued properties
+          // (value: {"@id": ...} answers 400/22023), which is exactly what
+          // a rule writing e.g. a waste class produces. Those entities go
+          // through the per-entity attrs endpoint, which accepts them; the
+          // rest keeps the batch path.
+          const mergeable = entities.filter(entity => !hasIriValue(entity));
+          const iriValued = entities.filter(hasIriValue);
+          if (mergeable.length > 0) {
+            result = await ngsild.batchMerge(mergeable, { headers });
+            if (result.statusCode !== 204 && result.statusCode !== 207) {
+              logger.error('Entity cannot run merge:' + JSON.stringify(result.body) + ' and status code ' + result.statusCode); // throw no error, log it and ignore it, repeating would probably not solve it
+            }
+          }
+          for (const entity of iriValued) {
+            const attrs = {};
+            Object.keys(entity).forEach(function (key) {
+              if (key !== 'id' && key !== 'type') {
+                attrs[key] = entity[key];
+              }
+            });
+            result = await ngsild.updateProperties(
+              { id: entity.id, body: attrs, isOverwrite: true }, { headers });
+            if (result.statusCode !== 204 && result.statusCode !== 207) {
+              logger.error('Entity cannot update properties:' + JSON.stringify(result.body) + ' and status code ' + result.statusCode);
+            }
           }
         }
       } else if (op === 'upsert') {

--- a/KafkaBridge/test/testLibNgsildUpdates.js
+++ b/KafkaBridge/test/testLibNgsildUpdates.js
@@ -533,6 +533,165 @@ describe('Test libNgsildUpdates', function () {
     batchMergeCalled.should.equal(true);
     revert();
   });
+
+  it('Should ignore an unparseable entities string without throwing', async function () {
+    let batchMergeCalled = false;
+    const config = {
+      ngsildUpdates: {
+        clientSecretVariable: 'CLIENT_SECRET',
+        refreshIntervalInSeconds: 200
+      },
+      keycloak: {
+        ngsildUpdatesAuthService: {
+        }
+      },
+      bridgeCommon: {
+        kafkaSyncOnAttribute: 'kafkaSyncOn'
+      }
+    };
+    const Logger = function () {
+      return logger;
+    };
+    const process = {
+      env: {
+        CLIENT_SECRET: 'client_secret'
+      }
+    };
+    // an unquoted ISO timestamp made a rule-written record unparseable, and
+    // the bridge then crashed its whole batch instead of skipping the record
+    const body = {
+      op: 'update',
+      entities: '[{"id":"id","value":2026-08-24T19:19:43.588Z}]',
+      overwriteOrReplace: false
+    };
+    const Ngsild = function () {
+      return {
+        batchMerge: function (entities, { headers }) {
+          batchMergeCalled = true;
+          return new Promise(function (resolve) {
+            resolve({ statusCode: 204 });
+          });
+        },
+        replaceEntities: function () {
+        }
+      };
+    };
+    const setInterval = function (fun, interv) {
+    };
+    const Keycloak = function () {
+      return {
+        grantManager: {
+          obtainFromClientCredentials: async function () {
+            return new Promise(function (resolve, reject) {
+              resolve({
+                access_token: {
+                  token: 'token'
+                }
+              });
+            });
+          }
+        }
+      };
+    };
+    const revert = ToTest.__set__('Logger', Logger);
+    ToTest.__set__('process', process);
+    ToTest.__set__('NgsiLd', Ngsild);
+    ToTest.__set__('setInterval', setInterval);
+    ToTest.__set__('Keycloak', Keycloak);
+    ToTest.__set__('addSyncOnAttribute', addSyncOnAttribute);
+    const ngsildUpdates = new ToTest(config);
+    await ngsildUpdates.ngsildUpdates(body);
+    batchMergeCalled.should.equal(false);
+    revert();
+  });
+
+  it('Should route IRI-valued properties to updateProperties, not batchMerge', async function () {
+    let batchMergeCalled = false;
+    let updatePropertiesId = null;
+    let updatePropertiesBody = null;
+    const config = {
+      ngsildUpdates: {
+        clientSecretVariable: 'CLIENT_SECRET',
+        refreshIntervalInSeconds: 200
+      },
+      keycloak: {
+        ngsildUpdatesAuthService: {
+        }
+      },
+      bridgeCommon: {
+        kafkaSyncOnAttribute: 'kafkaSyncOn'
+      }
+    };
+    const Logger = function () {
+      return logger;
+    };
+    const process = {
+      env: {
+        CLIENT_SECRET: 'client_secret'
+      }
+    };
+    const wasteclass = {
+      type: 'Property',
+      value: { '@id': 'https://example.com/WC2' }
+    };
+    const body = {
+      op: 'update',
+      entities: [{
+        id: 'urn:cartridge',
+        'https://example.com/hasWasteclass': [wasteclass]
+      }],
+      overwriteOrReplace: false
+    };
+    const Ngsild = function () {
+      return {
+        batchMerge: function (entities, { headers }) {
+          batchMergeCalled = true;
+          return new Promise(function (resolve) {
+            resolve({ statusCode: 204 });
+          });
+        },
+        updateProperties: function ({ id, body, isOverwrite }, { headers }) {
+          updatePropertiesId = id;
+          updatePropertiesBody = body;
+          return new Promise(function (resolve) {
+            resolve({ statusCode: 204 });
+          });
+        },
+        replaceEntities: function () {
+        }
+      };
+    };
+    const setInterval = function (fun, interv) {
+    };
+    const Keycloak = function () {
+      return {
+        grantManager: {
+          obtainFromClientCredentials: async function () {
+            return new Promise(function (resolve, reject) {
+              resolve({
+                access_token: {
+                  token: 'token'
+                }
+              });
+            });
+          }
+        }
+      };
+    };
+    const revert = ToTest.__set__('Logger', Logger);
+    ToTest.__set__('process', process);
+    ToTest.__set__('NgsiLd', Ngsild);
+    ToTest.__set__('setInterval', setInterval);
+    ToTest.__set__('Keycloak', Keycloak);
+    ToTest.__set__('addSyncOnAttribute', addSyncOnAttribute);
+    const ngsildUpdates = new ToTest(config);
+    await ngsildUpdates.ngsildUpdates(body);
+    batchMergeCalled.should.equal(false);
+    updatePropertiesId.should.equal('urn:cartridge');
+    updatePropertiesBody['https://example.com/hasWasteclass'][0]
+      .value['@id'].should.equal('https://example.com/WC2');
+    revert();
+  });
 });
 describe('Test getFlag', function () {
   it('Should get true', async function () {

--- a/semantic-model/kms/README.md
+++ b/semantic-model/kms/README.md
@@ -1,0 +1,31 @@
+# Knowledge, Models, Shapes (KMS)
+
+The default knowledge base of the platform: `knowledge.ttl` (ontology facts),
+`shacl.ttl` (constraints and SPARQL rules), and `model-instance.jsonld`
+(example entities; `model-instance.scorpio.jsonld` is the variant with one
+attribute instance per datasetId that Scorpio's batch upsert accepts).
+
+## Conventions
+
+### Timestamps
+
+Every timestamp carried as a **property value** uses ISO 8601 UTC with
+millisecond precision and the `Z` suffix:
+
+```
+YYYY-MM-DDTHH:mm:ss.SSSZ        e.g. 2024-02-27T13:54:55.400Z
+```
+
+This is the same representation NGSI-LD prescribes for `observedAt`, so one
+format flows from model to TSDB to writeback. The form is fixed-width, which
+makes lexical order equal chronological order — SPARQL rules may compare two
+timestamps directly (`FILTER(?ts1 > ?ts2)`), and `xsd:dateTime(?v)`
+normalizes a value into this canonical form for such comparisons. Rules that
+copy an attribute's `ngsild:observedAt` into a property value emit this form
+as well.
+
+Do not write epoch numbers into time-valued properties: they are ambiguous
+(seconds vs milliseconds), untyped, and the two SQL dialects the pipeline
+compiles to do not even share an epoch for their internal conversions.
+Millisecond arithmetic remains available inside rule expressions — arithmetic
+on time variables converts to milliseconds automatically.

--- a/semantic-model/kms/model-instance.jsonld
+++ b/semantic-model/kms/model-instance.jsonld
@@ -5,10 +5,12 @@
     "type": "iffBaseEntities:Machine",
     "iffBaseEntities:hasState": [
       {
-      "type": "Property",
-      "value": {
-        "@id": "base:state_ON"
-      }}]
+        "type": "Property",
+        "value": {
+          "@id": "base:state_ON"
+        }
+      }
+    ]
   },
   {
     "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
@@ -16,71 +18,30 @@
     "type": "iffBaseEntities:Cutter",
     "iffBaseEntities:hasState": [
       {
-      "iffBaseEntities:hasXXXWorkpiece": {
-        "type": "Relationship",
-        "object": "urn:workpiece:1"
-      },
-      "type": "Property",
-      "value": {
-        "@id": "base:state_PROCESSING"
-      }}],
-      "iffBaseEntities:hasList": {
-        "type": "ListProperty",
-        "valueList": []
-      },
-      "iffBaseEntities:hasJSON": {
-        "type": "JsonProperty",
-        "json": {}
-      },
-      "iffBaseEntities:hasFilter": [
-        {
-          "type": "Relationship",
-          "object": "urn:filter:1",
-          "iffBaseEntities:hasTrust": [{
-            "value": 2.1,
-            "type": "Property",
-            "iffBaseEntities:hasOutWorkpiecexx": { 
-              "type": "Property",
-              "value": 2.0,
-              "datasetId": "urn:index:1"
-            }
-          }]
-        }
-      ],
-      "iffBaseEntities:hasInWorkpiece": [
-        {
+        "iffBaseEntities:hasXXXWorkpiece": {
           "type": "Relationship",
           "object": "urn:workpiece:1"
+        },
+        "type": "Property",
+        "value": {
+          "@id": "base:state_PROCESSING"
         }
-      ]
-  },
-  {
-    "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
-    "id": "urn:plasmacutter:2",
-    "type": "iffBaseEntities:Plasmacutter",
-    "iffBaseEntities:hasState": [
+      }
+    ],
+    "iffBaseEntities:hasList": {
+      "type": "ListProperty",
+      "valueList": []
+    },
+    "iffBaseEntities:hasJSON": {
+      "type": "JsonProperty",
+      "json": {}
+    },
+    "iffBaseEntities:hasFilter": [
       {
-      "iffBaseEntities:hasXXXWorkpiece": {
         "type": "Relationship",
-        "object": "urn:workpiece:1"
-      },
-      "type": "Property",
-      "value": {
-        "@id": "base:state_PROCESSING"
-      }}],
-      "iffBaseEntities:hasList": {
-        "type": "ListProperty",
-        "valueList": []
-      },
-      "iffBaseEntities:hasJSON": {
-        "type": "JsonProperty",
-        "json": {}
-      },
-      "iffBaseEntities:hasFilter": [
-        {
-          "type": "Relationship",
-          "object": "urn:filter:2",
-          "iffBaseEntities:hasTrust": [{
+        "object": "urn:filter:1",
+        "iffBaseEntities:hasTrust": [
+          {
             "value": 2.1,
             "type": "Property",
             "iffBaseEntities:hasOutWorkpiecexx": {
@@ -88,31 +49,81 @@
               "value": 2.0,
               "datasetId": "urn:index:1"
             }
-          }]
-        }
-      ],
-      "iffBaseEntities:hasInWorkpiece": [
-        {
+          }
+        ]
+      }
+    ],
+    "iffBaseEntities:hasInWorkpiece": [
+      {
+        "type": "Relationship",
+        "object": "urn:workpiece:1"
+      }
+    ]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
+    "id": "urn:plasmacutter:2",
+    "type": "iffBaseEntities:Plasmacutter",
+    "iffBaseEntities:hasState": [
+      {
+        "iffBaseEntities:hasXXXWorkpiece": {
           "type": "Relationship",
           "object": "urn:workpiece:1"
+        },
+        "type": "Property",
+        "value": {
+          "@id": "base:state_PROCESSING"
         }
-      ]
+      }
+    ],
+    "iffBaseEntities:hasList": {
+      "type": "ListProperty",
+      "valueList": []
+    },
+    "iffBaseEntities:hasJSON": {
+      "type": "JsonProperty",
+      "json": {}
+    },
+    "iffBaseEntities:hasFilter": [
+      {
+        "type": "Relationship",
+        "object": "urn:filter:2",
+        "iffBaseEntities:hasTrust": [
+          {
+            "value": 2.1,
+            "type": "Property",
+            "iffBaseEntities:hasOutWorkpiecexx": {
+              "type": "Property",
+              "value": 2.0,
+              "datasetId": "urn:index:1"
+            }
+          }
+        ]
+      }
+    ],
+    "iffBaseEntities:hasInWorkpiece": [
+      {
+        "type": "Relationship",
+        "object": "urn:workpiece:1"
+      }
+    ]
   },
   {
     "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
     "id": "urn:filter:2",
     "type": "iffBaseEntities:Filter",
     "iffBaseEntities:hasState": [
-    {
-      "type": "Property",
-      "value": {
-        "@id": "base:state_ON"
+      {
+        "type": "Property",
+        "value": {
+          "@id": "base:state_ON"
+        }
       }
-    }],
+    ],
     "iffBaseEntities:hasCartridge": [
       {
-          "type": "Relationship",
-          "object": "urn:cartridge:1"
+        "type": "Relationship",
+        "object": "urn:cartridge:2"
       }
     ],
     "iffBaseEntities:hasStrength": [
@@ -128,16 +139,17 @@
     "id": "urn:filter:1",
     "type": "iffBaseEntities:Filter",
     "iffBaseEntities:hasState": [
-    {
-      "type": "Property",
-      "value": {
-        "@id": "base:state_ON"
+      {
+        "type": "Property",
+        "value": {
+          "@id": "base:state_ON"
+        }
       }
-    }],
+    ],
     "iffBaseEntities:hasCartridge": [
       {
-          "type": "Relationship",
-          "object": "urn:cartridge:1"
+        "type": "Relationship",
+        "object": "urn:cartridge:1"
       }
     ],
     "iffBaseEntities:hasStrength": [
@@ -167,55 +179,81 @@
     "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
     "id": "urn:cartridge:1",
     "type": "iffBaseEntities:FilterCartridge",
-    
     "iffBaseEntities:isUsedUntil": [
       {
         "type": "Property",
-        "value": "2024-02-27 13:54:55.4"
-      }],
-      "iffBaseEntities:isUsedFrom": [
-        {
-          "type": "Property",
-          "value": "2024-02-27 13:54:55.4"
-        }],
-      "iffFilterEntities:hasWasteclass":[
-        {
-          "type": "Property",
-          "value": {
-            "@id": "iffFilterKnowledge:WC1"
-          }
-        }        
-      ]
+        "value": "2024-02-27T13:54:55.400Z"
+      }
+    ],
+    "iffBaseEntities:isUsedFrom": [
+      {
+        "type": "Property",
+        "value": "2024-02-27T13:54:55.400Z"
+      }
+    ],
+    "iffFilterEntities:hasWasteclass": [
+      {
+        "type": "Property",
+        "value": {
+          "@id": "iffFilterKnowledge:WC1"
+        }
+      }
+    ]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
+    "id": "urn:cartridge:2",
+    "type": "iffBaseEntities:FilterCartridge",
+    "iffBaseEntities:isUsedUntil": [
+      {
+        "type": "Property",
+        "value": "2024-02-27T13:54:55.400Z"
+      }
+    ],
+    "iffBaseEntities:isUsedFrom": [
+      {
+        "type": "Property",
+        "value": "2024-02-27T13:54:55.400Z"
+      }
+    ],
+    "iffFilterEntities:hasWasteclass": [
+      {
+        "type": "Property",
+        "value": {
+          "@id": "iffFilterKnowledge:WC1"
+        }
+      }
+    ]
   },
   {
     "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
     "id": "urn:workpiece:1",
     "type": "iffBaseEntities:Workpiece",
-    
     "iffBaseEntities:hasMaterial": [
       {
         "type": "Property",
         "value": {
           "@id": "material:EN_1.4301"
         }
-      }],
-      "iffBaseEntities:hasHeight": [
-        {
-          "type": "Property",
-          "value": 5
-        }
-      ],
-      "iffBaseEntities:hasLength": [
-        {
-          "type": "Property",
-          "value": 100
-        }
-      ],
-      "iffBaseEntities:hasWidth": [
-        {
-          "type": "Property",
-          "value": 100
-        }
-      ]
+      }
+    ],
+    "iffBaseEntities:hasHeight": [
+      {
+        "type": "Property",
+        "value": 5
+      }
+    ],
+    "iffBaseEntities:hasLength": [
+      {
+        "type": "Property",
+        "value": 100
+      }
+    ],
+    "iffBaseEntities:hasWidth": [
+      {
+        "type": "Property",
+        "value": 100
+      }
+    ]
   }
 ]

--- a/semantic-model/kms/model-instance.scorpio.jsonld
+++ b/semantic-model/kms/model-instance.scorpio.jsonld
@@ -123,7 +123,7 @@
     "iffBaseEntities:hasCartridge": [
       {
         "type": "Relationship",
-        "object": "urn:cartridge:1"
+        "object": "urn:cartridge:2"
       }
     ],
     "iffBaseEntities:hasStrength": [
@@ -167,13 +167,38 @@
     "iffBaseEntities:isUsedUntil": [
       {
         "type": "Property",
-        "value": "2024-02-27 13:54:55.4"
+        "value": "2024-02-27T13:54:55.400Z"
       }
     ],
     "iffBaseEntities:isUsedFrom": [
       {
         "type": "Property",
-        "value": "2024-02-27 13:54:55.4"
+        "value": "2024-02-27T13:54:55.400Z"
+      }
+    ],
+    "iffFilterEntities:hasWasteclass": [
+      {
+        "type": "Property",
+        "value": {
+          "@id": "iffFilterKnowledge:WC1"
+        }
+      }
+    ]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/staging/example/v0.2/context.jsonld",
+    "id": "urn:cartridge:2",
+    "type": "iffBaseEntities:FilterCartridge",
+    "iffBaseEntities:isUsedUntil": [
+      {
+        "type": "Property",
+        "value": "2024-02-27T13:54:55.400Z"
+      }
+    ],
+    "iffBaseEntities:isUsedFrom": [
+      {
+        "type": "Property",
+        "value": "2024-02-27T13:54:55.400Z"
       }
     ],
     "iffFilterEntities:hasWasteclass": [

--- a/semantic-model/kms/shacl.ttl
+++ b/semantic-model/kms/shacl.ttl
@@ -29,7 +29,18 @@
             sh:property [ sh:maxCount 1 ;
                     sh:minCount 1 ;
                     sh:nodeKind sh:Literal ;
-                    sh:path ngsild:hasValue ] ] ;
+                    sh:path ngsild:hasValue ] ],
+        # A cartridge is physically installed in ONE filter. Two filters
+        # sharing a cartridge is the modelling mistake that lets one filter's
+        # waste-class escalation leak into another filter's cartridge, so it
+        # must raise a standing alert rather than wait to be noticed in the
+        # data. Both hops are spelled out because an NGSI-LD relationship
+        # reaches its target through ngsild:hasObject -- a bare inverse of
+        # hasCartridge matches nothing at all.
+        [ sh:maxCount 1 ;
+            sh:order 30 ;
+            sh:path ( [ sh:inversePath ngsild:hasObject ]
+                      [ sh:inversePath iffBaseEntities:hasCartridge ] ) ] ;
     sh:targetClass iffBaseEntities:FilterCartridge .
 
 :CutterShape a sh:NodeShape ;

--- a/semantic-model/shacl2flink/docs/supported-features.md
+++ b/semantic-model/shacl2flink/docs/supported-features.md
@@ -885,7 +885,68 @@ Supporting them means deciding what their value *is* for comparison -- a
 language map is not a scalar -- and adding them to both `attributes_query` and
 `VALUE_PATH_ATTRIBUTE_TYPES`. Until then the answer is an error, not a guess.
 
-## sh:message
+## Inverse property paths
+
+An inverse path with `sh:minCount`/`sh:maxCount` is supported. The focus node
+is the *referenced* entity and the counted value nodes are the entities
+referring to it -- a statement no forward path can express:
+
+```turtle
+:CartridgeShape a sh:NodeShape ;
+    sh:targetClass iffBaseEntities:FilterCartridge ;
+    # a cartridge is physically installed in at most ONE filter
+    sh:property [ sh:path ( [ sh:inversePath ngsild:hasObject ]
+                            [ sh:inversePath iffBaseEntities:hasCartridge ] ) ;
+                  sh:maxCount 1 ] .
+```
+
+**Both hops are required, and a bare `[ sh:inversePath P ]` is rejected.**
+NGSI-LD does not store a relationship as one triple: `filter hasCartridge
+cartridge` is `filter hasCartridge _:b` plus `_:b hasObject cartridge`. So an
+inverse of `hasCartridge` alone matches *nothing* -- a standard SHACL engine
+reports no violation for it, whatever the data. Reading it as "who references
+me" would make this compiler disagree with the reference engine about what a
+shape means, so the build fails and names the spelling that works. It is the
+same explicitness the forward relationship shapes already require, where the
+value shape names `ngsild:hasObject` in so many words.
+
+A violation is reported on the referenced entity as
+`CountConstraintComponent(^P)` -- the `^` is SPARQL's inverse-path syntax and
+keeps the event distinct from a forward count on the same predicate.
+
+Semantics and scope:
+
+- Referrers are counted **DISTINCT**, which is SHACL rather than hygiene: the
+  value nodes of an inverse path are a *set* of referring entities, so a
+  referrer carrying several attribute instances of the relationship counts
+  once.
+- Only *live* references count: the attribute row, the referring entity and
+  the focus node each carry their own deletion flag, and all three are
+  honoured.
+- `sh:maxCount 0` is a *prohibition* -- "this decommissioned part must not be
+  installed anywhere" -- and compiles like any other bound.
+- Plain-IRI inverse paths on a top-level property shape only -- no nesting,
+  no connectives, no value shape (the referring entities are not attribute
+  values, so none of the value machinery applies).
+
+Count bounds are the only supported parameters, and **the build rejects
+anything else on an inverse shape** rather than accepting it unchecked:
+
+| written on an inverse shape | outcome |
+|---|---|
+| `sh:minCount` / `sh:maxCount` | compiled |
+| no bound at all | **build fails** -- constrains nothing |
+| `sh:class`, `sh:nodeKind`, `sh:property`, … | **build fails** -- not evaluated here |
+| a bare `[ sh:inversePath P ]` | **build fails** -- matches nothing in NGSI-LD |
+| a path expression in the second hop | **build fails** -- only a plain predicate matches |
+
+`sh:class` on an inverse shape is the notable one: it would read "every
+referring entity must be a Filter", which is a meaningful and implementable
+constraint -- the forward `sh:class` check's subclass-closure join transplants
+onto the referrer's type -- but it is *not* evaluated today, so it is refused
+rather than silently dropped. Likewise `sh:qualifiedValueShape` ("at least one
+referrer of class C") is unsupported: qualified shapes are not compiled
+anywhere yet.
 
 `sh:message` replaces the generated explanation in the alert's `text`. The
 generated one names the attribute and the parameter that failed, which says

--- a/semantic-model/shacl2flink/lib/shacl_properties_to_sql.py
+++ b/semantic-model/shacl2flink/lib/shacl_properties_to_sql.py
@@ -213,6 +213,14 @@ def connective_operation(connective):
 
 yaml = ruamel.yaml.YAML()
 
+# Marker stored in constraint_table.attributeType for sh:inversePath count
+# constraints. It is deliberately NOT an NGSI-LD attribute type IRI: the focus
+# node of an inverse constraint has no attribute of its own -- the counted
+# rows belong to OTHER entities -- so none of the attribute-shaped templates
+# may ever pick these rows up, and each of them selects on a genuine NGSI-LD
+# type IRI.
+INVERSE_RELATIONSHIP_TYPE = 'inverse-relationship'
+
 alerts_bulk_table = configs.alerts_bulk_table_name
 alerts_bulk_table_object = configs.alerts_bulk_table_object_name
 constraint_table_name = configs.constraint_table_name
@@ -259,6 +267,49 @@ where {
         OPTIONAL { ?innerclause sh:class ?attributeclass ; }
 }
 order by ?inhertiedTargetclass
+"""  # noqa: E501
+
+# The inverse of an NGSI-LD relationship: which entities point AT this one.
+#
+# NGSI-LD does not store a relationship as one triple. `filter hasCartridge
+# cartridge` is really `filter hasCartridge _:b` plus `_:b hasObject
+# cartridge`, so a bare `[ sh:inversePath hasCartridge ]` matches nothing --
+# nothing points at the cartridge with that predicate. The spelling that
+# means what the author intends, and that the reference engine agrees with,
+# walks both hops back:
+#
+#     sh:path ( [ sh:inversePath ngsi-ld:hasObject ]
+#               [ sh:inversePath iff:hasCartridge ] )
+#
+# which is the same explicitness the FORWARD relationship shapes already
+# require of a value shape. The bare form is rejected by unsupported_shapes
+# rather than quietly given the meaning it does not have.
+#
+# The focus node is the REFERENCED entity and the value nodes are the
+# referring entities, so none of the attribute-walking machinery above
+# applies: matched at the top level of the node shape, no connectives
+# descended -- an inverse count is a statement about the focus node, not a
+# branch of an attribute shape.
+sparql_get_all_inverse_relationships = """
+SELECT ?nodeshape ?targetclass ?inheritedTargetclass ?inversepath ?mincount ?maxcount ?severitycode ?property
+where {
+    ?nodeshape a sh:NodeShape .
+    ?nodeshape sh:targetClass ?targetclass .
+    ?inheritedTargetclass rdfs:subClassOf* ?targetclass .
+    ?nodeshape sh:property ?property .
+    ?property sh:path ?pathlist .
+    ?pathlist rdf:first ?objectstep .
+    ?objectstep sh:inversePath ngsi-ld:hasObject .
+    ?pathlist rdf:rest ?rest .
+    ?rest rdf:first ?attributestep .
+    ?rest rdf:rest rdf:nil .
+    ?attributestep sh:inversePath ?inversepath .
+    FILTER(isIRI(?inversepath))
+    OPTIONAL { ?property sh:maxCount ?maxcount . }
+    OPTIONAL { ?property sh:minCount ?mincount . }
+    OPTIONAL { ?property sh:severity ?severity . ?severity rdfs:label ?severitycode . }
+}
+order by ?inheritedTargetclass
 """  # noqa: E501
 
 sparql_get_all_properties = """
@@ -499,6 +550,70 @@ sql_check_relationship_property_count = """
             FROM A1 WHERE `minCount` is NOT NULL or `maxCount` is NOT NULL
             GROUP BY this, propertyPath, maxCount, minCount, severity, constraint_id, parentPath
             HAVING {{ constraint_cond }}
+"""  # noqa: E501
+
+# The inverse count: for each focus entity, the number of DISTINCT live
+# entities referring to it through the forward relationship. DISTINCT is
+# SHACL semantics, not fan-out hygiene -- the value nodes of an inverse path
+# are a SET of referring nodes, so a referrer carrying two attribute
+# instances of the relationship still counts once.
+#
+# Everything the forward count learned the hard way applies unchanged (see
+# sql_check_relationship_property_count): `edeleted` is read as an AGGREGATE,
+# never a grouping key; deletion flags are read INSIDE the counted expression
+# as well, so only live references are counted -- with one more liveness flag
+# than the forward count, `redeleted`, because a reference here has two
+# owners: the attribute row (adeleted) and the REFERRING entity (redeleted),
+# and a deleted referrer whose attribute rows have not been swept must not
+# keep a violation alive. STATE_TTL('A1' = '0d') pins the accumulator, and
+# the join inputs are pinned in the inner hint, both load-bearing for
+# retraction.
+#
+# One streaming property is unique to the inverse form: the GROUP KEY is the
+# attribute VALUE, so re-pointing a reference MIGRATES rows between groups.
+# That migration is the intended semantics -- the retraction of the old row
+# lands in the old focus node's group and clears its violation, the insert
+# lands in the new one's -- and it is exactly the case the pinned accumulator
+# exists for: an expired accumulator would drop that retraction in silence
+# and freeze the violation on the old focus node forever.
+sql_check_inverse_relationship_count = """
+            INSERT {% if sqlite %}OR REPlACE{% endif %} INTO {{alerts_bulk_table}}
+            WITH A1 as (
+                    SELECT /*+ STATE_TTL('A' = '0d', 'D' = '0d', 'R' = '0d', 'RE' = '0d') */
+                        A.id AS this,
+                        IFNULL(A.`deleted`, false) as edeleted,
+                        R.`entityId` as referrer,
+                        COALESCE(R.`deleted`, false) as adeleted,
+                        IFNULL(RE.`deleted`, false) as redeleted,
+                        D.propertyPath as propertyPath,
+                        D.maxCount as maxCount,
+                        D.minCount as minCount,
+                        D.severity as severity,
+                        D.id as constraint_id
+                    FROM {{target_class}}_view AS A JOIN {{constraint_table}} as D ON A.`type` = D.targetClass
+                    LEFT JOIN attributes_view AS R ON R.name = D.propertyPath
+                        and R.`attributeValue` = A.id and R.parentId IS NULL
+                        and R.`type` = 'https://uri.etsi.org/ngsi-ld/Relationship'
+                    LEFT JOIN {{target_class}}_view AS RE ON RE.id = R.`entityId`
+                    WHERE D.attributeType = '{{ inverse_marker }}'
+            )
+            {%- set live_referrers %}COUNT(DISTINCT CASE WHEN NOT edeleted AND NOT adeleted AND NOT redeleted THEN referrer ELSE NULL END){% endset %}
+            SELECT /*+ STATE_TTL('A1' = '0d') */ this AS resource,
+                'CountConstraintComponent(^' || `propertyPath` || ')' AS event,
+                `constraint_id` as constraint_id,
+                true as triggered,
+                `severity` AS severity,
+                'Model validation for inverse relationship ^' || `propertyPath` || ' failed for ' || this || '. Found ' ||
+                    SQL_DIALECT_CAST({{ live_referrers }} AS STRING) || ' referring entities instead of [' || IFNULL(`minCount`, '0') || ', ' || IFNULL(`maxCount`, '*') || ']!'
+                    as `text`
+                {%- if sqlite %}
+                ,CURRENT_TIMESTAMP
+                {%- endif %}
+            FROM A1 WHERE `minCount` is NOT NULL or `maxCount` is NOT NULL
+            GROUP BY this, propertyPath, maxCount, minCount, severity, constraint_id
+            HAVING MAX(CASE WHEN edeleted THEN 1 ELSE 0 END) = 0 AND
+                ({{ live_referrers }} > SQL_DIALECT_CAST(`maxCount` AS INTEGER)
+                 OR {{ live_referrers }} < SQL_DIALECT_CAST(`minCount` AS INTEGER));
 """  # noqa: E501
 
 sql_check_relationship_nodeType = """
@@ -1145,6 +1260,20 @@ def create_relationship_sql():
     )
     sql_command_sqlite += ";"
     sql_command_yaml += ";"
+    sql_command_sqlite = utils.process_sql_dialect(sql_command_sqlite, True)
+    sql_command_yaml = utils.process_sql_dialect(sql_command_yaml, False)
+    return sql_command_sqlite, sql_command_yaml
+
+
+def create_inverse_relationship_sql():
+    render = dict(alerts_bulk_table=constraint_trigger_table_name,
+                  constraint_table=constraint_table_name,
+                  target_class="entities",
+                  inverse_marker=INVERSE_RELATIONSHIP_TYPE)
+    sql_command_yaml = Template(sql_check_inverse_relationship_count).render(
+        sqlite=False, **render)
+    sql_command_sqlite = Template(sql_check_inverse_relationship_count).render(
+        sqlite=True, **render)
     sql_command_sqlite = utils.process_sql_dialect(sql_command_sqlite, True)
     sql_command_yaml = utils.process_sql_dialect(sql_command_yaml, False)
     return sql_command_sqlite, sql_command_yaml
@@ -1839,6 +1968,33 @@ def expand_node_shapes(g):
             remove_shape(g, shape)
 
 
+def inverse_relationship_predicate(g, path):
+    """
+    The predicate of a canonical NGSI-LD inverse path, or None.
+
+    Canonical is the two-hop sequence that walks back out of the blank node
+    NGSI-LD stores a relationship in:
+
+        sh:path ( [ sh:inversePath ngsi-ld:hasObject ]
+                  [ sh:inversePath <predicate> ] )
+
+    Anything else -- a bare inverse, a longer sequence, a nested expression
+    in the second hop -- returns None and is reported by unsupported_shapes.
+    """
+    try:
+        steps = list(Collection(g, path))
+    except Exception:
+        return None
+    if len(steps) != 2:
+        return None
+    if g.value(steps[0], SH.inversePath) != NGSILD.hasObject:
+        return None
+    predicate = g.value(steps[1], SH.inversePath)
+    if predicate is None or isinstance(predicate, BNode):
+        return None
+    return predicate
+
+
 def unsupported_shapes(g, compiled):
     """
     Shapes the extractor will not compile, as a list of messages.
@@ -1848,6 +2004,63 @@ def unsupported_shapes(g, compiled):
     """
     problems = []
     seen_messages = set()
+
+    # Inverse paths. Two things are checked here, and both exist because the
+    # alternative is a shape that is accepted and never checked.
+    #
+    # First the SPELLING. NGSI-LD stores `filter hasCartridge cartridge` as
+    # two triples through a blank node, so a bare `[ sh:inversePath
+    # hasCartridge ]` has no matches at all -- pyshacl reports nothing for it,
+    # and giving it the meaning the author clearly wanted would make this
+    # compiler disagree with the reference engine about what a shape MEANS.
+    # It is refused, with the spelling that works.
+    #
+    # Then the PARAMETERS. Only count bounds are evaluated, so sh:class on the
+    # referrers, a nodeKind or a value shape would be silently ignored.
+    canonical = ('sh:path ( [ sh:inversePath ngsi-ld:hasObject ] '
+                 '[ sh:inversePath <predicate> ] )')
+    for prop in sorted(g.subjects(SH.path, None), key=str):
+        for path in g.objects(prop, SH.path):
+            bare = g.value(path, SH.inversePath)
+            if bare is not None:
+                problems.append(
+                    f'<{prop}> uses sh:inversePath directly. An NGSI-LD '
+                    f'relationship reaches its target through '
+                    f'ngsi-ld:hasObject, so this path matches nothing and the '
+                    f'shape would never be checked -- by this compiler or by '
+                    f'a standard SHACL engine. Write both hops: {canonical}.')
+                continue
+            steps = [step for step in g.objects(path, RDF.first)]
+            if not steps or not any(g.value(step, SH.inversePath) is not None
+                                    for step in steps):
+                continue
+            inverse = inverse_relationship_predicate(g, path)
+            if inverse is None:
+                problems.append(
+                    f'the inverse path in <{prop}> is not a supported NGSI-LD '
+                    f'inverse relationship. Exactly two hops are compiled, '
+                    f'the second naming a plain predicate: {canonical}.')
+                continue
+            supported = {SH.path, SH.minCount, SH.maxCount, SH.severity,
+                         SH.message, SH.order, SH.name, SH.description,
+                         SH.group, RDF.type}
+            written = {str(p) for p in g.predicates(prop, None)}
+            extra = sorted(written - {str(s) for s in supported})
+            if extra:
+                names = ', '.join(p.rsplit('#', 1)[-1] for p in extra)
+                problems.append(
+                    f'the inverse path shape for <{inverse}> carries '
+                    f'parameters the inverse check does not evaluate: {names}. '
+                    f'Only sh:minCount/sh:maxCount are compiled on an inverse '
+                    f'path, so those parameters would be accepted and never '
+                    f'checked.')
+            if g.value(prop, SH.minCount) is None and \
+                    g.value(prop, SH.maxCount) is None:
+                problems.append(
+                    f'the inverse path shape for <{inverse}> has no '
+                    f'sh:minCount or sh:maxCount. An inverse path constrains '
+                    f'nothing but the number of referring entities, so it '
+                    f'would be accepted and never checked.')
 
     # NGSI-LD value predicates the data path cannot represent. create_ngsild_
     # models builds the attributes table from hasValue/hasObject/hasValueList/
@@ -2157,6 +2370,48 @@ string elements in list are supported.")
         clause_nodes.setdefault(clause_key, []).append(constraint_id_counter)
         constraint_id_counter += 1
 
+    # Inverse relationship counts. Appended AFTER every forward loop on
+    # purpose: constraint ids are positional, and appending keeps the ids of
+    # every existing constraint stable across this feature's introduction.
+    qres = utils.in_stable_order(
+        g.query(sparql_get_all_inverse_relationships, initNs=prefixes))
+    for row in qres:
+        inversepath = getattr(row, 'inversepath', None)
+        if inversepath is None:
+            continue
+        mincount = row.mincount.toPython() if row.mincount is not None else None
+        maxcount = row.maxcount.toPython() if row.maxcount is not None else None
+        if mincount is None and maxcount is None:
+            # An inverse path constrains nothing but the count of its
+            # referrers; without a bound there is nothing to compile.
+            continue
+        target_class = row.inheritedTargetclass.toPython() \
+            if row.targetclass else None
+        inverse_path = inversepath.toPython()
+        property = row.property.toPython()
+        check = utils.init_constraint_check()
+        node_key = (property + OWN_PARAMS_SUFFIX, target_class)
+        clause_key = (node_key, 'inversecount')
+        clause_connectives[clause_key] = 'OR'
+        if node_key not in property_nodes.keys():
+            property_nodes[node_key] = []
+        if clause_key not in property_nodes[node_key]:
+            property_nodes[node_key].append(clause_key)
+        property_connectives[node_key] = 'OR'
+        focus_paths[node_key] = '^' + inverse_path
+        check['targetClass'] = target_class
+        check['propertyPath'] = inverse_path
+        check['message'] = shape_message(g, row.property)
+        check['attributeType'] = INVERSE_RELATIONSHIP_TYPE
+        check['maxCount'] = maxcount
+        check['minCount'] = mincount
+        check['severity'] = row.severitycode.toPython() \
+            if row.severitycode else 'warning'
+        check['id'] = constraint_id_counter
+        constraint_checks.append(check)
+        clause_nodes.setdefault(clause_key, []).append(constraint_id_counter)
+        constraint_id_counter += 1
+
     def fold(members, operation, target_class, focus):
         """
         Collapse members into one circuit node, or pass a lone member through.
@@ -2281,6 +2536,15 @@ string elements in list are supported.")
     sql_command_sqlite, sql_command_yaml = create_property_sql()
     sqlite += sql_command_sqlite
     statementsets.append(sql_command_yaml)
+    # Only when an inverse constraint exists: the check is a whole extra job
+    # vertex with pinned state, and a model without inverse shapes should not
+    # pay for it.
+    if any(check['attributeType'] == INVERSE_RELATIONSHIP_TYPE
+           for check in constraint_checks):
+        sqlite += '\n'
+        sql_command_sqlite, sql_command_yaml = create_inverse_relationship_sql()
+        sqlite += sql_command_sqlite
+        statementsets.append(sql_command_yaml)
 
     # Evaluate the constraint circuit bottom up, one statement per level. The
     # levels are known at build time, so no recursion is needed at runtime.

--- a/semantic-model/shacl2flink/lib/sparql_to_sql.py
+++ b/semantic-model/shacl2flink/lib/sparql_to_sql.py
@@ -346,7 +346,11 @@ def translate_function(ctx, function):
             else:
                 result = f'SQL_DIALECT_CAST(SQL_DIALECT_STRIP_IRI{{{expression}}} as {cast})'
         else:
-            result = f'SQL_DIALECT_TIME_TO_MILLISECONDS{{SQL_DIALECT_STRIP_LITERAL{{{expression}}}}}'
+            # xsd:dateTime() normalizes its argument into the canonical
+            # ISO 8601 UTC string, the same quoted form wrap_ngsild_variable
+            # gives observedAt-bound variables -- so FILTER(?ts > xsd:dateTime(
+            # ?value)) compares ISO against ISO, lexically == chronologically.
+            result = f"'\"' || SQL_DIALECT_ISO_TIMESTAMP{{SQL_DIALECT_STRIP_LITERAL{{{expression}}}}} || '\"'"
     elif iri in IFA:
         udf = utils.strip_class(iri)
         result = f'{udf}('
@@ -354,8 +358,7 @@ def translate_function(ctx, function):
         for i in range(0, numargs):
             if i != 0:
                 result += ', '
-            expression = translate(ctx, expr[i])
-            result += expression
+            result += translate_udf_argument(ctx, expr[i])
         utils.set_is_aggregate_var(ctx, False)
         result += ')'
     elif iri in IFN:
@@ -364,13 +367,22 @@ def translate_function(ctx, function):
         for i in range(0, numargs):
             if i != 0:
                 result += ', '
-            expression = translate(ctx, expr[i])
-            result += expression
+            result += translate_udf_argument(ctx, expr[i])
         utils.set_is_aggregate_var(ctx, False)
         result += ')'
     else:
         raise utils.WrongSparqlStructure(f'Function {iri.toPython()} not supported!')
     return result
+
+
+def translate_udf_argument(ctx, arg):
+    """UDF arguments live in the numeric domain: a time-bound variable is
+    handed to the UDF as epoch milliseconds (the UDFs' contract, e.g.
+    statetime subtracts its inputs), not as the quoted ISO string the
+    serialization/comparison domain uses."""
+    if isinstance(arg, Variable) and arg in ctx.get('time_variables', {}):
+        return utils.unwrap_variables(ctx, arg)
+    return translate(ctx, arg)
 
 
 def translate_builtin_now(ctx, builtin_now):

--- a/semantic-model/shacl2flink/lib/utils.py
+++ b/semantic-model/shacl2flink/lib/utils.py
@@ -737,7 +737,9 @@ def process_sql_dialect(expression, isSqlite):
     result_expression = expression
     max_recursion = 10
     while "SQL_DIALECT_STRIP" in result_expression or "SQL_DIALECT_CAST" in result_expression \
-            or "SQL_DIALECT_ATTRIBUTE_ID" in result_expression:
+            or "SQL_DIALECT_ATTRIBUTE_ID" in result_expression \
+            or "SQL_DIALECT_TIME_TO_MILLISECONDS" in result_expression \
+            or "SQL_DIALECT_ISO_TIMESTAMP" in result_expression:
         max_recursion = max_recursion - 1
         if max_recursion == 0:
             raise WrongSparqlStructure("Unexpected problem with SQL_DIALECT macros.")
@@ -750,6 +752,14 @@ def process_sql_dialect(expression, isSqlite):
                                        result_expression)
             result_expression = re.sub(r'SQL_DIALECT_TIME_TO_MILLISECONDS{([^{}]*)}',
                                        r"CAST(julianday(\1) * 86400000 as INTEGER)",
+                                       result_expression)
+            # Canonical time serialization: ISO 8601 UTC with milliseconds and
+            # 'Z'. Fixed-width, so lexical order equals chronological order --
+            # which is what makes ISO strings a valid comparison domain.
+            # julianday/strftime accept both the SQL (' ') and ISO ('T'/'Z')
+            # input forms, so the macro is format-tolerant on the way in.
+            result_expression = re.sub(r'SQL_DIALECT_ISO_TIMESTAMP{([^{}]*)}',
+                                       r"(strftime('%Y-%m-%dT%H:%M:%f', \1) || 'Z')",
                                        result_expression)
             result_expression = result_expression.replace('SQL_DIALECT_CURRENT_TIMESTAMP', 'datetime()')
             result_expression = result_expression.replace('SQL_DIALECT_INSERT_ATTRIBUTES',
@@ -766,9 +776,29 @@ def process_sql_dialect(expression, isSqlite):
             result_expression = re.sub(r'SQL_DIALECT_STRIP_LITERAL{([^{}]*)}',
                                        r"REGEXP_REPLACE(CAST(\1 as STRING), '\"', '')",
                                        result_expression)
+            # The REPLACE pair normalizes ISO 8601 input ('T' separator,
+            # trailing 'Z') to the SQL form Flink's UNIX_TIMESTAMP and
+            # TIMESTAMP cast understand; a TIMESTAMP column casts to the SQL
+            # form already, so the pair is a no-op there.
+            # normalizes ISO 8601 input ('T' separator, trailing 'Z') to the
+            # SQL form Flink's time functions parse; no-op for the string
+            # form a TIMESTAMP column casts to.
+            flink_norm = r"REPLACE(REPLACE(TRY_CAST(\1 AS STRING), 'T', ' '), 'Z', '')"
             result_expression = re.sub(r'SQL_DIALECT_TIME_TO_MILLISECONDS{([^{}]*)}',
-                                       r"1000 * UNIX_TIMESTAMP(TRY_CAST(\1 AS STRING)) + " +
-                                       r"EXTRACT(MILLISECOND FROM TRY_CAST(\1 as TIMESTAMP))",
+                                       r"1000 * UNIX_TIMESTAMP(" + flink_norm + r") + " +
+                                       r"EXTRACT(MILLISECOND FROM TRY_CAST(" +
+                                       flink_norm + r" as TIMESTAMP))",
+                                       result_expression)
+            # Canonical time serialization: ISO 8601 UTC with milliseconds and
+            # 'Z' (see the sqlite branch). DATE_FORMAT has no reliable
+            # millisecond pattern, so the milliseconds are appended from
+            # EXTRACT, zero-padded.
+            result_expression = re.sub(r'SQL_DIALECT_ISO_TIMESTAMP{([^{}]*)}',
+                                       r"(DATE_FORMAT(TRY_CAST(" + flink_norm +
+                                       r" AS TIMESTAMP), 'yyyy-MM-dd''T''HH:mm:ss.') || " +
+                                       r"LPAD(CAST(EXTRACT(MILLISECOND FROM TRY_CAST(" +
+                                       flink_norm +
+                                       r" AS TIMESTAMP)) AS STRING), 3, '0') || 'Z')",
                                        result_expression)
             result_expression = result_expression.replace('SQL_DIALECT_CURRENT_TIMESTAMP',
                                                           'CURRENT_TIMESTAMP')
@@ -827,7 +857,13 @@ def wrap_ngsild_variable(ctx, var):
             return "'\"' || " + bounds[varname] + " || '\"'"
     elif var in time_variables:
         if varname in bounds:
-            return f"SQL_DIALECT_TIME_TO_MILLISECONDS{{{bounds[varname]}}}"
+            # Times serialize and compare as ISO 8601 UTC strings
+            # ('YYYY-MM-DDTHH:mm:ss.SSSZ'). The form is fixed-width, so
+            # lexical comparison equals chronological comparison, and the
+            # same representation lands in written attribute values --
+            # one canonical time format from model to writeback. Millis
+            # remain the domain of arithmetic only (unwrap_variables).
+            return f"'\"' || SQL_DIALECT_ISO_TIMESTAMP{{{bounds[varname]}}} || '\"'"
     else:  # plain RDF variable
         return bounds[varname]
 

--- a/semantic-model/shacl2flink/tests/pyshacl-compare/compare.py
+++ b/semantic-model/shacl2flink/tests/pyshacl-compare/compare.py
@@ -37,6 +37,7 @@ import sys
 
 import pyshacl
 from rdflib import BNode, Graph, URIRef
+from rdflib.collection import Collection
 from rdflib.namespace import RDF, SH
 
 NGSILD = 'https://uri.etsi.org/ngsi-ld/'
@@ -53,6 +54,34 @@ DATASET_ID = URIRef(NGSILD + 'datasetId')
 # min/max are one CountConstraintComponent here, two components in SHACL.
 COMPONENT_ALIASES = {'MinCountConstraintComponent': 'CountConstraintComponent',
                      'MaxCountConstraintComponent': 'CountConstraintComponent'}
+
+
+def inverse_predicate(path, *graphs):
+    """
+    The relationship predicate of an NGSI-LD inverse path, or None.
+
+    The path is the two-hop sequence that walks back out of the blank node a
+    relationship is stored in -- ( [^ngsi-ld:hasObject] [^predicate] ) -- and
+    pyshacl reports it as an unnamed blank node. The compiler names the alert
+    after the predicate, so this recovers the same name. The path expression
+    may live in the report or in the shapes graph depending on how much
+    pyshacl copies, so both are searched.
+    """
+    if not isinstance(path, BNode):
+        return None
+    for g in graphs:
+        try:
+            steps = list(Collection(g, path))
+        except Exception:
+            continue
+        if len(steps) != 2:
+            continue
+        if g.value(steps[0], SH.inversePath) != URIRef(NGSILD + 'hasObject'):
+            continue
+        predicate = g.value(steps[1], SH.inversePath)
+        if isinstance(predicate, URIRef):
+            return predicate
+    return None
 
 
 def local(iri):
@@ -173,8 +202,16 @@ def pyshacl_findings(shapes, knowledge, model):
         # blank node in sh:resultPath is a path expression rather than a
         # predicate -- the ([sh:zeroOrMorePath rdf:rest] rdf:first) that walks
         # a list -- and has no name of its own, so it resolves the same way.
+        # An INVERSE relationship path is a blank node too, but it must not
+        # resolve to the focus node's own edge: the constraint is about who
+        # points AT the focus node, and its name is the predicate they point
+        # with. Read it out of the path expression, the way the compiler
+        # names the alert.
+        inverse = inverse_predicate(path, report, shape_graph)
         indirect = str(path) in VALUE_PATHS or isinstance(path, BNode)
-        if path is not None and indirect:
+        if path is not None and inverse is not None:
+            path = inverse
+        elif path is not None and indirect:
             path = edge
         label = local(path) if path is not None else ''
         if not label:

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/kms/model2.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/kms/model2.jsonld
@@ -171,12 +171,12 @@
     "iffBaseEntities:isUsedUntil": [
       {
         "type": "Property",
-        "value": "2024-02-27 13:54:55.4"
+        "value": "2024-02-27T13:54:55.400Z"
       }],
       "iffBaseEntities:isUsedFrom": [
         {
           "type": "Property",
-          "value": "2024-02-27 13:54:55.4"
+          "value": "2024-02-27T13:54:55.400Z"
         }],
       "iffFilterEntities:hasWasteclass":[
         {

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/kms/model2.jsonld_result
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/kms/model2.jsonld_result
@@ -1,3 +1,4 @@
+'urn:cartridge:1','CountConstraintComponent(^https://industryfusion.github.io/contexts/example/v0/base_entities/hasCartridge)','warning'
 'urn:cutter:1','CountConstraintComponent(https://industryfusion.github.io/contexts/example/v0/base_entities/hasState[0] ==> https://industryfusion.github.io/contexts/example/v0/base_entities/hasXXXWorkpiece)','warning'
 'urn:cutter:1','SPARQLConstraintComponent(StateValueShape)','ok'
 'urn:filter:1','CountConstraintComponent(https://industryfusion.github.io/contexts/example/v0/base_entities/hasState[0] ==> https://industryfusion.github.io/contexts/example/v0/base_entities/hasXXXWorkpiece)','warning'

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/kms/model3.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/kms/model3.jsonld
@@ -171,12 +171,12 @@
     "iffBaseEntities:isUsedUntil": [
       {
         "type": "Property",
-        "value": "2024-02-27 13:54:55.4"
+        "value": "2024-02-27T13:54:55.400Z"
       }],
       "iffBaseEntities:isUsedFrom": [
         {
           "type": "Property",
-          "value": "2024-02-27 13:54:55.4"
+          "value": "2024-02-27T13:54:55.400Z"
         }],
       "iffFilterEntities:hasWasteclass":[
         {

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/kms/model3.jsonld_result
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/kms/model3.jsonld_result
@@ -1,3 +1,4 @@
+'urn:cartridge:1','CountConstraintComponent(^https://industryfusion.github.io/contexts/example/v0/base_entities/hasCartridge)','warning'
 'urn:cutter:1','CountConstraintComponent(https://industryfusion.github.io/contexts/example/v0/base_entities/hasState[0] ==> https://industryfusion.github.io/contexts/example/v0/base_entities/hasXXXWorkpiece)','warning'
 'urn:cutter:1','SPARQLConstraintComponent(StateValueShape)','ok'
 'urn:filter:1','CountConstraintComponent(https://industryfusion.github.io/contexts/example/v0/base_entities/hasState[0] ==> https://industryfusion.github.io/contexts/example/v0/base_entities/hasXXXWorkpiece)','warning'

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/kms/model4.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/kms/model4.jsonld
@@ -171,12 +171,12 @@
     "iffBaseEntities:isUsedUntil": [
       {
         "type": "Property",
-        "value": "2024-02-27 13:54:55.4"
+        "value": "2024-02-27T13:54:55.400Z"
       }],
       "iffBaseEntities:isUsedFrom": [
         {
           "type": "Property",
-          "value": "2024-02-27 13:54:55.4"
+          "value": "2024-02-27T13:54:55.400Z"
         }],
       "iffFilterEntities:hasWasteclass":[
         {

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/kms/model4.jsonld_result
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/kms/model4.jsonld_result
@@ -1,3 +1,4 @@
+'urn:cartridge:1','CountConstraintComponent(^https://industryfusion.github.io/contexts/example/v0/base_entities/hasCartridge)','warning'
 'urn:cutter:1','CountConstraintComponent(https://industryfusion.github.io/contexts/example/v0/base_entities/hasState[0] ==> https://industryfusion.github.io/contexts/example/v0/base_entities/hasXXXWorkpiece)','warning'
 'urn:cutter:1','SPARQLConstraintComponent(StateValueShape)','ok'
 'urn:filter:1','CountConstraintComponent(https://industryfusion.github.io/contexts/example/v0/base_entities/hasState[0] ==> https://industryfusion.github.io/contexts/example/v0/base_entities/hasXXXWorkpiece)','warning'

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test1/model5.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test1/model5.jsonld
@@ -75,11 +75,11 @@
         "type": "https://industry-fusion.com/types/v0.9/filterCartridge",
         "https://industry-fusion.com/types/v0.9/inUseFrom": {
           "type": "Property",
-          "value": "2021-10-25 13:51:51.0"
+          "value": "2021-10-25T13:51:51.000Z"
         },
         "https://industry-fusion.com/types/v0.9/inUseUntil": {
           "type": "Property",
-          "value": "2021-10-25 13:54:55.4"
+          "value": "2021-10-25T13:54:55.400Z"
         },
         "https://industry-fusion.com/types/v0.9/wasteClass": [{
           "type": "Property",

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test1/model6.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test1/model6.jsonld
@@ -75,11 +75,11 @@
         "type": "https://industry-fusion.com/types/v0.9/filterCartridge",
         "https://industry-fusion.com/types/v0.9/inUseFrom": {
           "type": "Property",
-          "value": "2021-10-25 13:51:51.0"
+          "value": "2021-10-25T13:51:51.000Z"
         },
         "https://industry-fusion.com/types/v0.9/inUseUntil": {
           "type": "Property",
-          "value": "2021-10-25 13:54:55.4"
+          "value": "2021-10-25T13:54:55.400Z"
         },
         "https://industry-fusion.com/types/v0.9/wasteClass": [{
           "type": "Property",

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test1/model7.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test1/model7.jsonld
@@ -75,11 +75,11 @@
         "type": "https://industry-fusion.com/types/v0.9/filterCartridge",
         "https://industry-fusion.com/types/v0.9/inUseFrom": {
           "type": "Property",
-          "value": "2021-10-25 13:51:51.0"
+          "value": "2021-10-25T13:51:51.000Z"
         },
         "https://industry-fusion.com/types/v0.9/inUseUntil": {
           "type": "Property",
-          "value": "2021-10-25 13:54:55.4"
+          "value": "2021-10-25T13:54:55.400Z"
         },
         "https://industry-fusion.com/types/v0.9/wasteClass": [{
           "type": "Property",

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test2/model9.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test2/model9.jsonld
@@ -75,11 +75,11 @@
       "type": "https://industry-fusion.com/types/v0.9/filterCartridge",
       "https://industry-fusion.com/types/v0.9/inUseFrom": {
         "type": "Property",
-        "value": "2021-10-25 13:51:51.0"
+        "value": "2021-10-25T13:51:51.000Z"
       },
       "https://industry-fusion.com/types/v0.9/inUseUntil": {
         "type": "Property",
-        "value": "2021-10-25 13:54:55.4"
+        "value": "2021-10-25T13:54:55.400Z"
       },
       "https://industry-fusion.com/types/v0.9/wasteClass": {
         "type": "Property",

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/context.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/context.jsonld
@@ -1,0 +1,55 @@
+{ 
+        "@context": [
+                "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context.jsonld",
+                {
+                    "eclass": {
+                        "@id": "https://industry-fusion.org/eclass#",
+                        "@prefix": true
+                    },
+                    "xsd": {
+                        "@id": "http://www.w3.org/2001/XMLSchema#",
+                        "@prefix": true
+                    },
+                    "owl": {
+                        "@id": "http://www.w3.org/2002/07/owl#",
+                        "@prefix": true
+                    },
+                    "rdf": {
+                        "@id": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+                        "@prefix": true
+                    },
+                    "rdfs": {
+                        "@id": "http://www.w3.org/2000/01/rdf-schema#",
+                        "@prefix": true
+                    },
+                    "schema": {
+                        "@id": "http://schema.org/",
+                        "@prefix": true
+                    },
+                    "sh": {
+                        "@id": "http://www.w3.org/ns/shacl#",
+                        "@prefix": true
+                    },
+                    "iffBaseEntities": {
+                        "@id": "https://industryfusion.github.io/contexts/example/v0/base_entities/",
+                        "@prefix": true
+                    },
+                    "base": {
+                        "@id": "https://industryfusion.github.io/contexts/example/v0/base_knowledge/",
+                        "@prefix": true
+                    },
+                    "iffFilterKnowledge": {
+                        "@id": "https://industryfusion.github.io/contexts/example/v0/filter_knowledge/",
+                        "@prefix": true
+                    },
+                    "iffFilterEntities": {
+                        "@id": "https://industryfusion.github.io/contexts/example/v0/filter_entities/",
+                        "@prefix": true
+                    },
+                    "material": {
+                        "@id": "https://industryfusion.github.io/contexts/ontology/v0/material/",
+                        "@prefix": true
+                    }
+                }
+        ]
+}

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/knowledge.ttl
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/knowledge.ttl
@@ -1,0 +1,12 @@
+PREFIX rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs:  <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX iff:   <https://industry-fusion.com/types/v0.9/>
+
+# Flat on purpose: subclasses multiply constraints one row per inherited
+# target class, which complicates the expected ids without testing anything new.
+iff:filter a iff:class ;
+    a rdfs:Class .
+iff:cartridge a iff:class ;
+    a rdfs:Class .
+iff:scrapped a iff:class ;
+    a rdfs:Class .

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/model1.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/model1.jsonld
@@ -1,0 +1,13 @@
+[
+  {
+    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "id": "urn:cart:1",
+    "type": "https://industry-fusion.com/types/v0.9/cartridge"
+  },
+  {
+    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "id": "urn:filter:1",
+    "type": "https://industry-fusion.com/types/v0.9/filter",
+    "https://industry-fusion.com/types/v0.9/hasCartridge": { "type": "Relationship", "object": "urn:cart:1" }
+  }
+]

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/model2.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/model2.jsonld
@@ -1,0 +1,19 @@
+[
+  {
+    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "id": "urn:cart:1",
+    "type": "https://industry-fusion.com/types/v0.9/cartridge"
+  },
+  {
+    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "id": "urn:filter:1",
+    "type": "https://industry-fusion.com/types/v0.9/filter",
+    "https://industry-fusion.com/types/v0.9/hasCartridge": { "type": "Relationship", "object": "urn:cart:1" }
+  },
+  {
+    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "id": "urn:filter:2",
+    "type": "https://industry-fusion.com/types/v0.9/filter",
+    "https://industry-fusion.com/types/v0.9/hasCartridge": { "type": "Relationship", "object": "urn:cart:1" }
+  }
+]

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/model2.jsonld_result
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/model2.jsonld_result
@@ -1,0 +1,1 @@
+'urn:cart:1','CountConstraintComponent(^https://industry-fusion.com/types/v0.9/hasCartridge)','warning'

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/model3.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/model3.jsonld
@@ -1,0 +1,13 @@
+[
+  {
+    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "id": "urn:scrap:1",
+    "type": "https://industry-fusion.com/types/v0.9/scrapped"
+  },
+  {
+    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "id": "urn:filter:1",
+    "type": "https://industry-fusion.com/types/v0.9/filter",
+    "https://industry-fusion.com/types/v0.9/hasCartridge": { "type": "Relationship", "object": "urn:scrap:1" }
+  }
+]

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/model3.jsonld_result
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/model3.jsonld_result
@@ -1,0 +1,1 @@
+'urn:scrap:1','CountConstraintComponent(^https://industry-fusion.com/types/v0.9/hasCartridge)','warning'

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/model4.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/model4.jsonld
@@ -1,0 +1,7 @@
+[
+  {
+    "@context": "https://uri.etsi.org/ngsi-ld/v1/ngsi-ld-core-context-v1.8.jsonld",
+    "id": "urn:scrap:1",
+    "type": "https://industry-fusion.com/types/v0.9/scrapped"
+  }
+]

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/shacl.ttl
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test23/shacl.ttl
@@ -1,0 +1,28 @@
+@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix iff:  <https://industry-fusion.com/types/v0.9/> .
+@prefix ngsild: <https://uri.etsi.org/ngsi-ld/> .
+
+# Inverse property paths: a constraint on who points AT the focus node.
+#
+# Both hops are spelled out -- an NGSI-LD relationship reaches its target
+# through ngsild:hasObject, so a bare inverse of hasCartridge matches nothing.
+# This is the spelling a standard SHACL engine agrees with, which is what the
+# pyshacl comparison checks.
+#
+# Two bounds are exercised together because they fail in different ways.
+# sh:maxCount 1 is exclusivity ("installed in at most one filter"), and
+# sh:maxCount 0 is a prohibition ("this decommissioned part must not be
+# installed anywhere") -- the latter only compiles if the extractor tests
+# `is not None` rather than truthiness, since rdflib.Literal(0) is FALSY and a
+# truthiness test reads the bound as "none given" and drops the constraint.
+iff:CartridgeShape a sh:NodeShape ; sh:targetClass iff:cartridge ;
+    sh:property [ sh:path ( [ sh:inversePath ngsild:hasObject ]
+                            [ sh:inversePath iff:hasCartridge ] ) ;
+        sh:maxCount 1 ] .
+
+iff:ScrappedShape a sh:NodeShape ; sh:targetClass iff:scrapped ;
+    sh:property [ sh:path ( [ sh:inversePath ngsild:hasObject ]
+                            [ sh:inversePath iff:hasCartridge ] ) ;
+        sh:maxCount 0 ] .

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test5/model1.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test5/model1.jsonld
@@ -5,7 +5,7 @@
     "type": "https://industry-fusion.com/types/v0.9/cutter",
     "https://industry-fusion.com/types/v0.9/state": {
       "type": "Property",
-      "observedAt": "2023-03-24 13:42:32.0",
+      "observedAt": "2023-03-24T13:42:32.000Z",
       "value": {
         "@id": "https://industry-fusion.com/types/v0.9/state_PROCESSING"
       }
@@ -76,16 +76,16 @@
     "type": "https://industry-fusion.com/types/v0.9/oeeTemplate",
     "https://industry-fusion.com/types/v0.9/startTime": {
       "type": "Property",
-      "value": "2023-03-24 13:42:31"
+      "value": "2023-03-24T13:42:31.000Z"
     },
     "https://industry-fusion.com/types/v0.9/endTime": {
       "type": "Property",
-      "value": "2099-03-24 14:42:31"
+      "value": "2099-03-24T14:42:31.000Z"
     },
     "https://industry-fusion.com/oee/v0.9/availabilityState": {
       "type": "Property",
       "value": "1",
-      "observedAt": "2023-03-24 13:42:31.2"
+      "observedAt": "2023-03-24T13:42:31.200Z"
     },
     "https://industry-fusion.com/oee/v0.9/availabilityTimeAgg": {
       "type": "Property",

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test5/model2.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test5/model2.jsonld
@@ -5,7 +5,7 @@
     "type": "https://industry-fusion.com/types/v0.9/cutter",
     "https://industry-fusion.com/types/v0.9/state": {
       "type": "Property",
-      "observedAt": "2023-03-24 13:42:32.0",
+      "observedAt": "2023-03-24T13:42:32.000Z",
       "value": {
         "@id": "https://industry-fusion.com/types/v0.9/state_PROCESSING"
       }
@@ -76,16 +76,16 @@
     "type": "https://industry-fusion.com/types/v0.9/oeeTemplate",
     "https://industry-fusion.com/types/v0.9/startTime": {
       "type": "Property",
-      "value": "2099-03-24 13:42:31"
+      "value": "2099-03-24T13:42:31.000Z"
     },
     "https://industry-fusion.com/types/v0.9/endTime": {
       "type": "Property",
-      "value": "2023-03-24 14:42:31"
+      "value": "2023-03-24T14:42:31.000Z"
     },
     "https://industry-fusion.com/oee/v0.9/availabilityState": {
       "type": "Property",
       "value": "1",
-      "observedAt": "2023-03-24 13:42:31.2"
+      "observedAt": "2023-03-24T13:42:31.200Z"
     },
     "https://industry-fusion.com/oee/v0.9/availabilityTimeAgg": {
       "type": "Property",

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test8/model1.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test8/model1.jsonld
@@ -57,12 +57,12 @@
     "iffBaseEntities:isUsedFrom": [
     {
       "type": "Property",
-      "value": "2021-10-25 13:54:55.4"
+      "value": "2021-10-25T13:54:55.400Z"
     }],
     "iffBaseEntities:isUsedUntil": [
       {
         "type": "Property",
-        "value": "2024-02-27 13:54:55.4"
+        "value": "2024-02-27T13:54:55.400Z"
       }]
   }
 ]

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test8/model2.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test8/model2.jsonld
@@ -57,12 +57,12 @@
     "iffBaseEntities:isUsedFrom": [
     {
       "type": "Property",
-      "value": "2021-10-25 13:54:55.4"
+      "value": "2021-10-25T13:54:55.400Z"
     }],
     "iffBaseEntities:isUsedUntil": [
       {
         "type": "Property",
-        "value": "2024-02-27 13:54:55.4"
+        "value": "2024-02-27T13:54:55.400Z"
       }],
     "iffFilterEntities:hasWasteclass": [
       {

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test8/model3.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test8/model3.jsonld
@@ -54,22 +54,22 @@
       {
         "type": "Property",
         "value": 0.9,
-        "observedAt": "2024-02-28 13:52:32.0" 
+        "observedAt": "2024-02-28T13:52:32.000Z" 
       },
       {
         "type": "Property",
         "value": 0.8,
-        "observedAt": "2024-02-28 13:52:33.0" 
+        "observedAt": "2024-02-28T13:52:33.000Z" 
       },
       {
         "type": "Property",
         "value": 0.7,
-        "observedAt": "2024-02-28 13:52:34.0" 
+        "observedAt": "2024-02-28T13:52:34.000Z" 
       },
       {
         "type": "Property",
         "value": 0.6,
-        "observedAt": "2024-02-28 13:52:35.0" 
+        "observedAt": "2024-02-28T13:52:35.000Z" 
       }
     ]
   },
@@ -81,12 +81,12 @@
     "iffBaseEntities:isUsedUntil": [
       {
         "type": "Property",
-        "value": "2024-02-27 13:54:55.4"
+        "value": "2024-02-27T13:54:55.400Z"
       }],
       "iffBaseEntities:isUsedFrom": [
         {
           "type": "Property",
-          "value": "2024-02-27 13:54:55.4"
+          "value": "2024-02-27T13:54:55.400Z"
         }],
       "iffFilterEntities:hasWasteclass":[
         {

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test8/model4.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test8/model4.jsonld
@@ -54,22 +54,22 @@
       {
         "type": "Property",
         "value": 0.9,
-        "observedAt": "2024-02-28 13:52:32.0" 
+        "observedAt": "2024-02-28T13:52:32.000Z" 
       },
       {
         "type": "Property",
         "value": 0.8,
-        "observedAt": "2024-02-28 13:52:33.0" 
+        "observedAt": "2024-02-28T13:52:33.000Z" 
       },
       {
         "type": "Property",
         "value": 0.7,
-        "observedAt": "2024-02-28 13:52:34.0" 
+        "observedAt": "2024-02-28T13:52:34.000Z" 
       },
       {
         "type": "Property",
         "value": 0.6,
-        "observedAt": "2024-02-28 13:52:35.0" 
+        "observedAt": "2024-02-28T13:52:35.000Z" 
       }
     ]
   },
@@ -81,12 +81,12 @@
     "iffBaseEntities:isUsedUntil": [
       {
         "type": "Property",
-        "value": "2024-02-27 13:54:55.4"
+        "value": "2024-02-27T13:54:55.400Z"
       }],
       "iffBaseEntities:isUsedFrom": [
         {
           "type": "Property",
-          "value": "2024-02-27 13:54:55.4"
+          "value": "2024-02-27T13:54:55.400Z"
         }],
       "iffFilterEntities:hasWasteclass":[
         {

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test8/model5.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test8/model5.jsonld
@@ -54,22 +54,22 @@
       {
         "type": "Property",
         "value": 0.9,
-        "observedAt": "2024-02-28 13:52:32.0" 
+        "observedAt": "2024-02-28T13:52:32.000Z" 
       },
       {
         "type": "Property",
         "value": 0.8,
-        "observedAt": "2024-02-28 13:52:33.0" 
+        "observedAt": "2024-02-28T13:52:33.000Z" 
       },
       {
         "type": "Property",
         "value": 0.7,
-        "observedAt": "2024-02-28 13:52:34.0" 
+        "observedAt": "2024-02-28T13:52:34.000Z" 
       },
       {
         "type": "Property",
         "value": 0.6,
-        "observedAt": "2024-02-28 13:52:35.0" 
+        "observedAt": "2024-02-28T13:52:35.000Z" 
       }
     ]
   },
@@ -81,12 +81,12 @@
     "iffBaseEntities:isUsedUntil": [
       {
         "type": "Property",
-        "value": "2024-02-27 13:54:55.4"
+        "value": "2024-02-27T13:54:55.400Z"
       }],
       "iffBaseEntities:isUsedFrom": [
         {
           "type": "Property",
-          "value": "2024-02-27 13:54:55.4"
+          "value": "2024-02-27T13:54:55.400Z"
         }],
       "iffFilterEntities:hasWasteclass":[
         {

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test8/model6.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-constraints/test8/model6.jsonld
@@ -57,12 +57,12 @@
     "iffBaseEntities:isUsedFrom": [
     {
       "type": "Property",
-      "value": "2021-10-25 13:54:55.4"
+      "value": "2021-10-25T13:54:55.400Z"
     }],
     "iffBaseEntities:isUsedUntil": [
       {
         "type": "Property",
-        "value": "2024-02-27 13:54:55.4"
+        "value": "2024-02-27T13:54:55.400Z"
       }]
   }
 ]

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test3/model1.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test3/model1.jsonld
@@ -75,11 +75,11 @@
         "type": "https://industry-fusion.com/types/v0.9/filterCartridge",
         "https://industry-fusion.com/types/v0.9/inUseFrom": {
           "type": "Property",
-          "value": "2021-10-25 13:51:51.0"
+          "value": "2021-10-25T13:51:51.000Z"
         },
         "https://industry-fusion.com/types/v0.9/inUseUntil": {
           "type": "Property",
-          "value": "2021-10-25 13:54:55.4"
+          "value": "2021-10-25T13:54:55.400Z"
         },
         "https://industry-fusion.com/types/v0.9/wasteClass": [{
           "type": "Property",

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test3/model2.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test3/model2.jsonld
@@ -75,11 +75,11 @@
         "type": "https://industry-fusion.com/types/v0.9/filterCartridge",
         "https://industry-fusion.com/types/v0.9/inUseFrom": {
           "type": "Property",
-          "value": "2021-10-25 13:51:51.0"
+          "value": "2021-10-25T13:51:51.000Z"
         },
         "https://industry-fusion.com/types/v0.9/inUseUntil": {
           "type": "Property",
-          "value": "2021-10-25 13:54:55.4"
+          "value": "2021-10-25T13:54:55.400Z"
         },
         "https://industry-fusion.com/types/v0.9/wasteClass": [{
           "type": "Property",

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test3/model4.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test3/model4.jsonld
@@ -80,7 +80,7 @@
         }],
         "https://industry-fusion.com/types/v0.9/inUseFrom": [{
           "type": "Property",
-          "value": "2021-10-25 13:51:51.0"
+          "value": "2021-10-25T13:51:51.000Z"
         }]
       }
 ]

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test3/model5.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test3/model5.jsonld
@@ -80,7 +80,7 @@
         }],
         "https://industry-fusion.com/types/v0.9/inUseFrom": [{
           "type": "Property",
-          "value": "2021-10-25 13:51:51.0"
+          "value": "2021-10-25T13:51:51.000Z"
         }]
       }
 ]

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test3/model6.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test3/model6.jsonld
@@ -80,7 +80,7 @@
         }],
         "https://industry-fusion.com/types/v0.9/inUseFrom": [{
           "type": "Property",
-          "value": "2021-10-25 13:51:51.0"
+          "value": "2021-10-25T13:51:51.000Z"
         }]
       }
 ]

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test3/model7.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test3/model7.jsonld
@@ -80,7 +80,7 @@
         }],
         "https://industry-fusion.com/types/v0.9/inUseFrom": [{
           "type": "Property",
-          "value": "2021-10-25 13:51:51.0"
+          "value": "2021-10-25T13:51:51.000Z"
         }]
       }
 ]

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test3/model8.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test3/model8.jsonld
@@ -80,7 +80,7 @@
         }],
         "https://industry-fusion.com/types/v0.9/inUseFrom": [{
           "type": "Property",
-          "value": "2021-10-25 13:51:51.0"
+          "value": "2021-10-25T13:51:51.000Z"
         }]
       }
 ]

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test3/model9.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test3/model9.jsonld
@@ -96,7 +96,7 @@
     "https://industry-fusion.com/types/v0.9/inUseFrom": [
       {
         "type": "Property",
-        "value": "2021-10-25 13:51:51.0"
+        "value": "2021-10-25T13:51:51.000Z"
       }
     ]
   }

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test4/model1.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test4/model1.jsonld
@@ -5,7 +5,7 @@
     "type": "https://industry-fusion.com/types/v0.9/cutter",
     "https://industry-fusion.com/types/v0.9/state": {
       "type": "Property",
-      "observedAt": "2023-03-24 13:42:32.0",
+      "observedAt": "2023-03-24T13:42:32.000Z",
       "value": {
         "@id": "https://industry-fusion.com/types/v0.9/state_PROCESSING"
       }
@@ -76,16 +76,16 @@
     "type": "https://industry-fusion.com/types/v0.9/oeeTemplate",
     "https://industry-fusion.com/types/v0.9/startTime": {
       "type": "Property",
-      "value": "2023-03-24 13:42:31"
+      "value": "2023-03-24T13:42:31.000Z"
     },
     "https://industry-fusion.com/types/v0.9/endTime": {
       "type": "Property",
-      "value": "2099-03-24 14:42:31"
+      "value": "2099-03-24T14:42:31.000Z"
     },
     "https://industry-fusion.com/oee/v0.9/availabilityState": {
       "type": "Property",
       "value": "1",
-      "observedAt": "2023-03-24 13:42:31.2"
+      "observedAt": "2023-03-24T13:42:31.200Z"
     },
     "https://industry-fusion.com/oee/v0.9/availabilityTimeAgg": {
       "type": "Property",

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test4/model2.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test4/model2.jsonld
@@ -5,7 +5,7 @@
     "type": "https://industry-fusion.com/types/v0.9/cutter",
     "https://industry-fusion.com/types/v0.9/state": {
       "type": "Property",
-      "observedAt": "2023-03-24 13:42:32.0",
+      "observedAt": "2023-03-24T13:42:32.000Z",
       "value": {
         "@id": "https://industry-fusion.com/types/v0.9/state_PROCESSING"
       }
@@ -21,7 +21,7 @@
     "https://industry-fusion.com/oee/v0.9/availabilityState": {
       "type": "Property",
       "value": "1",
-      "observedAt": "2023-03-24 13:42:31.2"
+      "observedAt": "2023-03-24T13:42:31.200Z"
     }
   },
   {
@@ -81,11 +81,11 @@
     "type": "https://industry-fusion.com/types/v0.9/oeeTemplate",
     "https://industry-fusion.com/types/v0.9/startTime": {
       "type": "Property",
-      "value": "2000-01-01 00:00:00"
+      "value": "2000-01-01T00:00:00.000Z"
     },
     "https://industry-fusion.com/types/v0.9/endTime": {
       "type": "Property",
-      "value": "2099-03-24 23:59:59"
+      "value": "2099-03-24T23:59:59.000Z"
     },
     "https://industry-fusion.com/oee/v0.9/availabilityTimeAgg": {
       "type": "Property",

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test4/model3.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test4/model3.jsonld
@@ -5,7 +5,7 @@
     "type": "https://industry-fusion.com/types/v0.9/cutter",
     "https://industry-fusion.com/types/v0.9/state": {
       "type": "Property",
-      "observedAt": "2023-03-24 13:42:32.0",
+      "observedAt": "2023-03-24T13:42:32.000Z",
       "value": {
         "@id": "https://industry-fusion.com/types/v0.9/state_PROCESSING"
       }
@@ -22,27 +22,27 @@
       {
         "type": "Property",
         "value": "1",
-        "observedAt": "2023-03-24 13:42:31.2"
+        "observedAt": "2023-03-24T13:42:31.200Z"
       },
       {
         "type": "Property",
         "value": "1",
-        "observedAt": "2023-03-24 13:42:36.2"
+        "observedAt": "2023-03-24T13:42:36.200Z"
       },
       {
         "type": "Property",
         "value": "1",
-        "observedAt": "2023-03-24 13:42:41.2"
+        "observedAt": "2023-03-24T13:42:41.200Z"
       },
       {
         "type": "Property",
         "value": "0",
-        "observedAt": "2023-03-24 13:42:46.2"
+        "observedAt": "2023-03-24T13:42:46.200Z"
       },
       {
         "type": "Property",
         "value": "1",
-        "observedAt": "2023-03-24 13:47:46.2"
+        "observedAt": "2023-03-24T13:47:46.200Z"
       }
 
   ]
@@ -101,17 +101,17 @@
       {
         "type": "Property",
         "value": "1",
-        "observedAt": "2023-03-24 13:42:31.2"
+        "observedAt": "2023-03-24T13:42:31.200Z"
       },
       {
         "type": "Property",
         "value": "0",
-        "observedAt": "2023-03-24 13:42:36.2"
+        "observedAt": "2023-03-24T13:42:36.200Z"
       },
       {
         "type": "Property",
         "value": "1",
-        "observedAt": "2023-03-24 13:42:41.2"
+        "observedAt": "2023-03-24T13:42:41.200Z"
       }
   ]
   },
@@ -121,11 +121,11 @@
     "type": "https://industry-fusion.com/types/v0.9/oeeTemplate",
     "https://industry-fusion.com/types/v0.9/startTime": {
       "type": "Property",
-      "value": "2000-01-01 00:00:00"
+      "value": "2000-01-01T00:00:00.000Z"
     },
     "https://industry-fusion.com/types/v0.9/endTime": {
       "type": "Property",
-      "value": "2099-03-24 23:59:59"
+      "value": "2099-03-24T23:59:59.000Z"
     },
     "https://industry-fusion.com/oee/v0.9/availabilityTimeAgg": {
       "type": "Property",
@@ -150,11 +150,11 @@
     "type": "https://industry-fusion.com/types/v0.9/oeeTemplate",
     "https://industry-fusion.com/types/v0.9/startTime": {
       "type": "Property",
-      "value": "2000-01-01 00:00:00"
+      "value": "2000-01-01T00:00:00.000Z"
     },
     "https://industry-fusion.com/types/v0.9/endTime": {
       "type": "Property",
-      "value": "2099-03-24 23:59:59"
+      "value": "2099-03-24T23:59:59.000Z"
     },
     "https://industry-fusion.com/oee/v0.9/availabilityTimeAgg": {
       "type": "Property",

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test4/model4.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test4/model4.jsonld
@@ -5,7 +5,7 @@
     "type": "https://industry-fusion.com/types/v0.9/cutter",
     "https://industry-fusion.com/types/v0.9/state": {
       "type": "Property",
-      "observedAt": "2023-03-24 13:42:32.0",
+      "observedAt": "2023-03-24T13:42:32.000Z",
       "value": {
         "@id": "https://industry-fusion.com/types/v0.9/state_PROCESSING"
       }
@@ -80,11 +80,11 @@
     "type": "https://industry-fusion.com/types/v0.9/oeeTemplate",
     "https://industry-fusion.com/types/v0.9/startTime": {
       "type": "Property",
-      "value": "2000-01-01 00:00:00"
+      "value": "2000-01-01T00:00:00.000Z"
     },
     "https://industry-fusion.com/types/v0.9/endTime": {
       "type": "Property",
-      "value": "2099-03-24 23:59:59"
+      "value": "2099-03-24T23:59:59.000Z"
     },
     "https://industry-fusion.com/oee/v0.9/availabilityTimeAgg": {
       "type": "Property",

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test4/model5.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test4/model5.jsonld
@@ -5,7 +5,7 @@
     "type": "https://industry-fusion.com/types/v0.9/cutter",
     "https://industry-fusion.com/types/v0.9/state": {
       "type": "Property",
-      "observedAt": "2023-03-24 13:42:32.0",
+      "observedAt": "2023-03-24T13:42:32.000Z",
       "value": {
         "@id": "https://industry-fusion.com/types/v0.9/state_PROCESSING"
       }
@@ -18,12 +18,12 @@
       {
       "type": "Relationship",
       "object": "urn:workpiece:1",
-      "observedAt": "2023-03-24 13:42:32.0"
+      "observedAt": "2023-03-24T13:42:32.000Z"
       },
       {
         "type": "Relationship",
         "object": "urn:workpiece:2",
-        "observedAt": "2023-03-24 14:42:32.0"
+        "observedAt": "2023-03-24T14:42:32.000Z"
         }
     ],
     "https://industry-fusion.com/types/v0.9/hasFilter": {
@@ -120,11 +120,11 @@
     "type": "https://industry-fusion.com/types/v0.9/oeeTemplate",
     "https://industry-fusion.com/types/v0.9/startTime": {
       "type": "Property",
-      "value": "2000-01-01 00:00:00"
+      "value": "2000-01-01T00:00:00.000Z"
     },
     "https://industry-fusion.com/types/v0.9/endTime": {
       "type": "Property",
-      "value": "2099-03-24 23:59:59"
+      "value": "2099-03-24T23:59:59.000Z"
     },
     "https://industry-fusion.com/oee/v0.9/availabilityTimeAgg": {
       "type": "Property",

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test4/model6.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test4/model6.jsonld
@@ -5,7 +5,7 @@
     "type": "https://industry-fusion.com/types/v0.9/cutter",
     "https://industry-fusion.com/types/v0.9/state": {
       "type": "Property",
-      "observedAt": "2023-03-24 13:42:32.0",
+      "observedAt": "2023-03-24T13:42:32.000Z",
       "value": {
         "@id": "https://industry-fusion.com/types/v0.9/state_PROCESSING"
       }
@@ -18,22 +18,22 @@
       {
       "type": "Relationship",
       "object": "urn:workpiece:1",
-      "observedAt": "2023-03-24 13:42:32.0"
+      "observedAt": "2023-03-24T13:42:32.000Z"
       },
       {
         "type": "Relationship",
         "object": "urn:workpiece:2",
-        "observedAt": "2023-03-24 14:42:32.0"
+        "observedAt": "2023-03-24T14:42:32.000Z"
       },
       {
         "type": "Relationship",
         "object": "urn:workpiece:3",
-        "observedAt": "2023-03-24 15:42:32.0"
+        "observedAt": "2023-03-24T15:42:32.000Z"
       },
       {
         "type": "Relationship",
         "object": "urn:workpiece:4",
-        "observedAt": "2023-03-24 16:42:32.0"
+        "observedAt": "2023-03-24T16:42:32.000Z"
       }
     ],
     "https://industry-fusion.com/types/v0.9/hasFilter": {
@@ -141,11 +141,11 @@
     "type": "https://industry-fusion.com/types/v0.9/oeeTemplate",
     "https://industry-fusion.com/types/v0.9/startTime": {
       "type": "Property",
-      "value": "2000-01-01 00:00:00"
+      "value": "2000-01-01T00:00:00.000Z"
     },
     "https://industry-fusion.com/types/v0.9/endTime": {
       "type": "Property",
-      "value": "2099-03-24 23:59:59"
+      "value": "2099-03-24T23:59:59.000Z"
     },
     "https://industry-fusion.com/oee/v0.9/availabilityTimeAgg": {
       "type": "Property",

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test4/model7.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test4/model7.jsonld
@@ -5,7 +5,7 @@
     "type": "https://industry-fusion.com/types/v0.9/cutter",
     "https://industry-fusion.com/types/v0.9/state": {
       "type": "Property",
-      "observedAt": "2023-03-24 13:42:32.0",
+      "observedAt": "2023-03-24T13:42:32.000Z",
       "value": {
         "@id": "https://industry-fusion.com/types/v0.9/state_PROCESSING"
       }
@@ -18,22 +18,22 @@
       {
       "type": "Relationship",
       "object": "urn:workpiece:1",
-      "observedAt": "2023-03-24 13:42:32.0"
+      "observedAt": "2023-03-24T13:42:32.000Z"
       },
       {
         "type": "Relationship",
         "object": "urn:workpiece:2",
-        "observedAt": "2023-03-24 14:42:32.0"
+        "observedAt": "2023-03-24T14:42:32.000Z"
       },
       {
         "type": "Relationship",
         "object": "urn:workpiece:3",
-        "observedAt": "2023-03-24 15:42:32.0"
+        "observedAt": "2023-03-24T15:42:32.000Z"
       },
       {
         "type": "Relationship",
         "object": "urn:workpiece:4",
-        "observedAt": "2023-03-24 16:42:32.0"
+        "observedAt": "2023-03-24T16:42:32.000Z"
       }
     ],
     "https://industry-fusion.com/types/v0.9/hasFilter": {
@@ -81,13 +81,13 @@
       {
         "type": "Property",
         "value": "1",
-        "observedAt": "2023-03-24 14:42:32.0",
+        "observedAt": "2023-03-24T14:42:32.000Z",
         "datasetId": 0
       },
       {
         "type": "Property",
         "value": "0",
-        "observedAt": "2023-03-24 14:42:33.0",
+        "observedAt": "2023-03-24T14:42:33.000Z",
         "datasetId": 0
       }
     ],
@@ -152,11 +152,11 @@
     "type": "https://industry-fusion.com/types/v0.9/oeeTemplate",
     "https://industry-fusion.com/types/v0.9/startTime": {
       "type": "Property",
-      "value": "2000-01-01 00:00:00"
+      "value": "2000-01-01T00:00:00.000Z"
     },
     "https://industry-fusion.com/types/v0.9/endTime": {
       "type": "Property",
-      "value": "2099-03-24 23:59:59"
+      "value": "2099-03-24T23:59:59.000Z"
     },
     "https://industry-fusion.com/oee/v0.9/availabilityTimeAgg": {
       "type": "Property",

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test4/model8.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test4/model8.jsonld
@@ -5,7 +5,7 @@
     "type": "https://industry-fusion.com/types/v0.9/cutter",
     "https://industry-fusion.com/types/v0.9/state": {
       "type": "Property",
-      "observedAt": "2023-03-24 13:42:32.0",
+      "observedAt": "2023-03-24T13:42:32.000Z",
       "value": {
         "@id": "https://industry-fusion.com/types/v0.9/state_PROCESSING"
       }
@@ -18,17 +18,17 @@
       {
       "type": "Relationship",
       "object": "urn:workpiece:1",
-      "observedAt": "2023-03-24 13:42:32.0"
+      "observedAt": "2023-03-24T13:42:32.000Z"
       },
       {
         "type": "Relationship",
         "object": "urn:workpiece:2",
-        "observedAt": "2023-03-24 14:42:32.0"
+        "observedAt": "2023-03-24T14:42:32.000Z"
       },
       {
         "type": "Relationship",
         "object": "urn:workpiece:3",
-        "observedAt": "2100-03-24 15:42:32.0"
+        "observedAt": "2100-03-24T15:42:32.000Z"
       }
     ],
     "https://industry-fusion.com/types/v0.9/hasFilter": {
@@ -76,13 +76,13 @@
       {
         "type": "Property",
         "value": "1",
-        "observedAt": "2023-03-24 14:42:32.0",
+        "observedAt": "2023-03-24T14:42:32.000Z",
         "datasetId": 0
       },
       {
         "type": "Property",
         "value": "0",
-        "observedAt": "2023-03-24 14:42:33.0",
+        "observedAt": "2023-03-24T14:42:33.000Z",
         "datasetId": 0
       }
     ],
@@ -147,11 +147,11 @@
     "type": "https://industry-fusion.com/types/v0.9/oeeTemplate",
     "https://industry-fusion.com/types/v0.9/startTime": {
       "type": "Property",
-      "value": "2000-01-01 00:00:00"
+      "value": "2000-01-01T00:00:00.000Z"
     },
     "https://industry-fusion.com/types/v0.9/endTime": {
       "type": "Property",
-      "value": "2099-03-24 23:59:59"
+      "value": "2099-03-24T23:59:59.000Z"
     },
     "https://industry-fusion.com/oee/v0.9/availabilityTimeAgg": {
       "type": "Property",

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model1.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model1.jsonld
@@ -43,7 +43,7 @@
       "value": {
         "@id": "base:state_ON"
       },
-      "observedAt": "2024-02-29 13:52:32.0"
+      "observedAt": "2024-02-29T13:52:32.000Z"
     }],
     "iffBaseEntities:hasCartridge": [
       {
@@ -55,22 +55,22 @@
       {
         "type": "Property",
         "value": 0.9,
-        "observedAt": "2024-02-28 13:52:32.0"
+        "observedAt": "2024-02-28T13:52:32.000Z"
       },
       {
         "type": "Property",
         "value": 0.8,
-        "observedAt": "2024-02-28 13:52:33.0" 
+        "observedAt": "2024-02-28T13:52:33.000Z" 
       },
       {
         "type": "Property",
         "value": 0.7,
-        "observedAt": "2024-02-28 13:52:34.0" 
+        "observedAt": "2024-02-28T13:52:34.000Z" 
       },
       {
         "type": "Property",
         "value": 0.6,
-        "observedAt": "2024-02-28 13:52:35.0" 
+        "observedAt": "2024-02-28T13:52:35.000Z" 
       }
     ]
   },
@@ -82,12 +82,12 @@
     "iffBaseEntities:isUsedUntil": [
       {
         "type": "Property",
-        "value": "2024-02-27 13:54:55.4"
+        "value": "2024-02-27T13:54:55.400Z"
       }],
       "iffBaseEntities:isUsedFrom": [
         {
           "type": "Property",
-          "value": "2024-02-27 13:54:55.4"
+          "value": "2024-02-27T13:54:55.400Z"
         }],
       "iffFilterEntities:hasWasteclass":[
         {

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model1.jsonld_result
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model1.jsonld_result
@@ -1,2 +1,2 @@
-'urn:cartridge:1','https://industryfusion.github.io/contexts/example/v0/base_entities/isUsedUntil','@value',NULL,'@none','https://uri.etsi.org/ngsi-ld/Property','212575974752000'
+'urn:cartridge:1','https://industryfusion.github.io/contexts/example/v0/base_entities/isUsedUntil','@value',NULL,'@none','https://uri.etsi.org/ngsi-ld/Property','2024-02-29T13:52:32.000Z'
 'urn:cartridge:1','https://industryfusion.github.io/contexts/example/v0/filter_entities/hasWasteclass','@id',NULL,'@none','https://uri.etsi.org/ngsi-ld/Property','https://industryfusion.github.io/contexts/example/v0/filter_knowledge/WC2'

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model2.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model2.jsonld
@@ -43,7 +43,7 @@
       "value": {
         "@id": "base:state_OFF"
       },
-      "observedAt": "2024-02-29 13:52:32.0"
+      "observedAt": "2024-02-29T13:52:32.000Z"
     }],
     "iffBaseEntities:hasCartridge": [
       {
@@ -55,22 +55,22 @@
       {
         "type": "Property",
         "value": 0.9,
-        "observedAt": "2024-02-28 13:52:32.0"
+        "observedAt": "2024-02-28T13:52:32.000Z"
       },
       {
         "type": "Property",
         "value": 0.8,
-        "observedAt": "2024-02-28 13:52:33.0" 
+        "observedAt": "2024-02-28T13:52:33.000Z" 
       },
       {
         "type": "Property",
         "value": 0.7,
-        "observedAt": "2024-02-28 13:52:34.0" 
+        "observedAt": "2024-02-28T13:52:34.000Z" 
       },
       {
         "type": "Property",
         "value": 0.6,
-        "observedAt": "2024-02-28 13:52:35.0" 
+        "observedAt": "2024-02-28T13:52:35.000Z" 
       }
     ]
   },
@@ -82,12 +82,12 @@
     "iffBaseEntities:isUsedUntil": [
       {
         "type": "Property",
-        "value": "2024-02-27 13:54:55.4"
+        "value": "2024-02-27T13:54:55.400Z"
       }],
       "iffBaseEntities:isUsedFrom": [
         {
           "type": "Property",
-          "value": "2024-02-27 13:54:55.4"
+          "value": "2024-02-27T13:54:55.400Z"
         }],
       "iffFilterEntities:hasWasteclass":[
         {

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model3.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model3.jsonld
@@ -43,7 +43,7 @@
       "value": {
         "@id": "base:state_ON"
       },
-      "observedAt": "2024-02-29 13:52:32.0"
+      "observedAt": "2024-02-29T13:52:32.000Z"
     }],
     "iffBaseEntities:hasCartridge": [
       {
@@ -55,22 +55,22 @@
       {
         "type": "Property",
         "value": 0.9,
-        "observedAt": "2024-02-28 13:52:32.0"
+        "observedAt": "2024-02-28T13:52:32.000Z"
       },
       {
         "type": "Property",
         "value": 0.8,
-        "observedAt": "2024-02-28 13:52:33.0" 
+        "observedAt": "2024-02-28T13:52:33.000Z" 
       },
       {
         "type": "Property",
         "value": 0.7,
-        "observedAt": "2024-02-28 13:52:34.0" 
+        "observedAt": "2024-02-28T13:52:34.000Z" 
       },
       {
         "type": "Property",
         "value": 0.6,
-        "observedAt": "2024-02-28 13:52:35.0" 
+        "observedAt": "2024-02-28T13:52:35.000Z" 
       }
     ]
   },
@@ -82,12 +82,12 @@
     "iffBaseEntities:isUsedUntil": [
       {
         "type": "Property",
-        "value": "2024-02-27 13:54:55.4"
+        "value": "2024-02-27T13:54:55.400Z"
       }],
       "iffBaseEntities:isUsedFrom": [
         {
           "type": "Property",
-          "value": "2024-02-27 13:54:55.4"
+          "value": "2024-02-27T13:54:55.400Z"
         }],
       "iffFilterEntities:hasWasteclass":[
         {

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model3.jsonld_result
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model3.jsonld_result
@@ -1,1 +1,1 @@
-'urn:cartridge:1','https://industryfusion.github.io/contexts/example/v0/base_entities/isUsedUntil','@value',NULL,'@none','https://uri.etsi.org/ngsi-ld/Property','212575974752000'
+'urn:cartridge:1','https://industryfusion.github.io/contexts/example/v0/base_entities/isUsedUntil','@value',NULL,'@none','https://uri.etsi.org/ngsi-ld/Property','2024-02-29T13:52:32.000Z'

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model4.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model4.jsonld
@@ -43,7 +43,7 @@
       "value": {
         "@id": "base:state_ON"
       },
-      "observedAt": "2024-02-29 13:52:32.0"
+      "observedAt": "2024-02-29T13:52:32.000Z"
     }],
     "iffBaseEntities:hasCartridge": [
       {
@@ -55,22 +55,22 @@
       {
         "type": "Property",
         "value": 0.9,
-        "observedAt": "2024-02-28 13:52:32.0"
+        "observedAt": "2024-02-28T13:52:32.000Z"
       },
       {
         "type": "Property",
         "value": 0.8,
-        "observedAt": "2024-02-28 13:52:33.0" 
+        "observedAt": "2024-02-28T13:52:33.000Z" 
       },
       {
         "type": "Property",
         "value": 0.7,
-        "observedAt": "2024-02-28 13:52:34.0" 
+        "observedAt": "2024-02-28T13:52:34.000Z" 
       },
       {
         "type": "Property",
         "value": 0.6,
-        "observedAt": "2024-02-28 13:52:35.0" 
+        "observedAt": "2024-02-28T13:52:35.000Z" 
       }
     ]
   },
@@ -82,12 +82,12 @@
     "iffBaseEntities:isUsedUntil": [
       {
         "type": "Property",
-        "value": "2024-02-27 13:54:55.4"
+        "value": "2024-02-27T13:54:55.400Z"
       }],
       "iffBaseEntities:isUsedFrom": [
         {
           "type": "Property",
-          "value": "2024-02-27 13:54:55.4"
+          "value": "2024-02-27T13:54:55.400Z"
         }],
       "iffFilterEntities:hasWasteclass":[
         {

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model4.jsonld_result
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model4.jsonld_result
@@ -1,2 +1,2 @@
-'urn:cartridge:1','https://industryfusion.github.io/contexts/example/v0/base_entities/isUsedUntil','@value',NULL,'@none','https://uri.etsi.org/ngsi-ld/Property','212575974752000'
+'urn:cartridge:1','https://industryfusion.github.io/contexts/example/v0/base_entities/isUsedUntil','@value',NULL,'@none','https://uri.etsi.org/ngsi-ld/Property','2024-02-29T13:52:32.000Z'
 'urn:cartridge:1','https://industryfusion.github.io/contexts/example/v0/filter_entities/hasWasteclass','@id',NULL,'@none','https://uri.etsi.org/ngsi-ld/Property','https://industryfusion.github.io/contexts/example/v0/filter_knowledge/WC3'

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model5.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model5.jsonld
@@ -1,0 +1,132 @@
+[
+  {
+    "@context": "https://industryfusion.github.io/contexts/tests/context1.jsonld",
+    "id": "urn:cutter:1",
+    "type": "iffBaseEntities:Machine",
+    "iffBaseEntities:hasState": [
+      {
+      "type": "Property",
+      "value": {
+        "@id": "base:state_ON"
+      }}]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/tests/context1.jsonld",
+    "id": "urn:plasmacutter:1",
+    "type": "iffBaseEntities:Cutter",
+    "iffBaseEntities:hasState": [
+      {
+      "type": "Property",
+      "value": {
+        "@id": "base:state_PROCESSING"
+      }}],
+      "iffBaseEntities:hasFilter": [
+        {
+          "type": "Relationship",
+          "object": "urn:filter:1"
+        }
+      ],
+      "iffBaseEntities:hasInWorkpiece": [
+        {
+          "type": "Relationship",
+          "object": "urn:workpiece:1"
+        }
+      ]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/tests/context1.jsonld",
+    "id": "urn:filter:1",
+    "type": "iffBaseEntities:Filter",
+    "iffBaseEntities:hasState": [
+    {
+      "type": "Property",
+      "value": {
+        "@id": "base:state_ON"
+      },
+      "observedAt": "2024-02-29T13:52:32.000Z"
+    }],
+    "iffBaseEntities:hasCartridge": [
+      {
+          "type": "Relationship",
+          "object": "urn:cartridge:1"
+      }
+    ],
+    "iffBaseEntities:hasStrength": [
+      {
+        "type": "Property",
+        "value": 0.9,
+        "observedAt": "2024-02-28T13:52:32.000Z"
+      },
+      {
+        "type": "Property",
+        "value": 0.8,
+        "observedAt": "2024-02-28T13:52:33.000Z" 
+      },
+      {
+        "type": "Property",
+        "value": 0.7,
+        "observedAt": "2024-02-28T13:52:34.000Z" 
+      },
+      {
+        "type": "Property",
+        "value": 0.6,
+        "observedAt": "2024-02-28T13:52:35.000Z" 
+      }
+    ]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/tests/context1.jsonld",
+    "id": "urn:cartridge:1",
+    "type": "iffBaseEntities:FilterCartridge",
+    
+    "iffBaseEntities:isUsedUntil": [
+      {
+        "type": "Property",
+        "value": "2024-02-27T13:54:55.400Z"
+      }],
+      "iffBaseEntities:isUsedFrom": [
+        {
+          "type": "Property",
+          "value": "2024-02-27T13:54:55.400Z"
+        }],
+      "iffFilterEntities:hasWasteclass":[
+        {
+          "type": "Property",
+          "value": {
+            "@id": "iffFilterKnowledge:WC3"
+          }
+        }        
+      ]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/tests/context1.jsonld",
+    "id": "urn:workpiece:1",
+    "type": "iffBaseEntities:Workpiece",
+    
+    "iffBaseEntities:hasMaterial": [
+      {
+        "type": "Property",
+        "value": {
+          "@id": "material:EN_1.4301"
+        }
+      }],
+      "iffBaseEntities:hasHeight": [
+        {
+          "type": "Property",
+          "value": 5
+        }
+      ],
+      "iffBaseEntities:hasLength": [
+        {
+          "type": "Property",
+          "value": 100
+        }
+      ],
+      "iffBaseEntities:hasWidth": [
+        {
+          "type": "Property",
+          "value": 100
+        }
+      ]
+  }
+]

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model5.jsonld_result
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model5.jsonld_result
@@ -1,0 +1,1 @@
+'urn:cartridge:1','https://industryfusion.github.io/contexts/example/v0/base_entities/isUsedUntil','@value',NULL,'@none','https://uri.etsi.org/ngsi-ld/Property','2024-02-29T13:52:32.000Z'

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model6.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model6.jsonld
@@ -1,0 +1,124 @@
+[
+  {
+    "@context": "https://industryfusion.github.io/contexts/tests/context1.jsonld",
+    "id": "urn:cutter:1",
+    "type": "iffBaseEntities:Machine",
+    "iffBaseEntities:hasState": [
+      {
+      "type": "Property",
+      "value": {
+        "@id": "base:state_ON"
+      }}]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/tests/context1.jsonld",
+    "id": "urn:plasmacutter:1",
+    "type": "iffBaseEntities:Cutter",
+    "iffBaseEntities:hasState": [
+      {
+      "type": "Property",
+      "value": {
+        "@id": "base:state_PROCESSING"
+      }}],
+      "iffBaseEntities:hasFilter": [
+        {
+          "type": "Relationship",
+          "object": "urn:filter:1"
+        }
+      ],
+      "iffBaseEntities:hasInWorkpiece": [
+        {
+          "type": "Relationship",
+          "object": "urn:workpiece:1"
+        }
+      ]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/tests/context1.jsonld",
+    "id": "urn:filter:1",
+    "type": "iffBaseEntities:Filter",
+    "iffBaseEntities:hasState": [
+    {
+      "type": "Property",
+      "value": {
+        "@id": "base:state_ON"
+      },
+      "observedAt": "2024-02-29T13:52:32.000Z"
+    }],
+    "iffBaseEntities:hasCartridge": [
+      {
+          "type": "Relationship",
+          "object": "urn:cartridge:1"
+      }
+    ],
+    "iffBaseEntities:hasStrength": [
+      {
+        "type": "Property",
+        "value": 0.9,
+        "observedAt": "2024-02-28T13:52:32.000Z"
+      },
+      {
+        "type": "Property",
+        "value": 0.8,
+        "observedAt": "2024-02-28T13:52:33.000Z" 
+      },
+      {
+        "type": "Property",
+        "value": 0.7,
+        "observedAt": "2024-02-28T13:52:34.000Z" 
+      },
+      {
+        "type": "Property",
+        "value": 0.6,
+        "observedAt": "2024-02-28T13:52:35.000Z" 
+      }
+    ]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/tests/context1.jsonld",
+    "id": "urn:cartridge:1",
+    "type": "iffBaseEntities:FilterCartridge",
+    
+    "iffBaseEntities:isUsedUntil": [
+      {
+        "type": "Property",
+        "value": "2024-02-27T13:54:55.400Z"
+      }],
+      "iffBaseEntities:isUsedFrom": [
+        {
+          "type": "Property",
+          "value": "2024-02-27T13:54:55.400Z"
+        }]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/tests/context1.jsonld",
+    "id": "urn:workpiece:1",
+    "type": "iffBaseEntities:Workpiece",
+    
+    "iffBaseEntities:hasMaterial": [
+      {
+        "type": "Property",
+        "value": {
+          "@id": "material:EN_1.4301"
+        }
+      }],
+      "iffBaseEntities:hasHeight": [
+        {
+          "type": "Property",
+          "value": 5
+        }
+      ],
+      "iffBaseEntities:hasLength": [
+        {
+          "type": "Property",
+          "value": 100
+        }
+      ],
+      "iffBaseEntities:hasWidth": [
+        {
+          "type": "Property",
+          "value": 100
+        }
+      ]
+  }
+]

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model6.jsonld_result
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model6.jsonld_result
@@ -1,0 +1,2 @@
+'urn:cartridge:1','https://industryfusion.github.io/contexts/example/v0/base_entities/isUsedUntil','@value',NULL,'@none','https://uri.etsi.org/ngsi-ld/Property','2024-02-29T13:52:32.000Z'
+'urn:cartridge:1','https://industryfusion.github.io/contexts/example/v0/filter_entities/hasWasteclass','@id',NULL,'@none','https://uri.etsi.org/ngsi-ld/Property','https://industryfusion.github.io/contexts/example/v0/filter_knowledge/WC2'

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model7.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model7.jsonld
@@ -1,0 +1,132 @@
+[
+  {
+    "@context": "https://industryfusion.github.io/contexts/tests/context1.jsonld",
+    "id": "urn:cutter:1",
+    "type": "iffBaseEntities:Machine",
+    "iffBaseEntities:hasState": [
+      {
+      "type": "Property",
+      "value": {
+        "@id": "base:state_ON"
+      }}]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/tests/context1.jsonld",
+    "id": "urn:plasmacutter:1",
+    "type": "iffBaseEntities:Cutter",
+    "iffBaseEntities:hasState": [
+      {
+      "type": "Property",
+      "value": {
+        "@id": "base:state_ON"
+      }}],
+      "iffBaseEntities:hasFilter": [
+        {
+          "type": "Relationship",
+          "object": "urn:filter:1"
+        }
+      ],
+      "iffBaseEntities:hasInWorkpiece": [
+        {
+          "type": "Relationship",
+          "object": "urn:workpiece:1"
+        }
+      ]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/tests/context1.jsonld",
+    "id": "urn:filter:1",
+    "type": "iffBaseEntities:Filter",
+    "iffBaseEntities:hasState": [
+    {
+      "type": "Property",
+      "value": {
+        "@id": "base:state_ON"
+      },
+      "observedAt": "2024-02-29T13:52:32.000Z"
+    }],
+    "iffBaseEntities:hasCartridge": [
+      {
+          "type": "Relationship",
+          "object": "urn:cartridge:1"
+      }
+    ],
+    "iffBaseEntities:hasStrength": [
+      {
+        "type": "Property",
+        "value": 0.9,
+        "observedAt": "2024-02-28T13:52:32.000Z"
+      },
+      {
+        "type": "Property",
+        "value": 0.8,
+        "observedAt": "2024-02-28T13:52:33.000Z" 
+      },
+      {
+        "type": "Property",
+        "value": 0.7,
+        "observedAt": "2024-02-28T13:52:34.000Z" 
+      },
+      {
+        "type": "Property",
+        "value": 0.6,
+        "observedAt": "2024-02-28T13:52:35.000Z" 
+      }
+    ]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/tests/context1.jsonld",
+    "id": "urn:cartridge:1",
+    "type": "iffBaseEntities:FilterCartridge",
+    
+    "iffBaseEntities:isUsedUntil": [
+      {
+        "type": "Property",
+        "value": "2024-02-27T13:54:55.400Z"
+      }],
+      "iffBaseEntities:isUsedFrom": [
+        {
+          "type": "Property",
+          "value": "2024-02-27T13:54:55.400Z"
+        }],
+      "iffFilterEntities:hasWasteclass":[
+        {
+          "type": "Property",
+          "value": {
+            "@id": "iffFilterKnowledge:WC1"
+          }
+        }        
+      ]
+  },
+  {
+    "@context": "https://industryfusion.github.io/contexts/tests/context1.jsonld",
+    "id": "urn:workpiece:1",
+    "type": "iffBaseEntities:Workpiece",
+    
+    "iffBaseEntities:hasMaterial": [
+      {
+        "type": "Property",
+        "value": {
+          "@id": "material:EN_1.4301"
+        }
+      }],
+      "iffBaseEntities:hasHeight": [
+        {
+          "type": "Property",
+          "value": 5
+        }
+      ],
+      "iffBaseEntities:hasLength": [
+        {
+          "type": "Property",
+          "value": 100
+        }
+      ],
+      "iffBaseEntities:hasWidth": [
+        {
+          "type": "Property",
+          "value": 100
+        }
+      ]
+  }
+]

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model7.jsonld_result
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-rules/test7/model7.jsonld_result
@@ -1,0 +1,1 @@
+'urn:cartridge:1','https://industryfusion.github.io/contexts/example/v0/base_entities/isUsedUntil','@value',NULL,'@none','https://uri.etsi.org/ngsi-ld/Property','2024-02-29T13:52:32.000Z'

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-udf/test6/model1.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-udf/test6/model1.jsonld
@@ -6,13 +6,13 @@
     "https://industry-fusion.com/types/v0.9/state": [
       {
       "type": "Property",
-      "observedAt": "2023-03-24 13:42:32.0",
+      "observedAt": "2023-03-24T13:42:32.000Z",
       "value": {
         "@id": "https://industry-fusion.com/types/v0.9/state_PROCESSING"
       }},
       {
         "type": "Property",
-        "observedAt": "2023-03-24 13:52:32.0",
+        "observedAt": "2023-03-24T13:52:32.000Z",
         "value": {
           "@id": "https://industry-fusion.com/types/v0.9/state_PROCESSING"
         }
@@ -20,13 +20,13 @@
     "https://industry-fusion.com/types/v0.9/hasOutWorkpiece": [{
       "type": "Relationship",
       "object": "urn:workpiece:1",
-      "observedAt": "2023-03-24 13:42:32.0"
+      "observedAt": "2023-03-24T13:42:32.000Z"
 
     },
     {
       "type": "Relationship",
       "object": "urn:workpiece:2",
-      "observedAt": "2023-03-24 13:52:32.0"
+      "observedAt": "2023-03-24T13:52:32.000Z"
 
     }],
     "https://industry-fusion.com/types/v0.9/hasInWorkpiece": {
@@ -41,27 +41,27 @@
       {
         "type": "Property",
         "value": "0",
-        "observedAt": "2023-03-24 13:42:32.0"
+        "observedAt": "2023-03-24T13:42:32.000Z"
       },
       {
         "type": "Property",
         "value": "1",
-        "observedAt": "2023-03-24 13:42:42.0"
+        "observedAt": "2023-03-24T13:42:42.000Z"
       },
       {
         "type": "Property",
         "value": "1",
-        "observedAt": "2023-03-24 13:42:45.0"
+        "observedAt": "2023-03-24T13:42:45.000Z"
       },
       {
         "type": "Property",
         "value": "0",
-        "observedAt": "2023-03-24 13:42:50.0"
+        "observedAt": "2023-03-24T13:42:50.000Z"
       },
       {
         "type": "Property",
         "value": "1",
-        "observedAt": "2023-03-24 13:42:55.0"
+        "observedAt": "2023-03-24T13:42:55.000Z"
       }
     ]
   },
@@ -141,13 +141,13 @@
         "value": "1",
         "type": "Property",
         "datasetId": "0",
-        "observedAt": "2023-03-24 13:42:32.0"
+        "observedAt": "2023-03-24T13:42:32.000Z"
       },
       {
         "value": "0",
         "type": "Property",
         "datasetId": "0",
-        "observedAt": "2023-03-24 13:52:32.0"
+        "observedAt": "2023-03-24T13:52:32.000Z"
       }
     ],
     "https://schema.org/depth": {
@@ -207,7 +207,7 @@
     "type": "https://industry-fusion.com/types/v0.9/filterCartridge",
     "https://industry-fusion.com/types/v0.9/inUseUntil": {
       "type": "Property",
-      "value": "2021-10-25 13:54:55.4"
+      "value": "2021-10-25T13:54:55.400Z"
     },
     "https://industry-fusion.com/types/v0.9/wasteClass": {
       "type": "Property",
@@ -222,11 +222,11 @@
     "type": "https://industry-fusion.com/types/v0.9/oeeTemplate",
     "https://industry-fusion.com/types/v0.9/startTime": {
       "type": "Property",
-      "value": "2000-03-23 13:42:31"
+      "value": "2000-03-23T13:42:31.000Z"
     },
     "https://industry-fusion.com/types/v0.9/endTime": {
       "type": "Property",
-      "value": "2099-03-25 14:42:31"
+      "value": "2099-03-25T14:42:31.000Z"
     },
 
     "https://industry-fusion.com/oee/v0.9/hasReferenceMachine": {

--- a/semantic-model/shacl2flink/tests/sql-tests/kms-udf/test6/model2.jsonld
+++ b/semantic-model/shacl2flink/tests/sql-tests/kms-udf/test6/model2.jsonld
@@ -6,13 +6,13 @@
     "https://industry-fusion.com/types/v0.9/state": [
       {
       "type": "Property",
-      "observedAt": "2023-03-24 13:42:32.0",
+      "observedAt": "2023-03-24T13:42:32.000Z",
       "value": {
         "@id": "https://industry-fusion.com/types/v0.9/state_PROCESSING"
       }},
       {
         "type": "Property",
-        "observedAt": "2023-03-24 13:52:32.0",
+        "observedAt": "2023-03-24T13:52:32.000Z",
         "value": {
           "@id": "https://industry-fusion.com/types/v0.9/state_PROCESSING"
         }
@@ -20,13 +20,13 @@
     "https://industry-fusion.com/types/v0.9/hasOutWorkpiece": [{
       "type": "Relationship",
       "object": "urn:workpiece:1",
-      "observedAt": "2023-03-24 13:42:32.0"
+      "observedAt": "2023-03-24T13:42:32.000Z"
 
     },
     {
       "type": "Relationship",
       "object": "urn:workpiece:2",
-      "observedAt": "2023-03-24 13:52:32.0"
+      "observedAt": "2023-03-24T13:52:32.000Z"
 
     }],
     "https://industry-fusion.com/types/v0.9/hasInWorkpiece": {
@@ -41,27 +41,27 @@
         {
             "type": "Property",
             "value": "1",
-            "observedAt": "2023-03-24 13:42:55.0"
+            "observedAt": "2023-03-24T13:42:55.000Z"
       },
       {
         "type": "Property",
         "value": "0",
-        "observedAt": "2023-03-24 13:42:32.0"
+        "observedAt": "2023-03-24T13:42:32.000Z"
       },
       {
         "type": "Property",
         "value": "1",
-        "observedAt": "2023-03-24 13:42:45.0"
+        "observedAt": "2023-03-24T13:42:45.000Z"
       },
       {
         "type": "Property",
         "value": "0",
-        "observedAt": "2023-03-24 13:42:50.0"
+        "observedAt": "2023-03-24T13:42:50.000Z"
       },
       {
         "type": "Property",
         "value": "1",
-        "observedAt": "2023-03-24 13:42:42.0"
+        "observedAt": "2023-03-24T13:42:42.000Z"
       }
     ]
   },
@@ -141,13 +141,13 @@
         "value": "1",
         "type": "Property",
         "datasetId": "0",
-        "observedAt": "2023-03-24 13:42:32.0"
+        "observedAt": "2023-03-24T13:42:32.000Z"
       },
       {
         "value": "0",
         "type": "Property",
         "datasetId": "0",
-        "observedAt": "2023-03-24 13:52:32.0"
+        "observedAt": "2023-03-24T13:52:32.000Z"
       }
     ],
     "https://schema.org/depth": {
@@ -207,7 +207,7 @@
     "type": "https://industry-fusion.com/types/v0.9/filterCartridge",
     "https://industry-fusion.com/types/v0.9/inUseUntil": {
       "type": "Property",
-      "value": "2021-10-25 13:54:55.4"
+      "value": "2021-10-25T13:54:55.400Z"
     },
     "https://industry-fusion.com/types/v0.9/wasteClass": {
       "type": "Property",
@@ -222,11 +222,11 @@
     "type": "https://industry-fusion.com/types/v0.9/oeeTemplate",
     "https://industry-fusion.com/types/v0.9/startTime": {
       "type": "Property",
-      "value": "2000-03-23 13:42:31"
+      "value": "2000-03-23T13:42:31.000Z"
     },
     "https://industry-fusion.com/types/v0.9/endTime": {
       "type": "Property",
-      "value": "2099-03-25 14:42:31"
+      "value": "2099-03-25T14:42:31.000Z"
     },
 
     "https://industry-fusion.com/oee/v0.9/hasReferenceMachine": {

--- a/semantic-model/shacl2flink/tests/test_inverse_path.py
+++ b/semantic-model/shacl2flink/tests/test_inverse_path.py
@@ -1,0 +1,266 @@
+#
+# Copyright (c) 2026 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+Inverse NGSI-LD relationships: who points AT the focus node.
+
+"A cartridge is installed in at most one filter" -- the focus node is the
+REFERENCED entity and the value nodes are the entities referring to it, which
+the forward machinery cannot express because it walks an entity down to its
+OWN attributes.
+
+The path spells out both hops, because NGSI-LD stores a relationship through
+a blank node and a bare inverse of the relationship predicate therefore
+matches nothing at all:
+
+    sh:path ( [ sh:inversePath ngsi-ld:hasObject ]
+              [ sh:inversePath iff:hasCartridge ] )
+"""
+
+import os
+import tempfile
+
+import pytest
+import rdflib
+
+import lib.shacl_properties_to_sql as props
+
+
+SHAPES = """
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix iff: <https://industry-fusion.com/types/v0.9/> .
+@prefix ngsild: <https://uri.etsi.org/ngsi-ld/> .
+
+iff:ExclusiveCartridgeShape
+    a sh:NodeShape ;
+    sh:targetClass iff:FilterCartridge ;
+    sh:property [ sh:path ( [ sh:inversePath ngsild:hasObject ]
+                            [ sh:inversePath iff:hasCartridge ] ) ;
+                  sh:maxCount 1 ] .
+"""
+
+FORBIDDEN = """
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix iff: <https://industry-fusion.com/types/v0.9/> .
+@prefix ngsild: <https://uri.etsi.org/ngsi-ld/> .
+
+iff:ExclusiveCartridgeShape
+    a sh:NodeShape ;
+    sh:targetClass iff:FilterCartridge ;
+    sh:property [ sh:path ( [ sh:inversePath ngsild:hasObject ]
+                            [ sh:inversePath iff:hasCartridge ] ) ;
+                  sh:maxCount 0 ] .
+"""
+
+WITH_CLASS = """
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix iff: <https://industry-fusion.com/types/v0.9/> .
+@prefix ngsild: <https://uri.etsi.org/ngsi-ld/> .
+
+iff:ExclusiveCartridgeShape
+    a sh:NodeShape ;
+    sh:targetClass iff:FilterCartridge ;
+    sh:property [ sh:path ( [ sh:inversePath ngsild:hasObject ]
+                            [ sh:inversePath iff:hasCartridge ] ) ;
+                  sh:maxCount 1 ;
+                  sh:class iff:Filter ] .
+"""
+
+BARE = """
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix iff: <https://industry-fusion.com/types/v0.9/> .
+@prefix ngsild: <https://uri.etsi.org/ngsi-ld/> .
+
+iff:ExclusiveCartridgeShape
+    a sh:NodeShape ;
+    sh:targetClass iff:FilterCartridge ;
+    sh:property [ sh:path [ sh:inversePath iff:hasCartridge ] ;
+                  sh:maxCount 1 ] .
+"""
+
+NESTED_PATH = """
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix iff: <https://industry-fusion.com/types/v0.9/> .
+@prefix ngsild: <https://uri.etsi.org/ngsi-ld/> .
+
+iff:ExclusiveCartridgeShape
+    a sh:NodeShape ;
+    sh:targetClass iff:FilterCartridge ;
+    sh:property [ sh:path ( [ sh:inversePath ngsild:hasObject ]
+                            [ sh:inversePath [ sh:alternativePath ( iff:hasCartridge iff:hasSpare ) ] ] ) ;
+                  sh:maxCount 1 ] .
+"""
+
+UNBOUNDED = """
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix iff: <https://industry-fusion.com/types/v0.9/> .
+@prefix ngsild: <https://uri.etsi.org/ngsi-ld/> .
+
+iff:ExclusiveCartridgeShape
+    a sh:NodeShape ;
+    sh:targetClass iff:FilterCartridge ;
+    sh:property [ sh:path ( [ sh:inversePath ngsild:hasObject ]
+                            [ sh:inversePath iff:hasCartridge ] ) ] .
+"""
+
+KNOWLEDGE = """
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix iff: <https://industry-fusion.com/types/v0.9/> .
+@prefix ngsild: <https://uri.etsi.org/ngsi-ld/> .
+iff:FilterCartridge a rdfs:Class .
+"""
+
+PREFIXES = {
+    'sh': rdflib.Namespace('http://www.w3.org/ns/shacl#'),
+    'rdfs': rdflib.Namespace('http://www.w3.org/2000/01/rdf-schema#'),
+    'rdf': rdflib.Namespace('http://www.w3.org/1999/02/22-rdf-syntax-ns#'),
+    'ngsi-ld': rdflib.Namespace('https://uri.etsi.org/ngsi-ld/'),
+    'iff': rdflib.Namespace('https://industry-fusion.com/types/v0.9/'),
+}
+
+
+def _translate(shapes_ttl, tmp_path):
+    shapes, knowledge = tmp_path / 'shacl.ttl', tmp_path / 'knowledge.ttl'
+    shapes.write_text(shapes_ttl)
+    knowledge.write_text(KNOWLEDGE)
+    cwd = os.getcwd()
+    os.chdir(tempfile.mkdtemp())          # translate() writes into ./output
+    try:
+        sqlite, _ = props.translate(str(shapes), str(knowledge), PREFIXES)
+    finally:
+        os.chdir(cwd)
+    return sqlite
+
+
+@pytest.fixture(scope='module')
+def translated(tmp_path_factory):
+    return _translate(SHAPES, tmp_path_factory.mktemp('inverse'))
+
+
+def test_inverse_shape_lands_in_constraint_table(translated):
+    """The constraint row carries the marker, the FORWARD path and the bound.
+
+    The marker keeps the row out of every attribute-shaped template, all of
+    which select on genuine NGSI-LD type IRIs; the forward path is what the
+    check joins attribute names against.
+    """
+    row = next((line for line in translated.splitlines()
+                if 'constraint_table' in line and
+                props.INVERSE_RELATIONSHIP_TYPE in line), None)
+    assert row is not None, 'no constraint row with the inverse marker'
+    assert 'https://industry-fusion.com/types/v0.9/hasCartridge' in row
+    assert 'FilterCartridge' in row
+
+
+def test_inverse_check_groups_by_the_referenced_entity(translated):
+    """The event name says inverse (^) and referrers are counted DISTINCT.
+
+    DISTINCT is SHACL semantics: the value nodes of an inverse path are a SET
+    of referring entities, so a referrer with two attribute instances of the
+    relationship still counts once.
+    """
+    assert "'CountConstraintComponent(^' ||" in translated
+    assert 'COUNT(DISTINCT CASE WHEN NOT edeleted AND NOT adeleted ' \
+           'AND NOT redeleted THEN referrer' in translated
+
+
+def test_inverse_check_reads_every_liveness_flag(translated):
+    """A reference has two owners and the focus node is a third liveness.
+
+    adeleted covers the attribute row, redeleted the REFERRING entity,
+    edeleted the focus node -- a deleted referrer whose attribute rows have
+    not been swept must not keep a violation alive, and a deleted focus node
+    must not alert at all.
+    """
+    assert 'MAX(CASE WHEN edeleted THEN 1 ELSE 0 END) = 0' in translated
+    assert "COALESCE(R.`deleted`, false) as adeleted" in translated
+    assert "IFNULL(RE.`deleted`, false) as redeleted" in translated
+
+
+def test_inverse_check_pins_its_state(translated):
+    """Join inputs and the accumulator are pinned never-expire.
+
+    The group key is the attribute VALUE, so re-pointing a reference migrates
+    rows between groups: the retraction landing in the OLD group is what
+    clears its violation, and an expired accumulator would drop it in silence
+    and freeze the alert forever.
+    """
+    assert "STATE_TTL('A' = '0d', 'D' = '0d', 'R' = '0d', 'RE' = '0d')" \
+        in translated
+    inverse_part = translated[translated.find('CountConstraintComponent(^'):]
+    assert "STATE_TTL('A1' = '0d')" in translated
+    assert inverse_part, 'inverse check missing entirely'
+
+
+def test_maxcount_zero_compiles(tmp_path_factory):
+    """'must not be referenced at all' is a bound of ZERO, not a missing one.
+
+    rdflib.Literal(0) is falsy, so a truthiness test would read this shape as
+    'no bound given' and drop it from the build -- the exact failure the
+    zero-valued-parameter discipline exists to prevent, and the one that makes
+    a decommissioning guard silently unenforced.
+    """
+    translated = _translate(FORBIDDEN, tmp_path_factory.mktemp('forbidden'))
+    row = next((line for line in translated.splitlines()
+                if 'constraint_table' in line and
+                props.INVERSE_RELATIONSHIP_TYPE in line), None)
+    assert row is not None, 'sh:maxCount 0 on an inverse path was dropped'
+    assert "'0'" in row, f'the zero bound is not in the constraint row: {row}'
+
+
+def test_unsupported_parameter_on_inverse_shape_fails_loud(tmp_path_factory):
+    """sh:class on an inverse shape is not evaluated, so it must not compile.
+
+    Only count bounds are checked on an inverse path. Accepting sh:class
+    would ship 'every referrer must be a Filter' as a constraint nobody
+    evaluates.
+    """
+    with pytest.raises(Exception, match='does not evaluate'):
+        _translate(WITH_CLASS, tmp_path_factory.mktemp('withclass'))
+
+
+def test_bare_inverse_path_fails_loud(tmp_path_factory):
+    """A bare sh:inversePath matches NOTHING in NGSI-LD, so it is refused.
+
+    NGSI-LD stores a relationship through a blank node, so nothing points at
+    the target entity with the relationship's own predicate: a standard SHACL
+    engine reports no violation for this shape, whatever the data. Giving it
+    the meaning the author intended would make this compiler disagree with
+    the reference engine about what a shape MEANS, so the build fails and
+    names the spelling that works.
+    """
+    with pytest.raises(Exception, match='reaches its target through'):
+        _translate(BARE, tmp_path_factory.mktemp('bare'))
+
+
+def test_nested_second_hop_fails_loud(tmp_path_factory):
+    """The second hop must name a plain predicate.
+
+    A path expression there never matches the extraction pattern, so without
+    this the shape would vanish from the build without a word.
+    """
+    with pytest.raises(Exception, match='not a supported NGSI-LD'):
+        _translate(NESTED_PATH, tmp_path_factory.mktemp('nested'))
+
+
+def test_unbounded_inverse_path_fails_loud(tmp_path_factory):
+    """An inverse path without a count bound constrains nothing.
+
+    Accepting it would ship a shape that is never checked, which is the
+    failure mode the fail-loud pass exists to prevent.
+    """
+    with pytest.raises(Exception, match='produced no constraint'):
+        _translate(UNBOUNDED, tmp_path_factory.mktemp('unbounded'))

--- a/semantic-model/shacl2flink/tests/test_utils.py
+++ b/semantic-model/shacl2flink/tests/test_utils.py
@@ -364,7 +364,8 @@ zzSQL_DIALECT_CURRENT_TIMESTAMP, SQL_DIALECT_INSERT_ATTRIBUTES,SQL_DIALECT_SQLIT
     result_expression = utils.process_sql_dialect(expression, isSqlite)
     assert result_expression == "REGEXP_REPLACE(CAST(stripme as STRING), '>|<', '')\
 xxREGEXP_REPLACE(CAST(literal as STRING), '\\\"', '')\
-yy1000 * UNIX_TIMESTAMP(TRY_CAST(time AS STRING)) + EXTRACT(MILLISECOND FROM TRY_CAST(time as TIMESTAMP))\
+yy1000 * UNIX_TIMESTAMP(REPLACE(REPLACE(TRY_CAST(time AS STRING), 'T', ' '), 'Z', '')) + \
+EXTRACT(MILLISECOND FROM TRY_CAST(REPLACE(REPLACE(TRY_CAST(time AS STRING), 'T', ' '), 'Z', '') as TIMESTAMP))\
 zzCURRENT_TIMESTAMP, INSERT into attributes_insert, TRY_CAST"
 
     isSqlite = True
@@ -387,9 +388,12 @@ zzCURRENT_TIMESTAMP, INSERT into attributes_insert, TRY_CAST"
     isSqlite = False
     expression = "SQL_DIALECT_STRIP_LITERAL{SQL_DIALECT_TIME_TO_MILLISECONDS{SQL_DIALECT_STRIP_IRI{test}}}"
     result_expression = utils.process_sql_dialect(expression, isSqlite)
-    assert result_expression == 'REGEXP_REPLACE(CAST(1000 * UNIX_TIMESTAMP(TRY_CAST(REGEXP_REPLACE(CAST(test \
-as STRING), \'>|<\', \'\') AS STRING)) + EXTRACT(MILLISECOND FROM TRY_CAST(REGEXP_REPLACE(CAST(test as STRING), \
-\'>|<\', \'\') as TIMESTAMP)) as STRING), \'\\"\', \'\')'
+    assert result_expression == (
+        "REGEXP_REPLACE(CAST(1000 * UNIX_TIMESTAMP(REPLACE(REPLACE(TRY_CAST("
+        "REGEXP_REPLACE(CAST(test as STRING), '>|<', '') AS STRING), 'T', ' '), 'Z', '')) + "
+        "EXTRACT(MILLISECOND FROM TRY_CAST(REPLACE(REPLACE(TRY_CAST("
+        "REGEXP_REPLACE(CAST(test as STRING), '>|<', '') AS STRING), 'T', ' '), 'Z', '') "
+        "as TIMESTAMP)) as STRING), '\\\"', '')")
 
     isSqlite = True
     result_expression = utils.process_sql_dialect(expression, isSqlite)
@@ -602,3 +606,29 @@ def test_add_table_values():
         sqlsettings = result['spec']['sqlsettings']
         assert not any("state.backend" in s for s in sqlsettings)
         assert not any("execution.checkpointing.interval" in s for s in sqlsettings)
+
+
+def test_iso_timestamp_dialect():
+    expression = "SQL_DIALECT_ISO_TIMESTAMP{ts}"
+    sqlite = utils.process_sql_dialect(expression, True)
+    assert sqlite == "(strftime('%Y-%m-%dT%H:%M:%f', ts) || 'Z')"
+    flink = utils.process_sql_dialect(expression, False)
+    assert flink == (
+        "(DATE_FORMAT(TRY_CAST(REPLACE(REPLACE(TRY_CAST(ts AS STRING), 'T', ' '), 'Z', '') "
+        "AS TIMESTAMP), 'yyyy-MM-dd''T''HH:mm:ss.') || "
+        "LPAD(CAST(EXTRACT(MILLISECOND FROM TRY_CAST(REPLACE(REPLACE(TRY_CAST(ts AS STRING), "
+        "'T', ' '), 'Z', '') AS TIMESTAMP)) AS STRING), 3, '0') || 'Z')"
+    )
+
+
+def test_wrap_time_variable_serializes_iso():
+    var = rdflib.Variable('ts')
+    ctx = {
+        'bounds': {'ts': 'TABLE.`observedAt`'},
+        'property_variables': {},
+        'entity_variables': {},
+        'time_variables': {var: True},
+        'query': 'test',
+    }
+    result = utils.wrap_ngsild_variable(ctx, var)
+    assert result == "'\"' || SQL_DIALECT_ISO_TIMESTAMP{TABLE.`observedAt`} || '\"'"

--- a/semantic-model/shacl2flink/tools/ttl_test.py
+++ b/semantic-model/shacl2flink/tools/ttl_test.py
@@ -33,6 +33,12 @@ Kafka -> Flink -> Alerta), and checks:
                          relationship; count 0 and count 1 must both be
                          reported correctly and "Found 2" must never appear
                          in the verdict history.
+  * Waste class       -- ChangeWasteClassRulesShape through the full
+                         writeback loop (rule -> attributes_insert ->
+                         CoreServices -> Scorpio): the material escalates
+                         the cartridge's class, a lower-hazard material
+                         never downgrades it, and the escalation still
+                         works after the TTL idle.
   * Event time        -- observedAt governs, not arrival time: a newer-2024
                          value beats an older-2024 one regardless of arrival
                          order; a stale re-send does not overwrite; a delete
@@ -107,7 +113,9 @@ ALERTA = 'http://alerta.local/api'
 
 ENT = 'https://industryfusion.github.io/contexts/example/v0/base_entities'
 KNOW = 'https://industryfusion.github.io/contexts/example/v0/base_knowledge'
-MATERIAL = 'https://industryfusion.github.io/contexts/ontology/v0/material/EN_1.4301'
+MATERIALS = 'https://industryfusion.github.io/contexts/ontology/v0/material'
+# the default kms maps: EN_1.3401 -> WC1, EN_1.4301 -> WC2, EN_1.5301 -> WC3
+MATERIAL = f'{MATERIALS}/EN_1.4301'
 
 RESULTS = []
 
@@ -123,13 +131,17 @@ def record(phase, name, ok, detail=''):
 
 # --------------------------------------------------------------------------- plumbing
 
-def _req(url, method='GET', token=None, body=None, ctype='application/ld+json'):
+def _req(url, method='GET', token=None, body=None, ctype='application/ld+json',
+         accept=None):
     data = json.dumps(body).encode() if body is not None else None
     req = urllib.request.Request(url, data=data, method=method)
     if token:
         req.add_header('Authorization', f'Bearer {token}')
     if data:
         req.add_header('Content-Type', ctype)
+    if accept:
+        # Scorpio answers 406 to urllib's default Accept on entity reads
+        req.add_header('Accept', accept)
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
             return resp.status, resp.read()
@@ -330,6 +342,10 @@ class Family:
         self.filter = f'urn:rt:{run}:filter'
         self.workpiece = f'urn:rt:{run}:workpiece'
         self.cartridge = f'urn:rt:{run}:cartridge'
+        # one cartridge per filter: a shared instance would let filter2's
+        # permanently-active chain change the class while THE filter is off,
+        # which is exactly the confusion the kms example used to produce
+        self.cartridge2 = f'urn:rt:{run}:cartridge2'
         # a second cutter/filter pair reserved for the event-time check: its
         # hasStrength timeline must stay pristine 2024, and the other checks
         # restore with wall-clock (2026) observedAt -- which would correctly
@@ -337,7 +353,7 @@ class Family:
         self.cutter2 = f'urn:rt:{run}:cutter2'
         self.filter2 = f'urn:rt:{run}:filter2'
         self.all = [self.cutter, self.filter, self.cutter2, self.filter2,
-                    self.workpiece, self.cartridge]
+                    self.workpiece, self.cartridge, self.cartridge2]
 
     def entities(self):
         return [
@@ -382,7 +398,7 @@ class Family:
              'iffBaseEntities:hasState': [{'type': 'Property',
                                            'value': {'@id': 'base:state_ON'}}],
              'iffBaseEntities:hasCartridge': [{'type': 'Relationship',
-                                               'object': self.cartridge}],
+                                               'object': self.cartridge2}],
              'iffBaseEntities:hasStrength': [{'type': 'Property', 'value': 0.6,
                                               'observedAt': '2024-03-01T00:00:00.000Z'}]},
             {'@context': CONTEXT, 'id': self.workpiece, 'type': 'iffBaseEntities:Workpiece',
@@ -394,9 +410,23 @@ class Family:
             {'@context': CONTEXT, 'id': self.cartridge,
              'type': 'iffBaseEntities:FilterCartridge',
              'iffBaseEntities:isUsedFrom': [{'type': 'Property',
-                                             'value': '2024-02-27 13:54:55.4'}],
+                                             'value': '2024-02-27T13:54:55.400Z'}],
              'iffBaseEntities:isUsedUntil': [{'type': 'Property',
-                                              'value': '2024-02-27 13:54:55.4'}]},
+                                              'value': '2024-02-27T13:54:55.400Z'}],
+             # start at WC1 so the escalation to the material's WC2 is a real
+             # transition (and CartridgeShape's minCount is satisfied)
+             'iffFilterEntities:hasWasteclass': [{
+                 'type': 'Property',
+                 'value': {'@id': 'iffFilterKnowledge:WC1'}}]},
+            {'@context': CONTEXT, 'id': self.cartridge2,
+             'type': 'iffBaseEntities:FilterCartridge',
+             'iffBaseEntities:isUsedFrom': [{'type': 'Property',
+                                             'value': '2024-02-27T13:54:55.400Z'}],
+             'iffBaseEntities:isUsedUntil': [{'type': 'Property',
+                                              'value': '2024-02-27T13:54:55.400Z'}],
+             'iffFilterEntities:hasWasteclass': [{
+                 'type': 'Property',
+                 'value': {'@id': 'iffFilterKnowledge:WC1'}}]},
         ]
 
 
@@ -439,6 +469,67 @@ def set_state(token, eid, state):
 def set_strength(token, eid, value, observed_at):
     return post_attr(token, eid, 'hasStrength',
                      {'type': 'Property', 'value': value, 'observedAt': observed_at})
+
+
+def set_material(token, eid, material_iri):
+    return post_attr(token, eid, 'hasMaterial',
+                     {'type': 'Property', 'value': {'@id': material_iri}})
+
+
+def get_wasteclass(token, eid):
+    """The cartridge's hasWasteclass value ('WC1'..'WC3'), or None.
+
+    Read back from Scorpio, because that is where the rule's writeback
+    lands: SPARQL rule -> attributes_insert -> CoreServices ->
+    ngsild_updates -> Scorpio. Asserting here covers the entire loop.
+    """
+    code, body = _req(f'{NGSILD}/entities/{eid}', token=token.get(),
+                      accept='application/ld+json')
+    if code != 200:
+        return None
+    entity = json.loads(body)
+    for key, value in entity.items():
+        if key.split('/')[-1].split(':')[-1] != 'hasWasteclass':
+            continue
+        attr = value[0] if isinstance(value, list) else value
+        inner = attr.get('value', attr.get('object'))
+        if isinstance(inner, dict):
+            # Scorpio serializes the IRI value as {"id": ...} ("@id" pre-1.5)
+            inner = inner.get('@id') or inner.get('id') or ''
+        return str(inner).split('/')[-1].split(':')[-1]
+    return None
+
+
+def wasteclass_check(token, key, fam, phase, material_iri, want_wc,
+                     lower_material=None, timeout=120):
+    """ChangeWasteClassRulesShape end to end: setting the workpiece material
+    escalates the cartridge's waste class through the writeback loop, and a
+    lower-hazard material never downgrades it (a replaced cartridge is a NEW
+    entity, so there deliberately is no reset path)."""
+    set_material(token, fam.workpiece, material_iri)
+    deadline = time.time() + timeout
+    current = None
+    while time.time() < deadline:
+        current = get_wasteclass(token, fam.cartridge)
+        if current == want_wc:
+            break
+        time.sleep(5)
+    record(phase, f'wasteclass.escalate-{want_wc}', current == want_wc,
+           f'cartridge wasteclass: {current} (want {want_wc})')
+    if lower_material is None or current != want_wc:
+        return
+    set_material(token, fam.workpiece, lower_material)
+    held = True
+    settle = time.time() + 30
+    while time.time() < settle:
+        current = get_wasteclass(token, fam.cartridge)
+        if current != want_wc:
+            held = False
+            break
+        time.sleep(5)
+    record(phase, 'wasteclass.no-downgrade', held,
+           f'cartridge wasteclass after lower-hazard material: {current}')
+    set_material(token, fam.workpiece, material_iri)
 
 
 def now_observed_at():
@@ -1029,6 +1120,11 @@ def main():
         class_check(stats, token, key, fam, 'fresh')
         count_churn(stats, token, key, fam, args.namespace, 'fresh')
         event_time_check(stats, token, key, fam, 'fresh')
+        # the family starts at WC1 with an EN_1.4301 (WC2) workpiece, so the
+        # escalation is observed as a real transition; EN_1.3401 (WC1) then
+        # proves the ratchet never downgrades
+        wasteclass_check(token, key, fam, 'fresh', f'{MATERIALS}/EN_1.4301',
+                         'WC2', lower_material=f'{MATERIALS}/EN_1.3401')
         latency_phase(args, token, key, fam)
         checkpoint_phase(stats)
         last_write = time.time()
@@ -1042,6 +1138,10 @@ def main():
         stats.snap('postttl:baseline')
         sparql_checks(stats, token, key, fam, 'postttl')
         class_check(stats, token, key, fam, 'postttl')
+        # a writeback rule must also survive the idle: escalating to WC3
+        # proves the ChangeWasteClass joins are still alive after 3x TTL
+        wasteclass_check(token, key, fam, 'postttl', f'{MATERIALS}/EN_1.5301',
+                         'WC3')
 
         failed = [r for r in RESULTS if r['phase'] == 'postttl' and not r['ok']]
         if failed:


### PR DESCRIPTION
## What

Makes the material → waste-class use case of the default kms actually work end to end, and aligns every timestamp in the platform on one representation. Three commits:

1. **Align every timestamp on ISO 8601 UTC** (`YYYY-MM-DDTHH:mm:ss.SSSZ`). Time values existed in three shapes at once (ISO `observedAt`, naive `YYYY-MM-DD HH:mm:ss.S` model strings, epoch millis in tools) — and rule-written times went through millis conversions whose two dialects did not even share an epoch (Flink: unix, SQLite: julianday, base 4713 BC), so the batch oracle asserted values the streaming pipeline never produced. Now: a `SQL_DIALECT_ISO_TIMESTAMP` macro serializes the canonical form in both dialects, time variables compare as fixed-width ISO strings (lexical order = chronological order), `xsd:dateTime()` normalizes into the same domain, millis remain for arithmetic. 39 model/fixture files normalized; convention documented in `semantic-model/kms/README.md`.

2. **Pin every guard of `ChangeWasteClassRulesShape`** — the rule was already in the kms but only its happy path was exercised. New one-line-diff oracle fixtures with hand-written expectations: no-downgrade (WC3 stays above a WC2 material), WC0 default, cutter-not-PROCESSING. Streaming counterpart in `tools/ttl_test.py`: drives materials through Scorpio and reads the cartridge back from Scorpio, covering the full writeback loop — fresh (escalate WC1→WC2, never downgrade on EN_1.3401) and post-TTL (escalate to WC3 after the 3×TTL idle). No reset path by design: a replaced cartridge is a new entity.

3. **Quote string values in the writeback JSON** — the new streaming check immediately caught CoreServices emitting `@value` strings unquoted (`"value":2026-08-24T19:19:43.588Z`, unparseable) and the ngsild-updates bridge crashing its whole batch on one malformed record. Both fixed with regression tests; `observedAt` milliseconds are now zero-padded.

4. **Route IRI-valued properties around Scorpio's batchMerge** — the historical root cause: Scorpio's `entityOperations/merge` rejects `value: {"@id": ...}` with 400 / Postgres 22023 while the per-entity `/attrs` endpoint accepts the identical payload, so the waste-class writeback had **never** reached Scorpio. The bridge now partitions update batches: IRI-valued entities go through `updateProperties`, the rest keeps batchMerge. Regression test pins the routing.

## Testing

- shacl2flink pytest (211), sqlite fixture suites (incl. the new guard fixtures), pyshacl-compare, KafkaBridge mocha (11) — all green
- Live-cluster release gate `tools/ttl_test.py --phase all`: **39/39** — all rules raise/retract, count churn exact, full event-time contract, latency p90 1.12 s, resync cadence 394 s ≤ 540 s, wasteclass escalate + no-downgrade + post-TTL WC3 escalation, join-state plateau Δ1.2 MB over 30 min of churn

## Depends on

Builds on #889 (contains its commits); the effective diff of this PR is the top three commits. Rebases cleanly once #889 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Example physics

The kms example shared `urn:cartridge:1` between both filters, so switching filter:1 off still changed the cartridge's class through the plasmacutter:2/filter:2 chain — observed live, and physically impossible. Each filter now owns its cartridge (kms model instances and the test family), restoring the expected property: filter off ⇒ its cartridge's class never moves. Note the ratchet protects only the rule's own writes — a direct downgrade via the API sticks while no qualifying chain is processing; if manipulation visibility matters, a downgrade-alert constraint is a small follow-up.
