### PR TITLE
Document all three OPC UA validations, not just the instance one

### DIFF
--- a/NgsildAgent/package-lock.json
+++ b/NgsildAgent/package-lock.json
@@ -1406,9 +1406,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/semantic-model/opcua/README.md
+++ b/semantic-model/opcua/README.md
@@ -1,5 +1,13 @@
 # Tools to translate from OPC/UA Information Model to Semantic Web standards
 
+This file is the CLI reference. For step-by-step tutorials see [docs/](./docs/README.md),
+in particular the three validations:
+
+- [Validation Overview](./docs/validation-overview.md) — which of the three to run when
+- [Ontology (Graph) Validation](./docs/ontology-validation.md) — `validate.py -m ontology`
+- [Instance Validation](./docs/simple-example.md#validation-of-instances) — `validate.py` (default mode)
+- [Virtual Type (Logical) Validation](./docs/virtual-type-validation.md) — `validate.py -m vt` / `check_consistency.py`
+
 ## Setup
 
 To setup the python environment start a python3 virtual environment with `Python 3.11` and install the dependencies with:
@@ -289,4 +297,8 @@ Validate a semantic-bridge ontology against just its ValueRank consistency:
 Check a Virtual-Types ontology for logical consistency:
 
         python3 validate.py -m vt pumps.vt.owl.ttl
+
+Worked examples for all three modes, including deliberately broken nodesets and
+how to read each report, are in
+[docs/validation-overview.md](./docs/validation-overview.md).
 

--- a/semantic-model/opcua/docs/README.md
+++ b/semantic-model/opcua/docs/README.md
@@ -3,8 +3,15 @@
 1. [Overview & Setup](./overview.md)
 2. [Example & Tutorial](./simple-example.md)
 3. [Building Companion Specifications](./building-companion-specifications.md)
-3. [Mapping concept](./mapping-concept.md)
+4. [Mapping concept](./mapping-concept.md)
 5. [Tools](./tools.md)
+
+## Validation
+
+6. [Validation Overview](./validation-overview.md) — the three validations and when to use which
+7. [Ontology (Graph) Validation](./ontology-validation.md) — is the nodeset itself well formed?
+8. [Instance Validation](./simple-example.md#validation-of-instances) — does an object conform to its type?
+9. [Virtual Type (Logical) Validation](./virtual-type-validation.md) — are the type declarations satisfiable at all?
 
 
 # References
@@ -22,3 +29,5 @@
 [6] Berners-Lee, T., Hendler, J., & Lassila, O. (2001). The Semantic Web. Scientific American, 284(5), 34-43.
 
 [7] Protege, https://protege.stanford.edu/
+
+[8] Glimm, B., Horrocks, I., Motik, B., Stoilos, G., & Wang, Z. (2014). HermiT: An OWL 2 Reasoner. Journal of Automated Reasoning, 53(3), 245-269. Available at: http://www.hermit-reasoner.com/

--- a/semantic-model/opcua/docs/files/SensorArray.NodeSet2.xml
+++ b/semantic-model/opcua/docs/files/SensorArray.NodeSet2.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Tutorial nodeset for docs/ontology-validation.md.
+
+     SampleArrayType is a VariableType for a one-dimensional array of Doubles
+     (ValueRank="1", ArrayDimensions="0" meaning "one dimension, length not
+     fixed"). SensorType declares a Mandatory component "Samples" that is
+     typed by SampleArrayType and is likewise an array.
+
+     This nodeset is CONSISTENT. Its deliberately broken twin,
+     SensorArrayBroken.NodeSet2.xml, changes exactly one attribute. -->
+<UANodeSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+           LastModified="2024-07-15T00:00:00Z"
+           xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <Models>
+    <Model ModelUri="http://example.org/sensor/"
+           XmlSchemaUri="http://opcfoundation.org/UA/2008/02/Types.xsd"
+           Version="1.05.03"
+           PublicationDate="2024-07-29T00:00:00Z"
+           ModelVersion="1.5.3" />
+  </Models>
+  <NamespaceUris>
+    <Uri>http://example.org/sensor/</Uri>
+  </NamespaceUris>
+  <Aliases>
+    <Alias Alias="Double">i=11</Alias>
+    <Alias Alias="HasComponent">i=47</Alias>
+    <Alias Alias="HasSubtype">i=45</Alias>
+    <Alias Alias="HasTypeDefinition">i=40</Alias>
+    <Alias Alias="HasModellingRule">i=37</Alias>
+    <Alias Alias="BaseDataVariableType">i=63</Alias>
+    <Alias Alias="BaseObjectType">i=58</Alias>
+    <Alias Alias="Mandatory">i=78</Alias>
+  </Aliases>
+
+  <!-- A VariableType for a 1-dimensional array of Doubles. -->
+  <UAVariableType NodeId="ns=1;i=3000" BrowseName="1:SampleArrayType"
+                  DataType="Double" ValueRank="1" ArrayDimensions="0">
+    <DisplayName>SampleArrayType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">BaseDataVariableType</Reference>
+    </References>
+  </UAVariableType>
+
+  <!-- SensorType has a Mandatory component "Samples" of SampleArrayType. -->
+  <UAObjectType NodeId="ns=1;i=2000" BrowseName="1:SensorType">
+    <DisplayName>SensorType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">BaseObjectType</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2001</Reference>
+    </References>
+  </UAObjectType>
+
+  <!-- ValueRank="1" and ArrayDimensions="0" agree with SampleArrayType. -->
+  <UAVariable NodeId="ns=1;i=2001" BrowseName="1:Samples"
+              DataType="Double" ValueRank="1" ArrayDimensions="0">
+    <DisplayName>Samples</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=3000</Reference>
+      <Reference ReferenceType="HasModellingRule">Mandatory</Reference>
+    </References>
+  </UAVariable>
+</UANodeSet>

--- a/semantic-model/opcua/docs/files/SensorArrayBroken.NodeSet2.xml
+++ b/semantic-model/opcua/docs/files/SensorArrayBroken.NodeSet2.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Tutorial nodeset for docs/ontology-validation.md.
+
+     Identical to SensorArray.NodeSet2.xml except for the "Samples" Variable
+     (ns=1;i=2001), which is declared as a SCALAR (ValueRank="-1", no
+     ArrayDimensions) while its TypeDefinition SampleArrayType still declares
+     a one-dimensional array (ValueRank="1"). That contradicts OPC UA Part 3,
+     which requires an instance's ValueRank to be compatible with the
+     ValueRank of its VariableType.
+
+     Nothing in the XML schema rejects this: it is a *modelling* error, and
+     it is exactly what `validate.py -m ontology` is there to find. -->
+<UANodeSet xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+           LastModified="2024-07-15T00:00:00Z"
+           xmlns="http://opcfoundation.org/UA/2011/03/UANodeSet.xsd">
+  <Models>
+    <Model ModelUri="http://example.org/sensor/"
+           XmlSchemaUri="http://opcfoundation.org/UA/2008/02/Types.xsd"
+           Version="1.05.03"
+           PublicationDate="2024-07-29T00:00:00Z"
+           ModelVersion="1.5.3" />
+  </Models>
+  <NamespaceUris>
+    <Uri>http://example.org/sensor/</Uri>
+  </NamespaceUris>
+  <Aliases>
+    <Alias Alias="Double">i=11</Alias>
+    <Alias Alias="HasComponent">i=47</Alias>
+    <Alias Alias="HasSubtype">i=45</Alias>
+    <Alias Alias="HasTypeDefinition">i=40</Alias>
+    <Alias Alias="HasModellingRule">i=37</Alias>
+    <Alias Alias="BaseDataVariableType">i=63</Alias>
+    <Alias Alias="BaseObjectType">i=58</Alias>
+    <Alias Alias="Mandatory">i=78</Alias>
+  </Aliases>
+
+  <!-- A VariableType for a 1-dimensional array of Doubles. -->
+  <UAVariableType NodeId="ns=1;i=3000" BrowseName="1:SampleArrayType"
+                  DataType="Double" ValueRank="1" ArrayDimensions="0">
+    <DisplayName>SampleArrayType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">BaseDataVariableType</Reference>
+    </References>
+  </UAVariableType>
+
+  <UAObjectType NodeId="ns=1;i=2000" BrowseName="1:SensorType">
+    <DisplayName>SensorType</DisplayName>
+    <References>
+      <Reference ReferenceType="HasSubtype" IsForward="false">BaseObjectType</Reference>
+      <Reference ReferenceType="HasComponent">ns=1;i=2001</Reference>
+    </References>
+  </UAObjectType>
+
+  <!-- THE ERROR: scalar (ValueRank="-1") under an array VariableType. -->
+  <UAVariable NodeId="ns=1;i=2001" BrowseName="1:Samples"
+              DataType="Double" ValueRank="-1">
+    <DisplayName>Samples</DisplayName>
+    <References>
+      <Reference ReferenceType="HasTypeDefinition">ns=1;i=3000</Reference>
+      <Reference ReferenceType="HasModellingRule">Mandatory</Reference>
+    </References>
+  </UAVariable>
+</UANodeSet>

--- a/semantic-model/opcua/docs/ontology-validation.md
+++ b/semantic-model/opcua/docs/ontology-validation.md
@@ -1,0 +1,233 @@
+# Tutorial: Ontology (Graph) Validation
+
+This is validation type 1 of 3 (see [Validation Overview](./validation-overview.md)).
+It checks the **nodeset itself**, before any instance data exists: are
+`HasComponent`, `HasProperty`, `ValueRank`, `ArrayDimensions`, `Historizing` and
+`ModellingRule` used the way OPC UA Part 3 requires?
+
+None of these errors are caught by the OPC UA XML schema. `UANodeSet.xsd` is
+happy with `ValueRank="-7"`, with a `HasProperty` reference pointing at an
+`Object`, or with an `ArrayDimensions` list whose length disagrees with the
+`ValueRank`. They are *modelling* errors, and they are found by running a fixed
+set of SHACL shapes over the Semantic Bridge ontology that `nodeset2owl.py`
+produces.
+
+## Prerequisites
+
+Follow [Overview & Setup](./overview.md) first, then from
+`DigitalTwin/semantic-model/opcua`:
+
+```
+export BASE_ONTOLOGY=https://industryfusion.github.io/contexts/staging/ontology/v0.3/base.ttl
+export BASE_ONTOLOGY_NS=https://industryfusion.github.io/contexts/ontology/v0/base/
+
+make -f translate_default_nodesets.make core.owl.ttl
+```
+
+That builds `core.owl.ttl`, the OWL representation of the OPC UA core
+specification, which every other nodeset depends on. It takes a few minutes and
+needs network access. See the note on the two base-ontology values
+in the [Validation Overview](./validation-overview.md#a-note-on-the-base-ontology)
+— they are different strings and both are needed.
+
+Nothing beyond `make setup` has to be installed: this validation uses `pyshacl`,
+which is already in `requirements-dev.txt`.
+
+## The example model
+
+Two small nodesets are provided:
+
+- [`SensorArray.NodeSet2.xml`](./files/SensorArray.NodeSet2.xml) — consistent
+- [`SensorArrayBroken.NodeSet2.xml`](./files/SensorArrayBroken.NodeSet2.xml) — one deliberate error
+
+Both declare the same tiny model:
+
+```
+SensorType  --HasComponent-->  Samples  (Variable, Mandatory)
+                                  |
+                                  | HasTypeDefinition
+                                  v
+                          SampleArrayType  (VariableType, DataType=Double,
+                                            ValueRank=1, ArrayDimensions=0)
+```
+
+`SampleArrayType` is a VariableType for a **one-dimensional array** of Doubles:
+`ValueRank="1"` means "one dimension" and `ArrayDimensions="0"` means "one
+dimension whose length is not fixed". `SensorType` has a Mandatory component
+`Samples` typed by it.
+
+In the consistent nodeset, `Samples` is declared as an array too:
+
+```xml
+  <UAVariable NodeId="ns=1;i=2001" BrowseName="1:Samples"
+              DataType="Double" ValueRank="1" ArrayDimensions="0">
+```
+
+The broken one makes a single modelling change — `Samples` is declared a
+**scalar** while its TypeDefinition still says array. That takes two XML
+attributes, because `ArrayDimensions` has no meaning on a scalar and goes
+away with the rank:
+
+```xml
+  <UAVariable NodeId="ns=1;i=2001" BrowseName="1:Samples"
+              DataType="Double" ValueRank="-1">
+```
+
+## Step 1: Convert the nodeset to OWL
+
+```
+python3 nodeset2owl.py docs/files/SensorArray.NodeSet2.xml \
+    -i ${BASE_ONTOLOGY} core.owl.ttl \
+    -b ${BASE_ONTOLOGY_NS} -burl ${BASE_ONTOLOGY} \
+    -v http://example.com/v0.1/sensor/ -p sensor -o sensor.owl.ttl
+```
+
+This is the same first step as in the [Simple Example](./simple-example.md); the
+difference is what happens next. Ontology validation stops here — it needs only
+the `*.owl.ttl`, not `owl2instances.py`'s output.
+
+## Step 2: Validate
+
+```
+python3 validate.py -m ontology sensor.owl.ttl
+```
+
+```
+Using SHACL shapes from .../validation/ontology: hasComponent.shacl.ttl, hasProperty.shacl.ttl, historizing.shacl.ttl, modellingRule.shacl.ttl, rankValue.shacl.ttl
+Importing https://industryfusion.github.io/contexts/ontology/v0/base/ from url https://industryfusion.github.io/contexts/staging/ontology/v0.3/base.ttl.
+Importing http://www.w3.org/1999/02/22-rdf-syntax-ns# from url http://www.w3.org/1999/02/22-rdf-syntax-ns#.
+Importing http://www.w3.org/2000/01/rdf-schema# from url http://www.w3.org/2000/01/rdf-schema#.
+Importing https://uri.etsi.org/ngsi-ld/ from url https://industryfusion.github.io/contexts/staging/ontology/v0/ngsild.ttl.
+Importing http://opcfoundation.org/UA/ from url file:///.../core.owl.ttl
+Validation Conforms: True
+No validation errors found.
+```
+
+Note what `-m ontology` did on its own: with no `-s` given it merged **every**
+`*.shacl.ttl` file in `validation/ontology/`, and it followed the input's own
+`owl:imports` so the shapes can see `core.owl.ttl`'s class hierarchy. Unlike
+instance validation there is no single canonical shapes file to point at, only a
+small fixed set of structural rules that apply to any ontology equally.
+
+The `Importing ...` lines are network fetches. Add `-ni` (`--no-imports`) to skip
+them and validate the file entirely on its own; the ValueRank rules used in this
+tutorial still fire, because they only need the nodeset's own triples. Rules that
+walk the class hierarchy (`hasComponent.shacl.ttl`'s `rdfs:subClassOf*` checks,
+for instance) do need the imports, so `-ni` trades completeness for speed.
+
+## Step 3: Break it
+
+```
+python3 nodeset2owl.py docs/files/SensorArrayBroken.NodeSet2.xml \
+    -i ${BASE_ONTOLOGY} core.owl.ttl \
+    -b ${BASE_ONTOLOGY_NS} -burl ${BASE_ONTOLOGY} \
+    -v http://example.com/v0.1/sensor/ -p sensor -o sensorbroken.owl.ttl
+
+python3 validate.py -m ontology sensorbroken.owl.ttl
+```
+
+```
+Validation Conforms: False
+
+=== SHACL Validation Report ===
+Validation Report
+Conforms: False
+Results (1):
+
+    Constraint Violation in SPARQLConstraintComponent (http://www.w3.org/ns/shacl#SPARQLConstraintComponent):
+        Severity: http://www.w3.org/ns/shacl#Violation
+        Source Shape: https://industryfusion.github.io/contexts/ontology/v0/base/OPCUANodeShape
+        Focus Node: http://example.org/sensor/nodei2001
+        Value Node: http://example.org/sensor/nodei2001
+        Source Constraint:
+[] sh:message "The node {$this} has a valueRank {?valueRank} which does not match its type definition's valueRank {?parentValueRank}."^^xsd:string ;
+    sh:select """
+          SELECT $this ?valueRank ?parentValueRank WHERE {
+            ...
+          }
+        """^^xsd:string .
+
+        Message: The node http://example.org/sensor/nodei2001 has a valueRank -1 which does not match its type definition's valueRank 1.
+```
+
+`validate.py` also exits with status `1`, so this works in a CI pipeline.
+
+Reading the report:
+
+- **Focus Node** `http://example.org/sensor/nodei2001` is the offending node.
+  The IRI is built from the model URI plus `nodei` plus the numeric part of the
+  NodeId, so `ns=1;i=2001` in namespace `http://example.org/sensor/` becomes
+  `http://example.org/sensor/nodei2001` — that is the `Samples` Variable.
+- **Source Shape** names the shape that fired, `base:OPCUANodeShape`, which lives
+  in `validation/ontology/rankValue.shacl.ttl`.
+- **Source Constraint** is the full SPARQL query of the rule. It is verbose, but
+  it is also the precise definition of what was checked; the `Message` line at
+  the bottom is the readable summary.
+
+## Scoping the check to a single rule
+
+When a report is long, it helps to run one rule at a time. Pass a single file to
+`-s` instead of letting it default to the whole directory:
+
+```
+python3 validate.py -m ontology -ni -s validation/ontology/rankValue.shacl.ttl sensorbroken.owl.ttl
+```
+
+This is exactly what `tests/validation/test.bash` does, so that each test case
+can assert which specific rule fired.
+
+## Validating a real companion specification
+
+The same command works on any `*.owl.ttl` the build produces:
+
+```
+python3 validate.py -m ontology -ni core.owl.ttl
+```
+
+```
+Validation Conforms: True
+No validation errors found.
+```
+
+and on the companion specifications built from it:
+
+```
+make -f translate_default_nodesets.make di.owl.ttl
+python3 validate.py -m ontology -ni di.owl.ttl
+```
+
+```
+Validation Conforms: True
+No validation errors found.
+```
+
+Be patient with the large ones. The rules are SPARQL-based, so runtime grows
+quickly with the graph: `di.owl.ttl` takes about three seconds, while
+`core.owl.ttl` has hundreds of thousands of triples and takes roughly six and a
+half minutes. `-ni` avoids re-fetching the imports on every run, and scoping
+with `-s` to the single rule you care about is much faster than the merged
+default.
+
+## The rules
+
+`validation/ontology/` holds one file per topic. All of them are merged when no
+`-s` is given.
+
+| File | What it enforces |
+|------|------------------|
+| `rankValue.shacl.ttl` | `ValueRank` is an `xsd:integer` `>= -3` occurring at most once; `ArrayDimensions` is a well-formed list of non-negative integers; a Variable's `ValueRank` is compatible with its TypeDefinition's; a VariableType's `ValueRank` is compatible with its supertype's; `ArrayDimensions` agrees with the `ValueRank`, which per Part 3 means: a `ValueRank > 0` needs exactly that many entries, `-1` (Scalar) forbids them, `-3` (ScalarOrOneDimension) allows at most one, and `-2` (Any) and `0` (OneOrMoreDimensions) are left unconstrained. |
+| `hasComponent.shacl.ttl` | A Variable reached by `HasComponent` is (or inherits from) `BaseDataVariableType`; a Variable that itself has `HasComponent` children is a DataVariable (i.e. it is itself a component of something); the target of a `HasComponent` is a Variable, Object or Method; the source/target node-class pairing is legal (a Variable target needs an Object, ObjectType, DataVariable or VariableType source; an Object or Method target needs an Object or ObjectType source). |
+| `hasProperty.shacl.ttl` | `HasProperty` references a `VariableNodeClass` of `PropertyType`, by IRI; a node reached via `HasProperty` has no `HasProperty` links of its own (Properties are leaves). |
+| `modellingRule.shacl.ttl` | `HasModellingRule` occurs at most once and references one of the five real modelling rules: `Mandatory` (`i=78`), `Optional` (`i=80`), `ExposesItsArray` (`i=83`), `OptionalPlaceholder` (`i=11508`), `MandatoryPlaceholder` (`i=11510`). |
+| `historizing.shacl.ttl` | `Historizing` is an `xsd:boolean` occurring at most once, and only on Variables. |
+
+Adding a rule is a matter of dropping another `*.shacl.ttl` file into that
+directory — it is picked up automatically by the merged default. The `*.shacl.ttl`
+suffix is a naming convention, not content sniffing, so the extension matters.
+
+## What this validation cannot find
+
+Ontology validation reasons about one node and its immediate references. It
+cannot see a contradiction that only exists between a supertype's declaration and
+a subtype's override, because neither node is wrong on its own. For that, see
+[Virtual Type Validation](./virtual-type-validation.md).

--- a/semantic-model/opcua/docs/overview.md
+++ b/semantic-model/opcua/docs/overview.md
@@ -7,6 +7,12 @@ This document describes how to map OPCUA data into Semantic Web [6] data, more s
 
 The files are all represented in Resource Description Format[6] serialized in the Turtle[5] or JSON-LD.
 
+Each of these artefacts can be wrong in a different way, so there are three
+separate validations: **ontology** (is the nodeset itself well formed?),
+**instance** (does an object conform to its type?) and **Virtual Type** (are the
+type declarations logically satisfiable at all?). See the
+[Validation Overview](./validation-overview.md).
+
 
 # Setup for Linux
 

--- a/semantic-model/opcua/docs/simple-example.md
+++ b/semantic-model/opcua/docs/simple-example.md
@@ -1,5 +1,10 @@
 # Simple Example
 
+This tutorial ends in **instance validation**, which is validation type 2 of 3.
+See the [Validation Overview](./validation-overview.md) for how it relates to
+[ontology validation](./ontology-validation.md) and
+[Virtual Type validation](./virtual-type-validation.md).
+
 An example nodeset can be found [here](./files/Example.NodeSet2.xml). It describes the following OPCUA Model:
 ![Image](./images/opcua-simple-model.PNG)
 
@@ -18,38 +23,47 @@ To transform the data, first the relevant OPCUA companion specifications must be
 
 ```
 export NODESET_VERSION=UA-1.05.03-2023-12-15
-export BASE_ONTOLOGY=https://industryfusion.github.io/contexts/staging/ontology/v0.1/base.ttl
+export BASE_ONTOLOGY=https://industryfusion.github.io/contexts/staging/ontology/v0.3/base.ttl
+export BASE_ONTOLOGY_NS=https://industryfusion.github.io/contexts/ontology/v0/base/
 export CORE_NODESET=https://raw.githubusercontent.com/OPCFoundation/UA-Nodeset/${NODESET_VERSION}/Schema/Opc.Ua.NodeSet2.xml
 
-python3 nodeset2owl.py ${CORE_NODESET} -i ${BASE_ONTOLOGY} -v http://example.com/v0.1/UA/ -p opcua -o core.owl.ttl
+python3 nodeset2owl.py ${CORE_NODESET} -i ${BASE_ONTOLOGY} -b ${BASE_ONTOLOGY_NS} -burl ${BASE_ONTOLOGY} -v http://example.com/v0.1/UA/ -p opcua -o core.owl.ttl
 
 ```
 The result of this step is the file `core.owl.ttl` which contains all the base 
 definitions of OPCUA translated to OWL. 
+
+`BASE_ONTOLOGY` and `BASE_ONTOLOGY_NS` are two different strings and both are
+needed: the first is the fetchable base ontology *document*, the second is the
+*term namespace* the `base:` IRIs inside it are minted under. These are the same
+values `translate_default_nodesets.make` uses, so
+`make -f translate_default_nodesets.make core.owl.ttl` is an equivalent
+shortcut for this step.
 
 ## Convert the Target Nodeset to OWL
 
 This file can now be used to transform the example nodeset into a semantic representation:
 
 ```
-export NODESET_VERSION=UA-1.05.03-2023-12-15
-export BASE_ONTOLOGY=https://industryfusion.github.io/contexts/staging/ontology/v0.1/base.ttl
-export CORE_NODESET=https://raw.githubusercontent.com/OPCFoundation/UA-Nodeset/${NODESET_VERSION}/Schema/Opc.Ua.NodeSet2.xml
-python3 ./nodeset2owl.py docs/files/Example.NodeSet2.xml -i ${BASE_ONTOLOGY} core.owl.ttl -v http://example.com/v0.1/UA/ -p example -o example.owl.ttl
+python3 ./nodeset2owl.py docs/files/Example.NodeSet2.xml -i ${BASE_ONTOLOGY} core.owl.ttl -b ${BASE_ONTOLOGY_NS} -burl ${BASE_ONTOLOGY} -v http://example.com/v0.1/example/ -p example -o example.owl.ttl
 
 ```
 The result of this step is the file `example.owl.ttl` which contains the OWL representation of the [Example.Nodeset2.xml](./files/Example.NodeSet2.xml) file.
+
+A nodeset and every nodeset it depends on must be built against the *same* base
+ontology, so keep using the `BASE_ONTOLOGY`/`BASE_ONTOLOGY_NS` exported above
+for the rest of this tutorial.
 
 ## Extract SHACL and NGSI-LD files from OWL
 
 Now, having `core.owl.ttl` and `example.owl.ttl` finally the instance description in `NGSI-LD` and the `SHACL` constraints can be extracted. The following parameters have to be added:
 
-`-t` The type of the root Object which should be extracted (in this case `http://my.test/AlphaType`)
+`-t` The type of the root Object which should be extracted (in this case `http://example.org/AlphaType`)
 `-n` The namespace of the NGSI-LD objects (use `http://demo.machine/` if the default @context is used)
-`-i` the prefix for the object URNs (must start with urn, e.g. `urn:test)
+`-i` the prefix for the object URNs (must start with urn, e.g. `urn:test`)
 
 ```
-python3 ./owl2instances.py -t http://example.org/AlphaType -n http://demo.machine/  example.owl.ttl
+python3 ./owl2instances.py -t http://example.org/AlphaType -n http://demo.machine/ example.owl.ttl -i urn:test
 ```
 
 As a result, the following files are created:
@@ -82,8 +96,8 @@ Results (1):
 Constraint Violation in ClassConstraintComponent (http://www.w3.org/ns/shacl#ClassConstraintComponent):
         Severity: sh:Violation
         Source Shape: [ sh:class example:BType ; sh:maxCount Literal("1", datatype=xsd:integer) ; sh:minCount Literal("1", datatype=xsd:integer) ; sh:nodeKind sh:IRI ; sh:path ngsi-ld:hasObject ]
-        Focus Node: [ <https://uri.etsi.org/ngsi-ld/hasObject> <urn:test:AlphaInstance:sub:i2012> ; rdf:type <https://uri.etsi.org/ngsi-ld/Relationship> ]
-        Value Node: <urn:test:AlphaInstance:sub:i2012>
+        Focus Node: [ <https://uri.etsi.org/ngsi-ld/hasObject> <urn:testnodei2012> ; rdf:type <https://uri.etsi.org/ngsi-ld/Relationship> ]
+        Value Node: <urn:testnodei2012>
         Result Path: ngsi-ld:hasObject
         Message: Value does not have class example:BType
 ```
@@ -106,6 +120,48 @@ Conforms: True
 This is explained in the picture below.
 ![Image](./images/validation-success.PNG)
 
+### Using validate.py instead
+
+`pyshacl` is invoked directly above so that it is clear what is actually being
+checked against what. This repository also ships `validate.py`, which wraps the
+same evaluation and defaults `-s` to `shacl.ttl` and `-e` to `entities.ttl`, so
+the successful run above is simply:
+
+```
+python3 validate.py instances.jsonld
+```
+
+```
+Validation Conforms: True
+No validation errors found.
+```
+
+`-m instance` is the default mode, so it does not have to be given. Adding `-x`
+prints an extended report: for every violation it also resolves the failing
+shape back to its name and path, and dumps the offending entity as nested JSON.
+On a large model that context is usually what makes a report actionable:
+
+```
+python3 validate.py -x instances.jsonld
+```
+
+`validate.py` exits with status `1` when validation fails, which makes it usable
+in a CI pipeline.
+
+## The other two validations
+
+Instance validation answers "does *this object* conform to the type it claims to
+be?". It does not tell you whether the nodeset that produced the shapes is itself
+well formed, nor whether the type hierarchy is logically satisfiable at all.
+Those are separate checks:
+
+- [Ontology Validation](./ontology-validation.md) checks the nodeset itself —
+  `HasComponent`, `HasProperty`, `ValueRank`, `ModellingRule` usage.
+- [Virtual Type Validation](./virtual-type-validation.md) uses a DL reasoner to
+  find type declarations that no instance could ever satisfy.
+
+See the [Validation Overview](./validation-overview.md) for how the three relate.
+
 
 # Advanced Example: Build the Pump Example
 
@@ -125,21 +181,30 @@ Looking at the raw file, it can be determined that there is no `<Models>` descri
         <Uri>http://opcfoundation.org/UA/DI/</Uri>
     </NamespaceUris>
 
-This list suggests that the dependencies are `core.owl.ttl`, `devices.owl.ttl`, `machinery.owl.ttl` and `pump.owl.ttl`.
+This list suggests that the dependencies are `core.owl.ttl`, `di.owl.ttl`, `machinery.owl.ttl` and `pumps.owl.ttl`.
 
     NODESET_VERSION=UA-1.05.03-2023-12-15
     CORE_NODESET=https://raw.githubusercontent.com/OPCFoundation/UA-Nodeset/${NODESET_VERSION}/Schema/Opc.Ua.NodeSet2.xml
     DI_NODESET=https://raw.githubusercontent.com/OPCFoundation/UA-Nodeset/${NODESET_VERSION}/DI/Opc.Ua.Di.NodeSet2.xml
     MACHINERY_NODESET=https://raw.githubusercontent.com/OPCFoundation/UA-Nodeset/${NODESET_VERSION}/Machinery/Opc.Ua.Machinery.NodeSet2.xml
     PUMPS_NODESET=https://raw.githubusercontent.com/OPCFoundation/UA-Nodeset/${NODESET_VERSION}/Pumps/Opc.Ua.Pumps.NodeSet2.xml
-    BASE_ONTOLOGY=https://industryfusion.github.io/contexts/staging/ontology/v0.1/base.ttl
+    BASE_ONTOLOGY=https://industryfusion.github.io/contexts/staging/ontology/v0.3/base.ttl
+    BASE_ONTOLOGY_NS=https://industryfusion.github.io/contexts/ontology/v0/base/
     PUMP_EXAMPLE_NODESET=https://raw.githubusercontent.com/OPCFoundation/UA-Nodeset/${NODESET_VERSION}/Pumps/instanceexample.xml
 
-    python3 nodeset2owl.py ${CORE_NODESET} -i ${BASE_ONTOLOGY} -p opcua -o core.owl.ttl
-    python3 nodeset2owl.py  ${DI_NODESET} -i ${BASE_ONTOLOGY} core.owl.ttl  -p devices -o devices.owl.ttl
-    python3 nodeset2owl.py ${MACHINERY_NODESET} -i ${BASE_ONTOLOGY} core.owl.ttl devices.owl.ttl -p machinery -o machinery.owl.ttl
-    python3 nodeset2owl.py  ${PUMPS_NODESET} -i ${BASE_ONTOLOGY} core.owl.ttl devices.owl.ttl machinery.owl.ttl -p pumps -o pumps.owl.ttl
-    python3 nodeset2owl.py  ${PUMP_EXAMPLE_NODESET} -i ${BASE_ONTOLOGY} core.owl.ttl devices.owl.ttl machinery.owl.ttl pumps.owl.ttl -n http://yourorganisation.org/InstanceExample/  -p pumpexample -o pumpexample.owl.ttl
+    python3 nodeset2owl.py ${CORE_NODESET} -i ${BASE_ONTOLOGY} -b ${BASE_ONTOLOGY_NS} -burl ${BASE_ONTOLOGY} -v http://example.com/v0.1/UA/ -p opcua -o core.owl.ttl
+    python3 nodeset2owl.py ${DI_NODESET} -i ${BASE_ONTOLOGY} core.owl.ttl -b ${BASE_ONTOLOGY_NS} -burl ${BASE_ONTOLOGY} -v http://example.com/v0.1/DI/ -p di -o di.owl.ttl
+    python3 nodeset2owl.py ${MACHINERY_NODESET} -i ${BASE_ONTOLOGY} core.owl.ttl di.owl.ttl -b ${BASE_ONTOLOGY_NS} -burl ${BASE_ONTOLOGY} -v http://example.com/v0.1/Machinery/ -p machinery -o machinery.owl.ttl
+    python3 nodeset2owl.py ${PUMPS_NODESET} -i ${BASE_ONTOLOGY} core.owl.ttl di.owl.ttl machinery.owl.ttl -b ${BASE_ONTOLOGY_NS} -burl ${BASE_ONTOLOGY} -v http://example.com/v0.1/Pumps/ -p pumps -o pumps.owl.ttl
+    python3 nodeset2owl.py ${PUMP_EXAMPLE_NODESET} -i ${BASE_ONTOLOGY} core.owl.ttl di.owl.ttl machinery.owl.ttl pumps.owl.ttl -b ${BASE_ONTOLOGY_NS} -burl ${BASE_ONTOLOGY} -n http://yourorganisation.org/InstanceExample/ -v http://example.com/v0.1/pumpexample/ -p pumpexample -o pumpexample.owl.ttl
+
+The whole chain, including the dependency order, is also encoded in
+`translate_default_nodesets.make`, so
+
+    make -f translate_default_nodesets.make pumpexample.owl.ttl
+
+builds exactly the same five files. Expect a few minutes: `pumps.owl.ttl` alone
+is several megabytes of Turtle.
 
 
 
@@ -157,5 +222,24 @@ which will be successful:
     Validation Report
     Conforms: True
 
+The intermediate files this chain produced are also good inputs for the other
+two validations, now on a real companion specification rather than a toy one:
+
+    python3 validate.py -m ontology -ni di.owl.ttl
+
+    make -f translate_default_nodesets.make core.vt.owl.ttl di.vt.owl.ttl machinery.vt.owl.ttl pumps.vt.owl.ttl
+    python3 validate.py -m vt pumps.vt.owl.ttl
+
+The ontology check is shown on `di.owl.ttl` because it is small enough to finish
+in seconds; the same command works on `machinery.owl.ttl` or `pumps.owl.ttl`,
+just far more slowly.
+
+Note that the Virtual-Types targets have to be listed in dependency order:
+`pumps.vt.owl.ttl` `owl:imports` `machinery.vt.owl.ttl`, which imports
+`di.vt.owl.ttl` and `core.vt.owl.ttl`, and the Makefile does not chain the
+`*.vt.owl.ttl` targets for you.
+
+See [Ontology Validation](./ontology-validation.md) and
+[Virtual Type Validation](./virtual-type-validation.md).
 
 

--- a/semantic-model/opcua/docs/validation-overview.md
+++ b/semantic-model/opcua/docs/validation-overview.md
@@ -1,0 +1,97 @@
+# Validation Overview
+
+Translating an OPC UA nodeset into Semantic Web data produces three different
+artefacts (see [Overview](./overview.md)), and each of them can be *wrong* in a
+different way. Accordingly there are three separate validations in this
+repository, answering three different questions:
+
+| # | Validation | Question it answers | Input it consumes | Engine | Tutorial |
+|---|------------|---------------------|-------------------|--------|----------|
+| 1 | **Ontology** (graph) | Is the *nodeset itself* well formed? For example, are `HasComponent`, `HasProperty`, `ValueRank`, `Historizing` and `ModellingRule` used the way OPC UA Part 3 says they must be? Are there additional rules and complaints applied to the Nodesets coming from companions specifications?| the Semantic Bridge ontology `*.owl.ttl` (`nodeset2owl.py` output) | SHACL (`pyshacl`) | [Ontology Validation](./ontology-validation.md) |
+| 2 | **Instance** | Does a *concrete object* conform to the type it claims to be? For example, are all Mandatory components present, of the right type and cardinality? Are there additional constraints coming from specific companion specifications fulfilled? | `instances.jsonld` + `shacl.ttl` + `entities.ttl` (`owl2instances.py` output) | SHACL (`pyshacl`) | [Simple Example](./simple-example.md#validation-of-instances) |
+| 3 | **Virtual Types** (logical) | Are the *type declarations themselves* jointly satisfiable? Is there any logical contradiction? Does some subtype override an inherited declaration in a way that no instance could ever satisfy? | the Virtual Types ontology `*.vt.owl.ttl` (`owl2vt.py` output) | HermiT DL reasoner | [Virtual Type Validation](./virtual-type-validation.md) |
+
+All three are reachable through the same CLI, `validate.py`, selected with `-m`:
+
+```
+python3 validate.py -m ontology core.owl.ttl        # 1
+python3 validate.py instances.jsonld                # 2  (-m instance is the default)
+python3 validate.py -m vt core.vt.owl.ttl           # 3
+```
+
+## Why three and not one
+
+The three validations are not three flavours of the same check; they operate on
+different graphs and, in the case of the third, with a fundamentally different
+engine.
+
+**Ontology validation** looks at one node at a time (plus the nodes it directly
+references) and asks whether the *modelling* is legal. A `HasProperty` reference
+pointing at an `Object` instead of a `Variable`, a `ValueRank` of `-7`, an
+`ArrayDimensions` list whose length disagrees with the `ValueRank`: these are
+errors in the nodeset that no XML schema catches, because the OPC UA
+`UANodeSet.xsd` is happy with any well-formed integer. It runs *before* you have
+any instance data at all, and it is the right check to run on a companion
+specification you have just written or just downloaded.
+
+**Instance validation** takes the SHACL shapes that `owl2instances.py` derived
+from the type definitions and applies them to concrete NGSI-LD entities. This is
+the check that runs in the live platform, on the data that actually flows in from
+an OPC UA server. It answers "is *this* pump a valid `PumpType`?", not "is
+`PumpType` a sensible type?".
+
+**Virtual Type validation** is the odd one out. SHACL is a *constraint* language:
+it evaluates a shape against a graph and reports the nodes that fail. It has no
+notion of "these two declarations, taken together, describe something that cannot
+exist". But that is precisely the interesting failure mode of an OPC UA type
+hierarchy: a subtype is only allowed to *narrow* what it inherits, and an
+override that narrows to something incompatible produces a type that no server
+can ever instantiate. Nothing is malformed; every node passes ontology
+validation; every instance would pass instance validation, because no instance
+can exist. Finding this requires a Description-Logic reasoner, which is why
+`owl2vt.py` first compiles the type hierarchy into an OWL ontology of *Virtual
+Types* and `check_consistency.py` then runs HermiT over it.
+
+## Which one should I run?
+
+- Wrote or imported a **companion specification**? Run **ontology validation**.
+- Have an **instance nodeset**, or live data from a server? Run **instance
+  validation**.
+- Designed a **type hierarchy with subtypes that override inherited components**?
+  Run **Virtual Type validation**. This is the only one of the three that can
+  find contradictions spanning a supertype and its subtype.
+
+Running all three is cheap and they are independent; `make test` in this
+directory exercises all of them.
+
+## A note on the base ontology
+
+The three validation tutorials linked above build their nodesets against the
+same two values, which are the ones `translate_default_nodesets.make` uses
+(`building-companion-specifications.md` predates this and still shows the v0.1
+document without `BASE_ONTOLOGY_NS`):
+
+```
+export BASE_ONTOLOGY=https://industryfusion.github.io/contexts/staging/ontology/v0.3/base.ttl
+export BASE_ONTOLOGY_NS=https://industryfusion.github.io/contexts/ontology/v0/base/
+```
+
+They are **not** the same string and must not be conflated. `BASE_ONTOLOGY`
+(passed as `-i` and `-burl`) is the fetchable *document*; `BASE_ONTOLOGY_NS`
+(passed as `-b`) is the *term namespace* the `base:` IRIs inside it are minted
+under. The v0.3 document is a patched version of the base ontology that still
+declares its terms under the original, unchanged v0 namespace.
+
+A nodeset and every nodeset it depends on must be built against the *same* base
+ontology. Mixing a `core.owl.ttl` built with one version into a build that uses
+another produces IRIs that silently fail to join up.
+
+The URLs can be sourced straight from the Makefile so they cannot drift:
+
+```
+source <(make -f translate_default_nodesets.make -s print-nodesets)
+```
+
+That exports `BASE_ONTOLOGY` and one `<NAME>_NODESET_URL` per companion
+specification. It does **not** export `BASE_ONTOLOGY_NS`, so set that one
+yourself as shown above.

--- a/semantic-model/opcua/docs/virtual-type-validation.md
+++ b/semantic-model/opcua/docs/virtual-type-validation.md
@@ -1,0 +1,439 @@
+# Tutorial: Virtual Type (Logical) Validation
+
+This is validation type 3 of 3 (see [Validation Overview](./validation-overview.md)).
+It is the only one that does not use SHACL.
+
+The question it answers is: **are the type declarations jointly satisfiable?**
+An OPC UA subtype may only *narrow* what it inherits. Narrowing is allowed
+independently in the ObjectType hierarchy and in the VariableType hierarchy —
+and two narrowings that are each perfectly legal can combine into a type that
+no server could ever instantiate.
+
+## The contradiction, in OPC UA terms
+
+Before any of the tooling, here is the problem it exists to find. Two
+declarations, each well formed on its own.
+
+**Start.** `BaseType` is an ObjectType that declares a Mandatory Property
+`Signal`, of `PropertyType` and DataType `Double`, with `ValueRank = 1`
+(OneDimension) and `ArrayDimensions = "0"`. From this point on, every instance
+of `BaseType` — and of every subtype of `BaseType` — has a one-dimensional
+`Signal`.
+
+**The override.** `SubType` derives from `BaseType` and re-declares `Signal`,
+this time with `ValueRank = 2` (a two-dimensional array) and
+`ArrayDimensions = "0,0"`. Re-declaring an inherited component is ordinary OPC
+UA — it is how a subtype narrows what it inherits — and the re-declaration is
+locally consistent to boot: `ValueRank = 2` and a two-entry `ArrayDimensions`
+agree with each other exactly.
+
+```
+   ObjectType hierarchy
+
+   BaseType
+     |  Signal : PropertyType/Double, ValueRank 1   (OneDimension)
+     |
+     v  HasSubtype
+   SubType
+        Signal : PropertyType/Double, ValueRank 2   (MoreDimensions)
+```
+
+**The result cannot exist.** `Signal` in `SubType` is bound by two decisions at
+once:
+
+- From its **own** declaration: `ValueRank = 2`, which the Semantic Bridge
+  collapses into the symbolic class `ValueRank_MoreDimensions`.
+- From the **inherited** declaration: `BaseType` already fixed `Signal` to
+  `ValueRank = 1`, i.e. `ValueRank_OneDimension`. A subtype may restrict an
+  inherited declaration, but it cannot swap it for an incompatible one.
+
+`ValueRank_OneDimension` and `ValueRank_MoreDimensions` are declared pairwise
+disjoint, and `sb:hasValueRank` is Functional — a node has at most one rank. So
+`SubType` is a type no server can instantiate, even though neither declaration
+is malformed on its own.
+
+That last sentence is what makes this hard to catch. Run
+[ontology validation](./ontology-validation.md) over the very same nodeset and
+it passes, because every node is individually correct:
+
+```
+python3 validate.py -m ontology -ni signal.owl.ttl
+```
+
+```
+Validation Conforms: True
+No validation errors found.
+```
+
+## How virtual typing finds it
+
+The reason no per-node check can see this is that **`Signal` is not one
+thing**. `BaseType` has a `Signal` and `SubType` has a `Signal`; they are
+different nodes that happen to share a BrowsePath, and the fact that the second
+one *inherits the first one's restrictions* is a rule the reader is expected to
+apply mentally. OPC UA has no name for "the `Signal` of `SubType`" as an entity
+distinct from "the `Signal` of `BaseType`".
+
+`owl2vt.py` gives that concept a name. Walking each type's *Effective
+Declaration Tree* — its own declared children plus everything inherited from
+its supertype, with local overrides taking precedence — it mints one **Virtual
+Type** class per (owning type, BrowsePath) pair, and writes the inheritance out
+as `rdfs:subClassOf` edges:
+
+```
+VT(BaseType, "Signal")  ⊑ PropertyType
+                        ⊑ ValueRank_OneDimension     (the base declaration)
+
+VT(SubType, "Signal")   ⊑ PropertyType
+                        ⊑ ValueRank_MoreDimensions   (the override)
+                        ⊑ VT(BaseType, "Signal")      ← the inheritance
+```
+
+That last edge is the whole trick. It turns "a subtype inherits the base type's
+restrictions", which a human applies by reading, into a subclass edge a
+reasoner applies mechanically. Once both parents sit on one named class, the
+conflict stops being an argument about specification prose and becomes a plain
+subsumption question:
+
+`VT(SubType,"Signal")` is below both `ValueRank_MoreDimensions` and — through
+the inherited Virtual Type — `ValueRank_OneDimension`. Those two classes are
+declared disjoint, and `sb:hasValueRank` is a Functional property, so the class
+has no possible members. And because `SubType` requires at least one `Signal`
+of that class (`owl:minQualifiedCardinality 1`), `SubType` is empty too.
+
+The reasoner reports both, which is exactly the chain above read back out.
+
+The full transformation is described in
+[`owl_to_virtualtypes.md`](../owl_to_virtualtypes.md); the size of the
+resulting ontologies is analysed in
+[`virtual_type_explosion.md`](../virtual_type_explosion.md).
+
+## The pipeline
+
+Virtual Type validation has one more step than the other two validations:
+
+```
+NodeSet2.xml --[nodeset2owl.py]--> *.owl.ttl --[owl2vt.py]--> *.vt.owl.ttl --[HermiT]--> verdict
+                                (Semantic Bridge)          (Virtual Types)
+```
+
+## Prerequisites
+
+Beyond [Overview & Setup](./overview.md), this validation needs two things the
+others do not:
+
+```
+pip install owlready2==0.51
+```
+
+and a **`java` runtime on `PATH`**.
+
+`owlready2` is deliberately *not* in `requirements.txt` or
+`requirements-dev.txt`, and `make setup` will not install it. It is
+LGPL-3.0-or-later, and it bundles the HermiT.jar reasoner (also LGPL-3.0),
+which is incompatible with this repository's default Apache-2.0 dependency set.
+So it has to be an explicit, separate opt-in. It is used only to *locate* the
+bundled HermiT.jar; the reasoning itself runs as a plain `java` subprocess.
+
+Check both:
+
+```
+python3 -c "import owlready2; print(owlready2.VERSION)"
+java -version
+```
+
+Then build the core ontologies:
+
+```
+export BASE_ONTOLOGY=https://industryfusion.github.io/contexts/staging/ontology/v0.3/base.ttl
+export BASE_ONTOLOGY_NS=https://industryfusion.github.io/contexts/ontology/v0/base/
+
+make -f translate_default_nodesets.make core.owl.ttl core.vt.owl.ttl
+```
+
+Both files are needed: `core.owl.ttl` is what your own nodeset is built
+against, and `core.vt.owl.ttl` is what your generated Virtual-Types file will
+`owl:imports`. Without the latter the reasoner cannot resolve the OPC UA base
+types and the check is meaningless.
+
+## The example nodeset
+
+[`tests/owl2vt/test_vt_contradiction.NodeSet2.xml`](../tests/owl2vt/test_vt_contradiction.NodeSet2.xml)
+declares exactly the two declarations above, and nothing else.
+
+It is deliberately the same fixture the end-to-end suite uses:
+`tests/owl2vt/test.bash` runs it and asserts that a contradiction is found, and
+`tests/validation/test.bash` runs `validate.py -m vt` over its expected
+Virtual-Types output. Every command and every line of output quoted below is
+therefore covered by CI, and cannot drift away from the tutorial unnoticed.
+
+## Step 1: Convert the nodeset to OWL
+
+```
+python3 nodeset2owl.py tests/owl2vt/test_vt_contradiction.NodeSet2.xml \
+    -i ${BASE_ONTOLOGY} core.owl.ttl \
+    -b ${BASE_ONTOLOGY_NS} -burl ${BASE_ONTOLOGY} \
+    -v http://example.com/v0.1/signal/ -p signal -o signal.owl.ttl
+```
+
+## Step 2: Derive the Virtual Types
+
+```
+python3 owl2vt.py signal.owl.ttl -o signal.vt.owl.ttl
+```
+
+```
+Parsing signal.owl.ttl ...
+Resolving imports: ['https://industryfusion.github.io/contexts/staging/ontology/v0.3/base.ttl', 'file:///.../core.owl.ttl']
+...
+No --roots given: generating Virtual Types for all 2 ObjectType/VariableType classes this file itself declares (not its imports). This can take a while on the full core.owl.ttl (~600 types); pass --roots to scope a faster first look.
+Building Virtual Types and restrictions ...
+  [1/2] (5.1s elapsed) http://my.test/BaseType
+  [2/2] (5.1s elapsed) http://my.test/SubType
+Writing 239 triples to signal.vt.owl.ttl (5.1s elapsed) ...
+Done in 5.1s.
+```
+
+`owl2vt.py` only derives Virtual Types for the types the input file *itself*
+declares — two here. The hundreds of types in `core.owl.ttl` are not
+re-derived; the output `owl:imports` `core.vt.owl.ttl` instead. On a large
+companion specification, use `--roots` to scope the run to a few named types
+for a faster first look.
+
+## Step 3: Run the reasoner
+
+```
+python3 validate.py -m vt signal.vt.owl.ttl
+```
+
+```
+Validation Conforms: False
+
+=== HermiT DL Consistency Report ===
+2 unsatisfiable class(es) in signal.vt.owl.ttl:
+  http://my.test/SubType
+  http://my.test/VT_785e8afd2dbfb8041e9beca4
+```
+
+`validate.py` exits with status `1`, so this works in CI.
+
+The `http://my.test/` namespace is the one the fixture's own `<Models>` entry
+declares; it has nothing to do with the `-v` value passed in step 1, which only
+names the ontology being written.
+
+An **unsatisfiable class** is one the reasoner has proven equivalent to
+`owl:Nothing`: it can have no members, ever. `SubType` is unsatisfiable — that
+ObjectType cannot be instantiated by any server — and the Virtual Type
+alongside it says *which member* made it so.
+
+## Step 4: Read the report
+
+`VT_785e8afd2dbfb8041e9beca4` is a generated Virtual Type. The name is a
+sha256 digest of `"<owning type IRI>|<BrowsePath>"`, truncated to 24 hex
+characters, so it is stable and reproducible: the same model always yields the
+same name. Two ways to find out what it stands for.
+
+**Look it up in the generated file.** Every Virtual Type carries the BrowsePath
+it was minted for:
+
+```
+grep -A 16 "VT_785e8afd2dbfb8041e9beca4> a owl:Class" signal.vt.owl.ttl
+```
+
+```turtle
+<http://my.test/VT_785e8afd2dbfb8041e9beca4> a owl:Class ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:onProperty sb:hasValueRank ;
+            owl:someValuesFrom opcua:ValueRank_MoreDimensions ],
+        ...
+        [ a owl:Restriction ;
+            owl:allValuesFrom opcua:ValueRank_MoreDimensions ;
+            owl:onProperty sb:hasValueRank ],
+        <http://my.test/VT_0d94b86d0fb80fa6be1b3122>,
+        opcua:PropertyType ;
+    sb:originalBrowsePath "http://my.test/Signal" .
+```
+
+**Or recompute the digest** for a (type, BrowsePath) pair you suspect:
+
+```
+python3 -c "import hashlib; print(hashlib.sha256('http://my.test/SubType|http://my.test/Signal'.encode()).hexdigest()[:24])"
+```
+
+```
+785e8afd2dbfb8041e9beca4
+```
+
+So the flagged class is *`SubType`'s `Signal`*, it is below
+`ValueRank_MoreDimensions`, and it is below `VT_0d94b86d0fb80fa6be1b3122` —
+which the same lookup identifies as *`BaseType`'s `Signal`*:
+
+```turtle
+<http://my.test/VT_0d94b86d0fb80fa6be1b3122> a owl:Class ;
+    rdfs:subClassOf [ a owl:Restriction ;
+            owl:allValuesFrom opcua:ValueRank_OneDimension ;
+            owl:onProperty sb:hasValueRank ],
+        ...
+        [ a owl:Restriction ;
+            owl:onProperty sb:hasValueRank ;
+            owl:someValuesFrom opcua:ValueRank_OneDimension ],
+        opcua:PropertyType ;
+    sb:originalBrowsePath "http://my.test/Signal" .
+```
+
+`ValueRank_OneDimension` on one side, `ValueRank_MoreDimensions` on the other,
+and `sb:hasValueRank` is Functional — one value cannot be both. That is the
+contradiction from the first section, restated in the form the reasoner
+actually consumed.
+
+The rule of thumb when reading these reports: **the Virtual Types tell you
+*where*, the real types tell you *what*.** Take the `sb:originalBrowsePath` of
+each flagged `VT_...` class to locate the offending BrowseName, then look at
+which real types it ended up beneath.
+
+## Step 5: Fix it
+
+The report named `SubType`'s `Signal`, and the two Virtual Types disagreed on
+exactly one property: `sb:hasValueRank`. So the repair is a single declaration
+— give the override the rank it inherits instead of an incompatible one:
+
+```xml
+<!-- was: ValueRank="2" ArrayDimensions="0,0" -->
+<UAVariable NodeId="ns=1;i=2101" BrowseName="1:Signal"
+            DataType="Double" ValueRank="1" ArrayDimensions="0">
+```
+
+Re-run the same three steps on the corrected nodeset and the reasoner is
+satisfied:
+
+```
+python3 validate.py -m vt signalfixed.vt.owl.ttl
+```
+
+```
+Validation Conforms: True
+No validation errors found.
+```
+
+Dropping the re-declaration from `SubType` altogether works just as well —
+`SubType` then simply inherits `BaseType`'s `Signal` unchanged. What is *not* a
+fix is relaxing `BaseType` to `ValueRank = -2` (Any) so that both ranks become
+legal narrowings: that removes the contradiction by giving up the guarantee
+that made the base type worth declaring.
+
+## Other kinds of contradiction
+
+The same mechanism catches conflicts along every axis an OPC UA declaration
+has. Each has its own end-to-end fixture under `tests/owl2vt/`, alongside the
+one this tutorial walked through, and each is worth reading as a further worked
+example:
+
+| Axis | Fixture |
+|------|---------|
+| an instance declaration's `ValueRank` against its ancestor declaration (this tutorial) | `test_vt_contradiction.NodeSet2.xml` |
+| a VariableType's *own* `ValueRank` against an instance declaration that overrides it | `test_vt_type_valuerank_contradiction.NodeSet2.xml` |
+| the Variable's `DataType` | `test_vt_datatype_contradiction.NodeSet2.xml` |
+| the Variable's own VariableType, overridden to a disjoint sibling | `test_vt_variabletype_contradiction.NodeSet2.xml` |
+| a component Object's ObjectType | `test_vt_objecttype_contradiction.NodeSet2.xml` |
+
+Each has a sibling fixture asserting that a *legal* narrowing along the same
+axis is **not** flagged (`test_vt_datatype_subtype_override`,
+`test_vt_objecttype_optional_no_contradiction`,
+`test_vt_modellingrule_narrowing`, ...). The negative cases matter just as
+much: a reasoner that flags correct models is worse than no reasoner at all.
+
+## Checking many files at once
+
+`validate.py -m vt` is a single-file wrapper that puts this check behind the
+same CLI as the other two modes. The underlying tool, `check_consistency.py`,
+does more.
+
+Check several files, each on its own:
+
+```
+python3 check_consistency.py core.vt.owl.ttl signal.vt.owl.ttl
+```
+
+```
+core.vt.owl.ttl                OK  consistent  (33340 triples, 2.9s)
+signal.vt.owl.ttl              FAIL  2 unsatisfiable class(es)  (33554 triples, 2.1s)
+    http://my.test/SubType
+    http://my.test/VT_785e8afd2dbfb8041e9beca4
+
+1/2 ontologies consistent.
+Ontologies with issues: signal.vt.owl.ttl
+```
+
+With **no** file arguments it sweeps every `*.vt.owl.ttl` that
+`translate_default_nodesets.make` knows how to build and that exists on disk.
+This is the final step of `make test`.
+
+Other options:
+
+- `-c` / `--combine` merges *all* given files, plus everything they
+  transitively import, into one ontology and reasons over the union. Two
+  specifications that do not import each other are otherwise never loaded into
+  the same reasoning pass, so an interaction between them would never surface
+  from checking either one individually:
+
+  ```
+  python3 check_consistency.py -c tmc.vt.owl.ttl pumps.vt.owl.ttl
+  ```
+
+- `-o report.csv` also writes the results as CSV.
+- `--expect-contradiction` / `--expect-none` turn the run into an assertion:
+  the command exits non-zero when the verdict is not the expected one. This is
+  what `tests/owl2vt/test.bash` checks each scenario with.
+
+## Pitfalls
+
+**Passing the semantic-bridge file instead of the Virtual-Types file.** The two
+differ by only `.vt` in the name and it is an easy slip:
+
+```
+python3 validate.py -m vt signal.owl.ttl
+```
+
+fails with
+
+```
+ValueError: .../signal.owl.ttl looks like a semantic-bridge ttl (it has base:definesType triples),
+not a generated Virtual-Types ontology. ... Pass its Virtual-Types sibling instead (signal.vt.owl.ttl);
+if it does not exist yet, build it first with 'make -f translate_default_nodesets.make' or
+'python3 owl2vt.py signal.owl.ttl'.
+```
+
+The check is deliberate. A semantic-bridge file has none of the Virtual Type
+classes and restrictions the reasoner needs, so without this guard it would
+report a meaningless "consistent" verdict while validating nothing.
+
+**A missing `*.vt.owl.ttl` dependency.** Your generated file `owl:imports` the
+Virtual-Types file of every specification it depends on, by absolute `file://`
+URL. Imports are resolved eagerly and a missing one is fatal rather than a
+warning, so you get a bare `FileNotFoundError` naming it — from `owl2vt.py`
+when it resolves the inputs it is generating from, and from
+`check_consistency.py` (or `validate.py -m vt`) when it follows the imports of
+an already-generated file. Neither writes partial output:
+
+```
+FileNotFoundError: [Errno 2] No such file or directory: '.../di.vt.owl.ttl'
+```
+
+The Makefile builds the `*.owl.ttl` chain in dependency order, but it does
+**not** chain the `*.vt.owl.ttl` targets, so list them all yourself. For the
+pump specification, for instance:
+
+```
+make -f translate_default_nodesets.make core.vt.owl.ttl di.vt.owl.ttl machinery.vt.owl.ttl pumps.vt.owl.ttl
+```
+
+For the tutorial above, `core.vt.owl.ttl` is the only dependency, which is why
+the Prerequisites build it alongside `core.owl.ttl`.
+
+**Moving a `*.vt.owl.ttl` after generating it.** Those `owl:imports` are
+absolute paths written at generation time. Regenerate rather than relocate.
+
+**Reasoning takes real time on big specifications.** HermiT is exponential in
+the worst case. A small model like this one is seconds; the full corpus sweep
+in `make test` is minutes. Use `--roots` in `owl2vt.py` to scope the ontology
+while iterating on a design.

--- a/semantic-model/opcua/lib/shacl.py
+++ b/semantic-model/opcua/lib/shacl.py
@@ -747,8 +747,20 @@ class Validation:
 
     def add_term_to_query(self, query: str, target_class: URIRef) -> str:
         """
-        Adds the term '$this a <target_class> .' immediately after the first occurrence
-        of the 'WHERE { ' clause in the given SPARQL query, accommodating variable whitespace.
+        Binds $this to the targets of sh:targetClass <target_class>, immediately after
+        the first occurrence of the 'WHERE { ' clause in the given SPARQL query,
+        accommodating variable whitespace.
+
+        The binding follows rdfs:subClassOf*, because that is what SHACL means by
+        sh:targetClass: "node is a target if node rdf:type/rdfs:subClassOf* C". An
+        exact `$this a <target_class>` match instead silently produces no targets at
+        all whenever the shape targets a class that is only ever instantiated through
+        its subclasses -- nodeset2owl types nodes as opcua:VariableNodeClass,
+        opcua:ObjectNodeClass and friends, never as opcua:BaseNodeClass directly, so
+        every SPARQL constraint targeting opcua:BaseNodeClass used to be dead code.
+
+        rdf:type and rdfs:subClassOf are written out in full so that the rewrite does
+        not depend on which prefixes the constraint happens to declare.
 
         Args:
             query: A SPARQL query string.
@@ -767,7 +779,9 @@ class Validation:
         if not match:
             raise ValueError("The query does not contain a valid 'WHERE' clause.")
 
-        insertion = f"$this a <{target_class}> . "
+        rdf_type = "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>"
+        subclass_of = "<http://www.w3.org/2000/01/rdf-schema#subClassOf>"
+        insertion = f"$this {rdf_type}/{subclass_of}* <{target_class}> . "
         insertion_point = match.end()
         new_query = query[:insertion_point] + insertion + query[insertion_point:]
         return new_query

--- a/semantic-model/opcua/tests/test_libshacl.py
+++ b/semantic-model/opcua/tests/test_libshacl.py
@@ -653,7 +653,12 @@ class TestValidation(unittest.TestCase):
         # Create a sample query with a valid WHERE clause (with variable whitespace)
         query = "SELECT ?s WHERE { ?s ?p ?o . }"
         target_class = URIRef("http://example.org/TargetClass")
-        expected_insertion = f"$this a <{target_class}> . "
+        # $this is bound through rdfs:subClassOf*, which is what SHACL means by
+        # sh:targetClass. An exact `$this a <target_class>` match would silently
+        # select nothing for a class only ever instantiated via its subclasses.
+        rdf_type = "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>"
+        subclass_of = "<http://www.w3.org/2000/01/rdf-schema#subClassOf>"
+        expected_insertion = f"$this {rdf_type}/{subclass_of}* <{target_class}> . "
         
         # Instantiate Validation with dummy graphs (these are not used by the method)
         validation_instance = Validation(Graph(), Graph())

--- a/semantic-model/opcua/tests/validation/historizingTest.ttl
+++ b/semantic-model/opcua/tests/validation/historizingTest.ttl
@@ -1,0 +1,52 @@
+@prefix base: <https://industryfusion.github.io/contexts/ontology/v0/base/> .
+@prefix opcua: <http://opcfoundation.org/UA/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+opcua: a owl:Ontology ;
+    owl:versionInfo 1e-01 .
+
+# The shape targets opcua:BaseNodeClass, and SHACL reaches its targets through
+# rdfs:subClassOf*. The tests run with -ni, so no import supplies that hierarchy
+# and it has to be stated here.
+opcua:ObjectNodeClass        rdfs:subClassOf opcua:BaseNodeClass .
+opcua:VariableNodeClass      rdfs:subClassOf opcua:BaseNodeClass .
+opcua:MethodNodeClass        rdfs:subClassOf opcua:BaseNodeClass .
+opcua:ReferenceTypeNodeClass rdfs:subClassOf opcua:BaseNodeClass .
+
+
+# OK: Historizing is exactly what a Variable is allowed to declare. Neither of
+# these may be reported -- a filter that compares the node against a class IRI
+# instead of its rdf:type flags every historizing node, so these two guard
+# against a constraint that is "working" only by over-reporting.
+opcua:nodei1 a opcua:VariableNodeClass ;
+    base:hasBrowseName "HistorizingVariable" ;
+    base:isHistorizing true .
+
+opcua:nodei2 a opcua:VariableNodeClass ;
+    base:hasBrowseName "NonHistorizingVariable" ;
+    base:isHistorizing false .
+
+# Not OK: only a Variable may be Historizing.
+opcua:nodei3 a opcua:ObjectNodeClass ;
+    base:hasBrowseName "HistorizingObject" ;
+    base:isHistorizing true .
+
+opcua:nodei4 a opcua:MethodNodeClass ;
+    base:hasBrowseName "HistorizingMethod" ;
+    base:isHistorizing false .
+
+# Not OK: isHistorizing is xsd:boolean, occurring at most once.
+opcua:nodei5 a opcua:VariableNodeClass ;
+    base:hasBrowseName "NotABoolean" ;
+    base:isHistorizing "yes" .
+
+opcua:nodei6 a opcua:VariableNodeClass ;
+    base:hasBrowseName "TwiceHistorizing" ;
+    base:isHistorizing true, false .
+
+# OK: carrying no isHistorizing at all is always fine.
+opcua:nodei7 a opcua:ObjectNodeClass ;
+    base:hasBrowseName "PlainObject" .

--- a/semantic-model/opcua/tests/validation/historizingTest.ttl.result
+++ b/semantic-model/opcua/tests/validation/historizingTest.ttl.result
@@ -1,0 +1,8 @@
+Focus Node: <http://opcfoundation.org/UA/nodei5>
+Focus Node: <http://opcfoundation.org/UA/nodei6>
+Focus Node: http://opcfoundation.org/UA/nodei3
+Focus Node: http://opcfoundation.org/UA/nodei4
+Message: The node http://opcfoundation.org/UA/nodei3 is not a Variable and must not be Historizing.
+Message: The node http://opcfoundation.org/UA/nodei4 is not a Variable and must not be Historizing.
+Message: isHistorizing must have xsd:boolean domain and shall appear at most once.
+Message: isHistorizing must have xsd:boolean domain and shall appear at most once.

--- a/semantic-model/opcua/tests/validation/modellingRuleTest.ttl
+++ b/semantic-model/opcua/tests/validation/modellingRuleTest.ttl
@@ -1,0 +1,73 @@
+@prefix base: <https://industryfusion.github.io/contexts/ontology/v0/base/> .
+@prefix opcua: <http://opcfoundation.org/UA/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+opcua: a owl:Ontology ;
+    owl:versionInfo 1e-01 .
+
+# The shape targets opcua:BaseNodeClass, and SHACL reaches its targets through
+# rdfs:subClassOf*. The tests run with -ni, so no import supplies that hierarchy
+# and it has to be stated here.
+opcua:ObjectNodeClass        rdfs:subClassOf opcua:BaseNodeClass .
+opcua:VariableNodeClass      rdfs:subClassOf opcua:BaseNodeClass .
+opcua:MethodNodeClass        rdfs:subClassOf opcua:BaseNodeClass .
+opcua:ReferenceTypeNodeClass rdfs:subClassOf opcua:BaseNodeClass .
+opcua:DataTypeNodeClass      rdfs:subClassOf opcua:BaseNodeClass .
+
+
+# Not OK: two ModellingRules on one node violates sh:maxCount 1.
+opcua:nodei1 a opcua:VariableNodeClass ;
+    base:hasBrowseName "TwoRules" ;
+    base:hasModellingRule opcua:nodei78, opcua:nodei80 .
+
+# Not OK: nodei9999 is not one of the five real ModellingRules (sh:in).
+opcua:nodei2 a opcua:VariableNodeClass ;
+    base:hasBrowseName "BogusRule" ;
+    base:hasModellingRule opcua:nodei9999 .
+
+# Not OK: a ReferenceType may not carry a ModellingRule at all. Exactly one
+# legal rule, so sh:in and sh:maxCount stay silent and only the SPARQL
+# constraint can report this node.
+opcua:nodei3 a opcua:ReferenceTypeNodeClass ;
+    base:hasBrowseName "ReferenceTypeWithRule" ;
+    base:hasModellingRule opcua:nodei78 .
+
+# Not OK: same for a DataType.
+opcua:nodei4 a opcua:DataTypeNodeClass ;
+    base:hasBrowseName "DataTypeWithRule" ;
+    base:hasModellingRule opcua:nodei80 .
+
+# OK: Object, Variable and Method are the three node classes that may carry a
+# ModellingRule. None of these may be reported.
+opcua:nodei5 a opcua:ObjectNodeClass ;
+    base:hasBrowseName "MandatoryObject" ;
+    base:hasModellingRule opcua:nodei78 .
+
+opcua:nodei6 a opcua:VariableNodeClass ;
+    base:hasBrowseName "OptionalVariable" ;
+    base:hasModellingRule opcua:nodei80 .
+
+opcua:nodei7 a opcua:MethodNodeClass ;
+    base:hasBrowseName "MandatoryMethod" ;
+    base:hasModellingRule opcua:nodei78 .
+
+# OK: ExposesItsArray, OptionalPlaceholder and MandatoryPlaceholder are the
+# remaining three legal values of sh:in.
+opcua:nodei8 a opcua:VariableNodeClass ;
+    base:hasBrowseName "ExposesItsArray" ;
+    base:hasModellingRule opcua:nodei83 .
+
+opcua:nodei9 a opcua:ObjectNodeClass ;
+    base:hasBrowseName "OptionalPlaceholder" ;
+    base:hasModellingRule opcua:nodei11508 .
+
+opcua:nodei10 a opcua:ObjectNodeClass ;
+    base:hasBrowseName "MandatoryPlaceholder" ;
+    base:hasModellingRule opcua:nodei11510 .
+
+# OK: carrying no ModellingRule at all is always fine.
+opcua:nodei11 a opcua:ReferenceTypeNodeClass ;
+    base:hasBrowseName "PlainReferenceType" .

--- a/semantic-model/opcua/tests/validation/modellingRuleTest.ttl.result
+++ b/semantic-model/opcua/tests/validation/modellingRuleTest.ttl.result
@@ -1,0 +1,8 @@
+Focus Node: <http://opcfoundation.org/UA/nodei1>
+Focus Node: <http://opcfoundation.org/UA/nodei2>
+Focus Node: http://opcfoundation.org/UA/nodei3
+Focus Node: http://opcfoundation.org/UA/nodei4
+Message: The node http://opcfoundation.org/UA/nodei3 should not have a ModellingRule.
+Message: The node http://opcfoundation.org/UA/nodei4 should not have a ModellingRule.
+Message: hasModellingRule must reference a modelling rule node and shall appear at most once.
+Message: hasModellingRule must reference a modelling rule node and shall appear at most once.

--- a/semantic-model/opcua/tests/validation/rankValueTest.ttl
+++ b/semantic-model/opcua/tests/validation/rankValueTest.ttl
@@ -49,7 +49,8 @@ opcua:nodei4 a opcua:PropertyType,
     base:hasNodeId "4" ;
     base:hasValueRank -4 .
 
-# not allowed ArrayDimensions
+# OK - ValueRank -2 (Any) permits "a scalar or an array with any number of
+# dimensions", so no ArrayDimensions length contradicts it.
 opcua:nodei5 a opcua:PropertyType,
         opcua:VariableNodeClass ;
     base:hasBrowseName "Annotations5" ;
@@ -61,7 +62,8 @@ opcua:nodei5 a opcua:PropertyType,
     base:hasArrayDimensions ( 1 ) ;
     base:hasValueRank -2 .
 
-# not allowed ArrayDimensions
+# OK - ValueRank 0 (OneOrMoreDimensions) means the Value IS an array, so it has
+# ArrayDimensions; the declaration does not fix how many, so no length is wrong.
 opcua:nodei6 a opcua:PropertyType,
         opcua:VariableNodeClass ;
     base:hasBrowseName "Annotations6" ;
@@ -245,3 +247,57 @@ base:hasNamespace opcua:OPCUANamespace ;
 base:hasNodeId "21" ;
 base:hasArrayDimensions ( 0 1 );
 base:hasValueRank 1 .
+
+# OK - ValueRank -3 (ScalarOrOneDimension) with a single ArrayDimensions entry.
+# This is the exact shape of OPC UA DI's WarningValues (ns=1;i=472), which is
+# compliant: Part 3 5.6.2 lets the Value of a -3 Variable be a one-dimensional
+# array, and one element of 0 means "maximum length unknown". Must NOT be flagged.
+opcua:nodei22 a opcua:PropertyType,
+    opcua:VariableNodeClass ;
+base:hasBrowseName "Annotations22" ;
+base:hasDatatype opcua:Annotation ;
+base:hasDisplayName "Annotations22" ;
+base:hasIdentifierType base:numericID ;
+base:hasNamespace opcua:OPCUANamespace ;
+base:hasNodeId "22" ;
+base:hasArrayDimensions ( 0 );
+base:hasValueRank -3 .
+
+# Not OK - ValueRank -3 permits at most ONE dimension, so two is still a violation.
+opcua:nodei23 a opcua:PropertyType,
+    opcua:VariableNodeClass ;
+base:hasBrowseName "Annotations23" ;
+base:hasDatatype opcua:Annotation ;
+base:hasDisplayName "Annotations23" ;
+base:hasIdentifierType base:numericID ;
+base:hasNamespace opcua:OPCUANamespace ;
+base:hasNodeId "23" ;
+base:hasArrayDimensions ( 0 2 );
+base:hasValueRank -3 .
+
+# Not OK - ValueRank -1 is Scalar, "The value is not an array", so ArrayDimensions
+# shall be null. This is the one rank below 1 that does constrain the length, and
+# it is what keeps the relaxations for -2/0/-3 from emptying the rule.
+opcua:nodei24 a opcua:PropertyType,
+    opcua:VariableNodeClass ;
+base:hasBrowseName "Annotations24" ;
+base:hasDatatype opcua:Annotation ;
+base:hasDisplayName "Annotations24" ;
+base:hasIdentifierType base:numericID ;
+base:hasNamespace opcua:OPCUANamespace ;
+base:hasNodeId "24" ;
+base:hasArrayDimensions ( 1 );
+base:hasValueRank -1 .
+
+# OK - ValueRank -2 with a multi-dimensional ArrayDimensions: "any number of
+# dimensions" includes this one.
+opcua:nodei25 a opcua:PropertyType,
+    opcua:VariableNodeClass ;
+base:hasBrowseName "Annotations25" ;
+base:hasDatatype opcua:Annotation ;
+base:hasDisplayName "Annotations25" ;
+base:hasIdentifierType base:numericID ;
+base:hasNamespace opcua:OPCUANamespace ;
+base:hasNodeId "25" ;
+base:hasArrayDimensions ( 2 2 );
+base:hasValueRank -2 .

--- a/semantic-model/opcua/tests/validation/rankValueTest.ttl.result
+++ b/semantic-model/opcua/tests/validation/rankValueTest.ttl.result
@@ -7,8 +7,8 @@ Focus Node: http://opcfoundation.org/UA/nodei16
 Focus Node: http://opcfoundation.org/UA/nodei18
 Focus Node: http://opcfoundation.org/UA/nodei19
 Focus Node: http://opcfoundation.org/UA/nodei21
-Focus Node: http://opcfoundation.org/UA/nodei5
-Focus Node: http://opcfoundation.org/UA/nodei6
+Focus Node: http://opcfoundation.org/UA/nodei23
+Focus Node: http://opcfoundation.org/UA/nodei24
 Message: ArrayDimension must be null or a List of integers > 0.
 Message: The node http://opcfoundation.org/UA/nodei11 has a valueRank 1 which does not match its type definition's valueRank -1.
 Message: The node http://opcfoundation.org/UA/nodei14 has valueRank 2 without arrayDimension.
@@ -16,7 +16,7 @@ Message: The node http://opcfoundation.org/UA/nodei16 has a valueRank 2 which do
 Message: The node http://opcfoundation.org/UA/nodei16 has valueRank 2 without arrayDimension.
 Message: The node http://opcfoundation.org/UA/nodei18 has valueRank 1 without arrayDimension.
 Message: The node http://opcfoundation.org/UA/nodei21 hasArrayDimensions length of 2 but this does not match the valueRank 1.
-Message: The node http://opcfoundation.org/UA/nodei5 hasArrayDimensions length of 1 but this does not match the valueRank -2.
-Message: The node http://opcfoundation.org/UA/nodei6 hasArrayDimensions length of 1 but this does not match the valueRank 0.
+Message: The node http://opcfoundation.org/UA/nodei23 hasArrayDimensions length of 2 but this does not match the valueRank -3.
+Message: The node http://opcfoundation.org/UA/nodei24 hasArrayDimensions length of 1 but this does not match the valueRank -1.
 Message: The variable type node http://opcfoundation.org/UA/nodei19 has a valueRank -1 which does not match its super type definition's valueRank 0.
 Message: ValueRank can apopear at most once, must be xsd:integer and >= -3.

--- a/semantic-model/opcua/tests/validation/test.bash
+++ b/semantic-model/opcua/tests/validation/test.bash
@@ -25,6 +25,8 @@ RESULTFILE=result.txt
 tests=(
   "RankValueTest ../../validation/ontology/rankValue.shacl.ttl ./rankValueTest.ttl -ni -m ontology"
   "HasComponentTest ../../validation/ontology/hasComponent.shacl.ttl ./hasComponentTest.ttl -m ontology -ni"
+  "ModellingRuleTest ../../validation/ontology/modellingRule.shacl.ttl ./modellingRuleTest.ttl -m ontology -ni"
+  "HistorizingTest ../../validation/ontology/historizing.shacl.ttl ./historizingTest.ttl -m ontology -ni"
 )
 
 for test in "${tests[@]}"; do

--- a/semantic-model/opcua/validation/ontology/hasComponent.shacl.ttl
+++ b/semantic-model/opcua/validation/ontology/hasComponent.shacl.ttl
@@ -116,7 +116,7 @@ base:HasComponentTargetSourceConstraint a sh:NodeShape ;
                         ?source a ?stype .
     				?source a ?stype .
     				?stype rdfs:subClassOf* opcua:BaseNodeClass .
-      				FILTER(?stype != opcua:ObjectNodeClass || ?stype != opcua:ObjectTypeNodeClass )
+      				FILTER(?stype != opcua:ObjectNodeClass && ?stype != opcua:ObjectTypeNodeClass )
     				
             	}
             }

--- a/semantic-model/opcua/validation/ontology/historizing.shacl.ttl
+++ b/semantic-model/opcua/validation/ontology/historizing.shacl.ttl
@@ -16,9 +16,9 @@ base:OPCUAHistorizingRuleShape a sh:NodeShape ;
     ] ;
 
 
-    # SPARQL constraint: ModellingRule only for Object, Variable or Method
+    # SPARQL constraint: Historizing only for Variables
     sh:sparql [
-        sh:message "The node {$this} should not have a ModellingRule." ;
+        sh:message "The node {$this} is not a Variable and must not be Historizing." ;
         sh:select """
           PREFIX base: <https://industryfusion.github.io/contexts/ontology/v0/base/>
           PREFIX opcua: <http://opcfoundation.org/UA/>
@@ -27,9 +27,14 @@ base:OPCUAHistorizingRuleShape a sh:NodeShape ;
           PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
           PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-          SELECT $this WHERE { 
+          SELECT $this WHERE {
             $this base:isHistorizing ?ml .
-              FILTER($this != opcua:VariableNodeClass)
+            # Only a Variable may be Historizing. Test the node's rdf:type --
+            # comparing $this itself against a class IRI is always true and so
+            # would flag every historizing node, Variables included.
+            FILTER NOT EXISTS {
+              $this rdf:type/rdfs:subClassOf* opcua:VariableNodeClass .
+            }
           }
         """ ;
     ] ;

--- a/semantic-model/opcua/validation/ontology/modellingRule.shacl.ttl
+++ b/semantic-model/opcua/validation/ontology/modellingRule.shacl.ttl
@@ -28,9 +28,17 @@ base:OPCUAModellingRuleShape a sh:NodeShape ;
           PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
           PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 
-          SELECT $this WHERE { 
+          SELECT $this WHERE {
             $this base:hasModellingRule ?ml .
-              FILTER($this != opcua:ObjectNodeClass && $this && opcua:VariableNodeClass && $this != opcua:MethodNodeClass)
+            # Only an Object, a Variable or a Method may carry a ModellingRule.
+            # Test the node's rdf:type -- comparing $this itself against a class
+            # IRI can never hold, so the node class has to be bound and filtered.
+            FILTER NOT EXISTS {
+              $this rdf:type/rdfs:subClassOf* ?nodeClass .
+              FILTER(?nodeClass = opcua:ObjectNodeClass
+                     || ?nodeClass = opcua:VariableNodeClass
+                     || ?nodeClass = opcua:MethodNodeClass)
+            }
           }
         """ ;
     ] ;

--- a/semantic-model/opcua/validation/ontology/rankValue.shacl.ttl
+++ b/semantic-model/opcua/validation/ontology/rankValue.shacl.ttl
@@ -124,7 +124,34 @@ base:OPCUANodeShape a sh:NodeShape ;
               GROUP BY $this
             }
             # Trigger a violation if the number of dimensions does not match valueRank.
-  			    FILTER ( (?valueRank > 0 && ?count != ?valueRank) || (?valueRank <= 0 && ?count > 0) )
+            #
+            # Each ValueRank constrains the ArrayDimensions length differently, because
+            # Part 3 5.6.2 ties ArrayDimensions to the Value, not to ValueRank: "The
+            # number of elements shall be equal to the number of dimensions of the
+            # Value. This Attribute shall be null if the Value is not an array."
+            # Combined with the ValueRank definitions in the same clause, the only
+            # statically checkable constraints are:
+            #
+            #   n >= 1  the Value is an array of n dimensions  -> exactly n
+            #   -1      "The value is not an array"            -> none (must be null)
+            #   -3      scalar or a one dimensional array      -> at most 1
+            #   -2      "scalar or an array with any number
+            #            of dimensions"                        -> unconstrained
+            #    0      "an array with one or more dimensions" -> unconstrained (>= 1,
+            #                                                     and n is not fixed by
+            #                                                     the declaration)
+            #
+            # So -2 and 0 impose no length this rule can test, and must not be folded in
+            # with -1: for -2 an array Value of any rank is legal, and for 0 the Value
+            # IS an array, so rejecting its ArrayDimensions rejects what the spec asks
+            # for. Likewise do not fold -3 back in -- that rejects the legal
+            # ValueRank="-3" ArrayDimensions="0" form used by OPC UA DI's WarningValues
+            # (ns=1;i=472). tests/validation/rankValueTest.ttl pins every branch:
+            # nodei24 (-1, must be flagged), nodei22/nodei23 (-3, one legal / two not),
+            # nodei5 and nodei25 (-2) and nodei6 (0), which must all pass.
+  			    FILTER ( (?valueRank > 0 && ?count != ?valueRank)
+                     || (?valueRank = -1 && ?count > 0)
+                     || (?valueRank = -3 && ?count > 1) )
           }
         """ ;
     ] ;


### PR DESCRIPTION
`validate.py` has had three modes for a while (`-m ontology`, the default `instance`, and `-m vt`), but `semantic-model/opcua/docs` shipped a tutorial for only one of them. The other two were reachable only by reading the CLI reference or the test scripts.

## Adds

- **`docs/validation-overview.md`** — what the three validations each answer, which artefact each consumes, why the third needs a DL reasoner rather than SHACL, and the `BASE_ONTOLOGY` vs `BASE_ONTOLOGY_NS` distinction the tutorials rely on.

- **`docs/ontology-validation.md`** — a worked example over a consistent nodeset and a twin differing in exactly one modelling decision (a scalar Variable under an array VariableType), how to read the report, scoping to a single rule with `-s`, and a catalogue of the five `validation/ontology/*.shacl.ttl` rules.

- **`docs/virtual-type-validation.md`** — the worked example is `tests/owl2vt/test_vt_contradiction.NodeSet2.xml`: `BaseType` declares a Mandatory `Signal` with `ValueRank = 1` (OneDimension), and `SubType` re-declares it with `ValueRank = 2` (MoreDimensions). Each declaration is locally well formed, ontology validation **passes** on the nodeset, and HermiT nonetheless reports `SubType` and one `VT_` class unsatisfiable. The tutorial shows how to trace a `VT_` hash back to its BrowsePath (`sb:originalBrowsePath`, or recomputing the sha256), how a one-attribute change repairs it, `check_consistency.py`'s batch/`--combine`/CSV modes, and the pitfalls.

**The virtual-type tutorial deliberately rides on an existing e2e fixture rather than one of its own.** `tests/owl2vt/test.bash` already asserts that this file yields a contradiction, and `tests/validation/test.bash` runs `validate.py -m vt` over its expected Virtual-Types output. So every command and every line of output quoted in the tutorial is covered by CI. That matters most for the `VT_` class names — sha256 digests of `"<owning type IRI>|<BrowsePath>"` — which would otherwise rot silently the first time naming changed.

Two new nodesets under `docs/files/` back the ontology tutorial, as a consistent/deliberately-broken pair.

## Fixes four validation rules that never fired

While documenting the rule catalogue it turned out that four SPARQL-based constraints in `validation/ontology` reported nothing at all. Three separate faults, each silent — a shape that selects nothing looks exactly like a shape that found no violations:

1. **`lib/shacl.py`'s `add_term_to_query()`** bound `$this` with an exact `$this a <target>` match. SHACL defines `sh:targetClass` as `rdf:type/rdfs:subClassOf*`, and `nodeset2owl` types nodes as `opcua:VariableNodeClass`, `opcua:ObjectNodeClass` and friends — never as `opcua:BaseNodeClass` directly. Every top-level `sh:sparql` constraint targeting `BaseNodeClass` therefore selected the empty set: `HasComponentTargetConstraint`, `modellingRule` and `historizing`. The pyshacl-evaluated `sh:property` constraints in the same files were unaffected, which is why those files looked half-alive.

2. **`hasComponent.shacl.ttl`'s Case 2** filtered on `?stype != ObjectNodeClass || ?stype != ObjectTypeNodeClass`. No value can equal both, so the disjunction is always true and no source was ever rejected. Case 1 directly above it already uses `&&`.

3. **`modellingRule` and `historizing`** compared `$this` — the node — against class IRIs instead of testing its `rdf:type`. `historizing`'s `$this != VariableNodeClass` is true for every node, and `modellingRule`'s `$this && VariableNodeClass` is not a comparison at all: an IRI has no effective boolean value, so the filter raised a type error and dropped every row.

`modellingRule` and `historizing` had **no tests**, which is how they stayed dead. Both now have fixtures covering the legal cases as well as the violations — a constraint that over-reports is as broken as one that never fires, and `historizing`'s old filter would have flagged every Variable had it ever run. Reverting `add_term_to_query()` alone makes `ModellingRuleTest` fail, so the coverage is real.

## Aligns rankValue with Part 3

`rankValue.shacl.ttl` folded `-2`, `0` and `-3` in with `-1` and rejected any `ArrayDimensions` on them. Only some combinations are statically checkable: `n >= 1` needs exactly *n* entries, `-1` forbids them, `-3` allows at most one, and `-2` and `0` are unconstrained. The old rule rejected the `ValueRank="-3" ArrayDimensions="0"` form OPC UA DI itself uses for `WarningValues` (`ns=1;i=472`), so validating DI reported a violation against a conformant companion specification. `di.owl.ttl` now conforms.

## Also corrects the existing tutorial

`docs/simple-example.md` had drifted:

- `BASE_ONTOLOGY` was still v0.1 and omitted the `-b`/`-burl` pair, out of sync with `translate_default_nodesets.make` — a nodeset and its dependencies must share one base ontology.
- The sample report showed a stale `urn:test:AlphaInstance:sub:i2012` where the command actually produces `urn:testnodei2012`.
- The `-t` description named a different type than the command below it.
- The pump chain built `devices.owl.ttl`; the rest of the repo uses `di.owl.ttl`.

## Unblocking the Build workflow

The Build workflow was failing on this PR, and on every other PR against main, for a reason unrelated to any of them. The "Build iff-agent" step ends in `npm audit --production --audit-level high`, and `fast-uri` 3.0.0–3.1.5 has four HIGH advisories (GHSA-5jgf-p345-68v8, GHSA-f65p-4m7j-42xc, GHSA-fph4-wmhf-6fwf, GHSA-jqff-g426-hqxp), so the audit exits 1. The failure is easy to misread: the step afterwards drops into `Setup tmate session`, which hangs until the job times out, so the run reports `in_progress` for hours after it has actually failed.

`NgsildAgent/package-lock.json` therefore moves `fast-uri` 3.1.5 → **3.1.7**. It is transitive, via `ajv`'s `^3.0.1`, so 3.1.7 is the highest patched release the range admits — 4.x would not satisfy it. Lockfile only.

Worth noting separately: `FlinkSqlGateway`, `KafkaBridge` and `semantic-model/datamodel/tools` still pin `fast-uri` 3.1.4, which the same advisories cover. They are not failing CI only because `NgsildAgent` is the one package with an audit gate. Left for its own PR.

## Verification

Every command and every quoted output in the new and changed sections was executed against a real build (`core.owl.ttl`, `core.vt.owl.ttl`, the full pump chain), with `owlready2==0.51` and a `java` runtime for the HermiT mode. All `docs/files/*.xml` parse; all relative links and heading anchors resolve.

`make lint` clean, 257 unit tests pass at 84% coverage, `tests/validation` 6/6, `tests/owl2vt` all green.

One thing verification turned up and the docs now record: a missing `*.vt.owl.ttl` dependency is fatal rather than a warning — imports are resolved eagerly, so both `owl2vt.py` and `check_consistency.py` die on a bare `FileNotFoundError` and neither writes partial output. The Makefile chains the `*.owl.ttl` targets but not the `*.vt.owl.ttl` ones, so they have to be listed in dependency order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
