### PR TITLE
Upgrade k3s 1.33 and k3d 5.9, Added optional corporate-proxy support for Docker, Maven and k3d;

### DIFF
--- a/FlinkOperatorWithCoreServices/Dockerfile
+++ b/FlinkOperatorWithCoreServices/Dockerfile
@@ -1,5 +1,28 @@
+# syntax=docker/dockerfile:1.7
 FROM maven:3.9.2-eclipse-temurin-17 AS build
 WORKDIR /app
+RUN <<'SCRIPT'
+set -eu
+PROXY_HOST=$(printf '%s' "${HTTPS_PROXY:-${HTTP_PROXY:-}}" | sed -E 's#^https?://##' | cut -d: -f1)
+PROXY_PORT=$(printf '%s' "${HTTPS_PROXY:-${HTTP_PROXY:-}}" | sed -E 's#^https?://##' | cut -d: -f2)
+if [ -n "$PROXY_HOST" ]; then
+  mkdir -p /root/.m2
+  cat > /root/.m2/settings.xml <<CONF
+<settings>
+  <proxies>
+    <proxy>
+      <id>build-proxy</id>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>${PROXY_HOST}</host>
+      <port>${PROXY_PORT}</port>
+      <nonProxyHosts>localhost|127.0.0.1</nonProxyHosts>
+    </proxy>
+  </proxies>
+</settings>
+CONF
+fi
+SCRIPT
 COPY CoreServices/pom.xml ./
 RUN mvn dependency:go-offline test -B -Pcluster
 COPY CoreServices/src ./src

--- a/helm/README.md
+++ b/helm/README.md
@@ -44,6 +44,28 @@ After that, the following steps have to be executed (note the round brackets):
 
 ---
 
+## Building and Installing Behind a Corporate Proxy
+
+If your build/install host requires a proxy for outbound internet access (e.g. a corporate network), export the standard proxy environment variables **before** running any of the scripts above:
+
+```
+export HTTP_PROXY=http://your-proxy-host:port
+export HTTPS_PROXY=http://your-proxy-host:port
+export NO_PROXY=127.0.0.1,localhost,::1,0.0.0.0,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+```
+
+For a persistent setup, it's recommended to add these to `/etc/environment` on Ubuntu so they apply to every shell session without needing to be re-exported.
+
+**Why this is not a config file setting:** Proxy configuration is intentionally **not** stored in a shared, git-tracked file such as `common.yaml`. The build (docker images, Maven, npm) and deploy (k3d cluster, Helm/helmfile) steps can run on different hosts or networks - each with a different proxy, or no proxy at all - so a single committed value would be wrong for at least one of them. Instead, each host's own OS-level environment is treated as the single source of truth for that host.
+
+**What picks this up automatically:**
+* `test/prepare-platform.sh` reads `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` from the environment and configures: the Docker daemon (`/etc/systemd/system/docker.service.d/http-proxy.conf`), the Docker client (`~/.docker/config.json`, so `docker build`/`docker run` inject the proxy into containers automatically), a generated Maven `~/.m2/settings.xml` (Maven does not honor `HTTP_PROXY` env vars on its own), and the k3d cluster nodes (`k3d cluster create -e HTTP_PROXY=...@server:*;agent:*`, since k3d nodes run their own containerd and don't inherit host env vars).
+* `helm/env.sh` normalizes the same variables and is sourced by `build-local-platform.sh`, `install-platform.sh`, `install_operators.sh`, `uninstall_operators.sh` and `prepare-airgap.bash`. Since these scripts invoke `docker`, `helm`/`helmfile` (Go binaries that honor `HTTP_PROXY`/`HTTPS_PROXY`/`NO_PROXY` automatically for chart repo/registry fetches), and `docker-compose build` as subprocesses, the proxy is inherited consistently without any extra per-tool configuration.
+* If `FlinkOperatorWithCoreServices/Dockerfile`'s Maven build steps run behind a proxy, they derive `~/.m2/settings.xml` at build time directly from the `HTTP_PROXY`/`HTTPS_PROXY` build args that Docker automatically forwards once `~/.docker/config.json` is configured as above.
+
+If no proxy environment variables are set, none of the above proxy configuration is applied and behavior is unchanged.
+
+
 
 # Accessing Keycloak and Scorpio
 

--- a/helm/airgap-deployment/prepare-airgap.bash
+++ b/helm/airgap-deployment/prepare-airgap.bash
@@ -26,7 +26,7 @@ if [ "${REGISTRY}" = "docker.io" ]; then
       docker.io/emqx/emqx-operator-controller:${EMQX_OPERATOR_VERSION}
       docker.io/minio/minio:RELEASE.2023-01-12T02-06-16Z
       docker.io/redis:7.2
-      ghcr.io/zalando/spilo-15:2.1-p9
+      ghcr.io/zalando/spilo-15:3.2-p1
       docker.io/velero/velero:${VELERO_VERSION}
       docker.io/alerta/alerta-web:${ALERTA_VERSION}
       docker.io/busybox:1.28
@@ -64,7 +64,7 @@ else
       docker.io/emqx/emqx-operator-controller:${EMQX_OPERATOR_VERSION}
       docker.io/minio/minio:RELEASE.2023-01-12T02-06-16Z
       docker.io/redis:7.2
-      ghcr.io/zalando/spilo-15:2.1-p9
+      ghcr.io/zalando/spilo-15:3.2-p1
       docker.io/velero/velero:${VELERO_VERSION}
       docker.io/alerta/alerta-web:${ALERTA_VERSION}
       docker.io/busybox:1.28

--- a/helm/charts/alerta/templates/ingress.yaml
+++ b/helm/charts/alerta/templates/ingress.yaml
@@ -43,7 +43,7 @@ spec:
 {{ end }}
 ---
 {{- if and (ne .Values.alerta.externalPath "/") (eq .Values.ingressType "traefik") }}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: remove-path-alerta

--- a/helm/charts/fuseki/templates/ingress.yaml
+++ b/helm/charts/fuseki/templates/ingress.yaml
@@ -41,7 +41,7 @@ spec:
             pathType: ImplementationSpecific
 ---
 {{- if eq .Values.ingressType "traefik" }}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: fuseki-realm-auth

--- a/helm/charts/pgrest/templates/ingress.yaml
+++ b/helm/charts/pgrest/templates/ingress.yaml
@@ -41,7 +41,7 @@ spec:
         pathType: ImplementationSpecific
 ---
 {{- if and (ne .Values.pgrest.externalPath "/") (eq .Values.ingressType "traefik") }}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: remove-path-pgrest

--- a/helm/charts/postgres/templates/minimal-postgres-manifest.yaml
+++ b/helm/charts/postgres/templates/minimal-postgres-manifest.yaml
@@ -9,7 +9,7 @@ metadata:
   name: {{ .Values.clusterSvcName }}
   namespace: {{ .Release.Namespace }}
 spec:
-  dockerImage: {{ .Values.externalRegistry4 }}/zalando/spilo-15:2.1-p9
+  dockerImage: {{ .Values.externalRegistry4 }}/zalando/spilo-15:3.2-p1
   env:
   - name: AWS_SECRET_ACCESS_KEY
 # NOTE: This env value must be index 0 - see above the lookup

--- a/helm/charts/scorpio/templates/ingress.yaml
+++ b/helm/charts/scorpio/templates/ingress.yaml
@@ -45,7 +45,7 @@ spec:
         pathType: ImplementationSpecific
 ---
 {{- if and (ne .Values.scorpio.externalPath "/") (eq .Values.ingressType "traefik") }}
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
   name: remove-path-scorpio

--- a/helm/env.sh
+++ b/helm/env.sh
@@ -11,7 +11,7 @@ export VELERO_PLUGIN_VERSION="v1.12.2"
 export VELERO_VERSION="v1.16.2"
 export MINIO_OPERATOR_VERSION="5.0.14"
 export CERT_MANAGER_VERSION="1.9.1"
-export STRIMZI_VERSION="0.45.0"
+export STRIMZI_VERSION="0.45.1"
 export OFFLINE=${OFFLINE:-false}
 export OFFLINE_DIR=$(cd $DIRNAME/airgap-deployment; pwd)
 export KEYCLOAK_VERSION=25.0.0
@@ -29,3 +29,21 @@ export EXT_REGISTRY2=${EXT_REGISTRY2:-${COMMON_EXTERNAL_REGISTRY2}}
 export EXT_REGISTRY3=${EXT_REGISTRY3:-${COMMON_EXTERNAL_REGISTRY3}}
 export EXT_REGISTRY4=${EXT_REGISTRY4:-${COMMON_EXTERNAL_REGISTRY4}}
 export KUBECTL_VERSION=1.28-debian-11
+
+# Optional corporate/network proxy configuration.
+# Build and deploy may run on different machines/networks (e.g. a build
+# host behind proxy A pushing images, and a deploy/CI runner behind proxy B
+# or no proxy at all), so the proxy value itself must NOT be hardcoded in a
+# shared, git-tracked file - each host's own OS-level environment (e.g.
+# HTTP_PROXY/HTTPS_PROXY/NO_PROXY exported via /etc/environment on Ubuntu)
+# is the single source of truth per host. This just normalizes the
+# upper/lowercase variants consistently so every consumer (Docker, Maven via
+# generated settings.xml in test/prepare-platform.sh, Helm's Go net/http
+# client for chart repo fetches) sees the same values without duplicating
+# this logic elsewhere.
+export HTTP_PROXY="${HTTP_PROXY:-${http_proxy:-}}"
+export HTTPS_PROXY="${HTTPS_PROXY:-${https_proxy:-}}"
+export NO_PROXY="${NO_PROXY:-${no_proxy:-}}"
+export http_proxy="$HTTP_PROXY"
+export https_proxy="$HTTPS_PROXY"
+export no_proxy="$NO_PROXY"

--- a/helm/install_operators.sh
+++ b/helm/install_operators.sh
@@ -117,7 +117,7 @@ printf "\n"
 printf "\033[1mInstalling Postgres-operator ${POSTGRES_OPERATOR_VERSION}\n"
 printf -- "------------------------\033[0m\n"
 if [ "$OFFLINE" = "true" ]; then
-  ( cd ${OFFLINE_DIR}/postgres-operator && helm -n iff upgrade --install postgres-operator ./charts/postgres-operator --set image.registry=${EXT_REGISTRY3} --set configGeneral.docker_image=${EXT_REGISTRY4}/zalando/spilo-15:2.1-p9)
+  ( cd ${OFFLINE_DIR}/postgres-operator && helm -n iff upgrade --install postgres-operator ./charts/postgres-operator --set image.registry=${EXT_REGISTRY3} --set configGeneral.docker_image=${EXT_REGISTRY4}/zalando/spilo-15:3.2-p1)
 else
   rm -rf postgres-operator
   git clone https://github.com/zalando/postgres-operator.git

--- a/test/prepare-platform-for-self-hosted-runner.sh
+++ b/test/prepare-platform-for-self-hosted-runner.sh
@@ -15,7 +15,7 @@
 #
 
 # use specific k3s image to avoid surprises with k8s api changes
-K3S_IMAGE=rancher/k3s:v1.31.5-k3s1-amd64
+K3S_IMAGE=rancher/k3s:v1.33.13-k3s2
 
 
 echo Installing K3d cluster

--- a/test/prepare-platform.sh
+++ b/test/prepare-platform.sh
@@ -15,9 +15,30 @@
 #
 
 # use specific k3s image to avoid surprises with k8s api changes
-K3S_IMAGE=rancher/k3s:v1.31.5-k3s1-amd64
+K3S_IMAGE=rancher/k3s:v1.33.13-k3s2
 CURR_DIR=$(pwd)
 SCRIPT_PATH=$(realpath $0)
+
+# Optional corporate proxy support.
+# Build (this script) and deploy (install-platform.sh/helm/env.sh, run
+# possibly on a different host or CI runner) may sit behind different
+# proxies, or no proxy at all - so the proxy value itself is intentionally
+# NOT stored in a shared, git-tracked file. Each host's own OS-level
+# environment (e.g. HTTP_PROXY/HTTPS_PROXY/NO_PROXY exported via
+# /etc/environment on Ubuntu) is the single source of truth for that host,
+# and is propagated consistently from here to: the Docker daemon, the
+# Docker client (so `docker build`/`docker run` inject them into
+# containers), Maven, and the k3d cluster nodes (which run their own
+# containerd and don't inherit host env vars). If no proxy is set, none of
+# this runs and behavior is unchanged.
+PROXY_HTTP="${HTTP_PROXY:-${http_proxy:-}}"
+PROXY_HTTPS="${HTTPS_PROXY:-${https_proxy:-}}"
+PROXY_NO="${NO_PROXY:-${no_proxy:-}}"
+USE_PROXY=false
+if [ -n "$PROXY_HTTP" ] || [ -n "$PROXY_HTTPS" ]; then
+    USE_PROXY=true
+    echo "Detected proxy configuration (from environment or helm/common.yaml) - will configure Docker, Maven and k3d to use it."
+fi
 
 printf "\033[1mInstalling docker\n"
 printf -- "-----------------\033[0m\n"
@@ -35,12 +56,53 @@ sudo apt-get install -y docker-ce=5:27.2.1-1~ubuntu.$(lsb_release -sr)~$(lsb_rel
 printf "\033[1mSuccessfully installed %s\033[0m\n" "$(docker --version)"
 printf "\n"
 
+if [ "$USE_PROXY" = true ]; then
+    printf "\033[1mConfiguring Docker proxy (daemon + client)\n"
+    printf -- "-------------------------------------------\033[0m\n"
+
+    # Docker daemon proxy: needed so `docker pull`/`docker build` base image
+    # pulls go through the proxy.
+    sudo mkdir -p /etc/systemd/system/docker.service.d
+    {
+        echo "[Service]"
+        [ -n "$PROXY_HTTP" ] && echo "Environment=\"HTTP_PROXY=${PROXY_HTTP}\""
+        [ -n "$PROXY_HTTPS" ] && echo "Environment=\"HTTPS_PROXY=${PROXY_HTTPS}\""
+        [ -n "$PROXY_NO" ] && echo "Environment=\"NO_PROXY=${PROXY_NO}\""
+    } | sudo tee /etc/systemd/system/docker.service.d/http-proxy.conf > /dev/null
+    sudo systemctl daemon-reload
+    sudo systemctl restart docker
+
+    # Docker client proxy: needed so `docker build`/`docker run` inject
+    # HTTP_PROXY/HTTPS_PROXY/NO_PROXY into the containers themselves (e.g.
+    # for npm install/pip install/apt-get running inside RUN steps).
+    mkdir -p "$HOME/.docker"
+    python3 - "$PROXY_HTTP" "$PROXY_HTTPS" "$PROXY_NO" <<'PYEOF'
+import json, os, sys
+http_proxy, https_proxy, no_proxy = sys.argv[1], sys.argv[2], sys.argv[3]
+cfg_path = os.path.expanduser("~/.docker/config.json")
+cfg = {}
+if os.path.exists(cfg_path):
+    with open(cfg_path) as f:
+        cfg = json.load(f)
+proxies = {}
+if http_proxy:
+    proxies["httpProxy"] = http_proxy
+if https_proxy:
+    proxies["httpsProxy"] = https_proxy
+if no_proxy:
+    proxies["noProxy"] = no_proxy
+cfg.setdefault("proxies", {})["default"] = proxies
+with open(cfg_path, "w") as f:
+    json.dump(cfg, f, indent=2)
+PYEOF
+fi
+
 if [[ -z $(groups | grep docker) ]];
 then
     sudo usermod -a -G docker $USER;
     echo "$USER has been added to the docker group.";
     echo "Script is being restarted for changes to take effect.";
-    sudo -u $USER /bin/bash $SCRIPT_PATH;
+    sudo -u $USER HTTP_PROXY="$PROXY_HTTP" HTTPS_PROXY="$PROXY_HTTPS" NO_PROXY="$PROXY_NO" /bin/bash $SCRIPT_PATH;
     exit;
 fi;
 
@@ -65,10 +127,29 @@ sudo snap install yq --classic
 echo Installing K3d cluster
 echo ----------------------
 ## k3d cluster with 2 nodes
-curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v5.8.3 bash
+curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v5.9.0 bash
 k3d registry create iff.localhost -p 12345
+
+# k3d node containers run their own containerd and do NOT inherit the host's
+# proxy env vars, so image pulls (e.g. rancher/mirrored-pause) would hang/fail
+# on proxy-only networks unless we inject the proxy explicitly into the nodes.
+K3D_PROXY_ARGS=()
+if [ "$USE_PROXY" = true ]; then
+    echo "Configuring k3d node proxy"
+    echo "--------------------------"
+    K3D_NO_PROXY="${PROXY_NO:-127.0.0.1,localhost,0.0.0.0}"
+    case "$K3D_NO_PROXY" in
+        *cluster.local*) ;;
+        *) K3D_NO_PROXY="${K3D_NO_PROXY},10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local" ;;
+    esac
+    [ -n "$PROXY_HTTP" ] && K3D_PROXY_ARGS+=(-e "HTTP_PROXY=${PROXY_HTTP}@server:*;agent:*")
+    [ -n "$PROXY_HTTPS" ] && K3D_PROXY_ARGS+=(-e "HTTPS_PROXY=${PROXY_HTTPS}@server:*;agent:*")
+    K3D_PROXY_ARGS+=(-e "NO_PROXY=${K3D_NO_PROXY}@server:*;agent:*")
+fi
+
 k3d cluster create --image ${K3S_IMAGE} -a 2 --registry-use k3d-iff.localhost:12345 iff-cluster \
-  --k3s-arg "--kubelet-arg=eviction-hard=imagefs.available<2%,nodefs.available<2%,nodefs.inodesFree<2%@all"
+  --k3s-arg "--kubelet-arg=eviction-hard=imagefs.available<2%,nodefs.available<2%,nodefs.inodesFree<2%@all" \
+  "${K3D_PROXY_ARGS[@]}"
 
 if [ -z "$BUILDONLY" ];then
     echo Install Helm v3.10.3
@@ -121,6 +202,39 @@ sudo mv maven.sh /etc/profile.d/
 source /etc/profile.d/maven.sh
 mvn --version
 
+if [ "$USE_PROXY" = true ]; then
+    echo Configuring Maven proxy
+    echo -----------------------
+    # Maven does NOT read HTTP_PROXY/HTTPS_PROXY env vars, so it needs an
+    # explicit <proxies> entry in settings.xml.
+    mkdir -p "$HOME/.m2"
+    PROXY_URL="${PROXY_HTTPS:-$PROXY_HTTP}"
+    PROXY_HOST=$(echo "$PROXY_URL" | sed -E 's#^https?://##' | cut -d: -f1)
+    PROXY_PORT=$(echo "$PROXY_URL" | sed -E 's#^https?://##' | cut -d: -f2)
+    cat > "$HOME/.m2/settings.xml" <<EOF
+<settings>
+  <proxies>
+    <proxy>
+      <id>build-proxy-http</id>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>${PROXY_HOST}</host>
+      <port>${PROXY_PORT}</port>
+      <nonProxyHosts>localhost|127.0.0.1</nonProxyHosts>
+    </proxy>
+    <proxy>
+      <id>build-proxy-https</id>
+      <active>true</active>
+      <protocol>https</protocol>
+      <host>${PROXY_HOST}</host>
+      <port>${PROXY_PORT}</port>
+      <nonProxyHosts>localhost|127.0.0.1</nonProxyHosts>
+    </proxy>
+  </proxies>
+</settings>
+EOF
+fi
+
 if [ -z "$BUILDONLY" ];then
     echo Install shellcheck
     echo ------------------
@@ -170,7 +284,7 @@ if [ -z "$BUILDONLY" ];then
     echo -------------------
     sudo apt remove -y nodejs libnode-dev libnode72
     sudo apt purge -y nodejs
-    curl -sL https://deb.nodesource.com/setup_18.x -o /tmp/nodesource_setup.sh
+    curl -sL https://deb.nodesource.com/setup_22.x -o /tmp/nodesource_setup.sh
     sudo bash /tmp/nodesource_setup.sh
     sudo apt install -y nodejs
 


### PR DESCRIPTION
…host Node.js to v22